### PR TITLE
Fixes

### DIFF
--- a/RustPlusApi/RustPlusApi.Fcm/Data/Events/ServerFullEventArg.cs
+++ b/RustPlusApi/RustPlusApi.Fcm/Data/Events/ServerFullEventArg.cs
@@ -5,8 +5,10 @@
         public string Ip { get; set; } = null!;
         public int Port { get; set; }
         public string Desc { get; set; } = null!;
-        public int Logo { get; set; }
-        public int Img { get; set; }
+        public string Logo { get; set; }
+        public string Img { get; set; }
         public string Url { get; set; } = null!;
+        public ulong PlayerId { get; set; }
+        public string PlayerToken { get; set; } = null!;
     }
 }

--- a/RustPlusApi/RustPlusApi.Fcm/Data/FcmMessage.cs
+++ b/RustPlusApi/RustPlusApi.Fcm/Data/FcmMessage.cs
@@ -31,8 +31,8 @@ namespace RustPlusApi.Fcm.Data
         public int Port { get; set; }
         public string Name { get; set; } = null!;
         public string Desc { get; set; } = null!;
-        public int Logo { get; set; }
-        public int Img { get; set; }
+        public string Logo { get; set; }
+        public string Img { get; set; }
         public string Url { get; set; } = null!;
         public ulong PlayerId { get; set; }
         public string PlayerToken { get; set; } = null!;

--- a/RustPlusApi/RustPlusApi.Fcm/FcmListener.cs
+++ b/RustPlusApi/RustPlusApi.Fcm/FcmListener.cs
@@ -72,7 +72,9 @@ namespace RustPlusApi.Fcm
                         Desc = body.Desc,
                         Logo = body.Logo,
                         Img = body.Img,
-                        Url = body.Url
+                        Url = body.Url,
+                        PlayerId = body.PlayerId,
+                        PlayerToken = body.PlayerToken
                     };
                     OnServerPairing?.Invoke(this, serverFull);
                     break;


### PR DESCRIPTION
1. Got error when I received a server pairing notification, it was due to the properties `Logo` and `Img` being an **int** and the Logo of the server being a **string** with the URL to it - changed those types to **string**.

2. Subscribed to the `OnServerPairing` event, and noticed that `PlayerId` and `PlayerToken` wasn't in the properties of `ServerFullEventArg` - added them since I think that they're necessary there as that's what the event will be used for, for getting that information.