### PR TITLE
Apply authoritative proto refresh + drift-check workflow

### DIFF
--- a/.github/workflows/ProtoRefresh.yml
+++ b/.github/workflows/ProtoRefresh.yml
@@ -1,0 +1,109 @@
+name: Proto Refresh Check
+
+# Authoritatively checks whether the Rust dedicated server's Companion contracts have drifted
+# from the committed RustPlusContracts.proto (§6, Method A — see tools/update-proto/README.md).
+# On drift it opens (or comments on) a tracking issue with the diff; the regenerated proto is
+# NOT auto-applied because new fields usually need matching model/mapper changes by hand.
+
+on:
+  schedule:
+    # Rust force-updates on the first Thursday of each month (~18:00–20:00 UTC). cron can't
+    # express "first Thursday", so run every Thursday at 21:00 UTC and gate on the day-of-month.
+    - cron: "0 21 * * 4"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  proto-refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: First-Thursday gate
+        id: gate
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "$(date -u +%-d)" -le 7 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Not the first Thursday of the month — skipping."
+          fi
+
+      - name: Checkout
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install SteamCMD runtime deps (32-bit)
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends lib32gcc-s1
+
+      - name: Run proto refresh
+        if: steps.gate.outputs.run == 'true'
+        id: refresh
+        run: |
+          set +e
+          ./tools/update-proto/update-proto.sh
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload diff artifact
+        if: steps.gate.outputs.run == 'true' && steps.refresh.outputs.exit_code == '1'
+        uses: actions/upload-artifact@v4
+        with:
+          name: proto-diff
+          path: tools/update-proto/out/proto.diff
+
+      - name: Open or update drift issue
+        if: steps.gate.outputs.run == 'true' && steps.refresh.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          manifest="tools/update-proto/rds/steamapps/appmanifest_258550.acf"
+          build_id="$(grep -o '"buildid"[^0-9]*[0-9]*' "$manifest" 2>/dev/null | grep -o '[0-9]*' || echo unknown)"
+
+          {
+            echo "The Rust dedicated server's Companion contracts have drifted from the committed"
+            echo "\`src/RustPlusApi/Protobuf/RustPlusContracts.proto\`."
+            echo
+            echo "- **Server build id:** \`${build_id}\`"
+            echo "- **Workflow run:** ${RUN_URL}"
+            echo
+            echo "Review the diff and apply the genuine wire changes (plus any matching \`Data/*\` model"
+            echo "and \`Extensions/*\` mapper updates), then open a PR. See \`tools/update-proto/README.md\`."
+            echo
+            echo "<details><summary>Diff (committed → server)</summary>"
+            echo
+            echo '```diff'
+            cat tools/update-proto/out/proto.diff
+            echo '```'
+            echo
+            echo "</details>"
+          } > /tmp/drift-body.md
+
+          # Ensure the label exists (no-op if it already does).
+          gh label create proto-drift --color FBCA04 \
+            --description "Committed proto drifted from the Rust dedicated server" 2>/dev/null || true
+
+          existing="$(gh issue list --label proto-drift --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file /tmp/drift-body.md
+            echo "::notice::Updated existing drift issue #${existing}."
+          else
+            gh issue create --label proto-drift \
+              --title "Proto drift detected (server build ${build_id})" \
+              --body-file /tmp/drift-body.md
+          fi

--- a/proto-refresh-plan.md
+++ b/proto-refresh-plan.md
@@ -1,0 +1,232 @@
+# Proto-refresh tooling — implementation plan (§6, Method A)
+
+> Decomposition of the cross-cutting task in [v2-progress.md](v2-progress.md#L184-L191).
+> Source spec: §6 of [v2-plan.md](v2-plan.md#L422-L493).
+> Branch: `refactor/v2`. This task is independent of the v2 phases and can land on its own PR.
+
+## Goal
+
+**Done when:** `tools/update-proto/` runs end-to-end and **reproduces the committed
+[`RustPlusContracts.proto`](src/RustPlusApi/Protobuf/RustPlusContracts.proto) from a fresh
+server download** — i.e. a clean run produces a `.proto` whose only diff against the
+committed copy is intentional (new Facepunch fields), not tooling noise.
+
+Two distinct outcomes ship from this task:
+1. A **reproducible, scripted pipeline** committed under `tools/update-proto/`.
+2. The **one-time v2 proto refresh** itself (the authoritative re-derivation the §0 diff
+   called for: `AppInfo.camerasEnabled`, `AppCameraRays.timeOfDay`, real `Monument`/`Note`
+   field names) — landed as its own reviewed diff against the committed proto.
+
+## ⚠️ Finding (server build `23601104`) — the protobuf-net premise was wrong
+
+§6 claims *"Facepunch uses protobuf-net internally"* and Step 3 calls
+`Serializer.GetProto<AppMessage>()`. **Decompilation disproves this:**
+
+- The Companion contracts live in **`Rust.Data.dll`**, namespace **`ProtoBuf`**, as
+  **SilentOrbit-generated** `IProto<T>` classes — plain fields + hand-written
+  `Serialize`/`Deserialize` methods. **No `[ProtoContract]`/`[ProtoMember]` attributes,
+  no protobuf-net assembly** ships with the server.
+- So `GetProto<T>()` is **not applicable**. Field numbers/types/names are instead recovered
+  by **parsing the decompiled C#**: field number = `case <wirekey>: → wirekey >> 3`;
+  type = declared C# field type + the `ProtocolParser.Read*` call; `required`/`optional`
+  inferred from the `Serialize` method's guards.
+- **Method A remains valid and authoritative** (the server is still the source of truth,
+  names included) — only the Step-3 extraction mechanism changes. Verified end-to-end:
+  the decoded `AppMap` matches the committed proto field-for-field.
+
+## Key facts (verified in-repo)
+
+- The committed schema is `proto2`, package `RustPlusContracts`, with **snake_case field
+  names** — a deliberate Phase-2 decision (§14) so `protogen`/BuildTools emit uniform
+  PascalCase C#. **The generator must reproduce snake_case**, or every field will appear
+  changed.
+- The proto is consumed at build time by `protobuf-net.BuildTools` as an `<AdditionalFiles>`
+  entry in [RustPlusApi.csproj](src/RustPlusApi/RustPlusApi.csproj#L29) — there is no
+  committed generated `.cs`. So the **`.proto` text is the artifact this tooling owns**.
+- Rust dedicated server = SteamCMD app **`258550`**, anonymous login, no license needed.
+- Facepunch compiles the Companion contracts (`AppRequest`, `AppMessage`,
+  `AppCameraInput`, …) as `[ProtoContract]` classes into the server assemblies — same
+  format v2 already targets. This is the whole reason Method A is primary.
+
+## Open questions — RESOLVED (build `23601104`)
+
+1. **Which assembly + namespace holds `AppRequest`/`AppMessage`?**
+   ✅ **`Rust.Data.dll`, namespace `ProtoBuf`.** (`Assembly-CSharp.dll` only *references*
+   them.) `2-decompile.sh` defaults to `Rust.Data.dll` with a `CONTRACT_DLL` override and a
+   `--list` discovery mode.
+2. **Unity/engine deps blocking standalone compilation?**
+   ✅ **Moot** — the types aren't protobuf-net, so the *compile-and-reflect* approach (D1)
+   is off the table entirely. Step 3 parses the decompiled C# text instead.
+3. **Naming transform direction?**
+   ✅ Decompiled fields are **camelCase** (`jpgImage`, `oceanMargin`); committed proto is
+   **snake_case** (`jpg_image`, `ocean_margin`). Normalization = camelCase→snake_case.
+
+## Proposed directory layout
+
+```
+tools/update-proto/
+├── README.md                # what this is, prerequisites, how to run, cadence
+├── update-proto.sh          # orchestrator: fetch → decompile → regenerate → diff
+├── 1-fetch-server.sh        # SteamCMD wrapper (app 258550)
+├── 2-decompile.sh           # ilspycmd decompile of Rust.Data.dll
+├── ProtoGen/                # .NET tool: parses decompiled SilentOrbit C# → .proto
+│   ├── ProtoGen.csproj      # (incl. snake_case + ordering normalization)
+│   ├── Program.cs           # entry: parse server + committed, emit, write
+│   ├── ServerParser.cs      # Roslyn: decompiled C# → message/enum model
+│   ├── CommittedProto.cs    # committed proto → labels, order, preserved blocks
+│   ├── Emitter.cs           # model → normalized .proto text
+│   └── Model.cs             # Message / Field / EnumDef records
+├── Directory.Build.props    # isolates the tool from the repo's shipping build settings
+├── Directory.Packages.props # local (CPM off) so the tool pins its own deps
+└── .gitignore               # ignore steamcmd/rds/decompiled/out + ProtoGen bin/obj
+```
+
+---
+
+## Step-by-step decomposition
+
+### Step 1 — SteamCMD fetch of the dedicated server (app `258550`)
+
+- [ ] Write `1-fetch-server.sh`:
+      `steamcmd +force_install_dir ./rds +login anonymous +app_update 258550 validate +quit`
+- [ ] Make SteamCMD a documented prerequisite (not vendored): detect it on `PATH`, else
+      print install guidance (package name per-OS / the Valve tarball). Allow a
+      `STEAMCMD` env override mirroring the repo's `CHROME_PATH` convention.
+- [ ] `.gitignore` the multi-GB `./rds` install dir.
+- [ ] Capture the resolved **server build id / manifest** into the run output so a diff can
+      be attributed to a specific Rust update.
+- **Verify:** `rds/RustDedicated_Data/Managed/Assembly-CSharp.dll` exists after the run.
+
+### Step 2 — Decompile the contract types with `ilspycmd`
+
+- [ ] Document `dotnet tool install -g ilspycmd` as a prerequisite.
+- [ ] Spike (resolves Open Question #1): list types in the managed assembly and locate the
+      namespace containing `AppRequest`/`AppMessage`. Record the exact assembly + namespace
+      in the README so the script isn't a black box.
+- [ ] Write `2-decompile.sh` to decompile `Rust.Data.dll` into `./decompiled` (ilspycmd
+      emits one `Rust.Data.decompiled.cs`; Step 3 scopes to the companion subset). ✅ done.
+- [ ] `.gitignore` `./decompiled`. ✅ done.
+- **Verify:** decompiled output contains `class AppMessage : … IProto<AppMessage>` (the
+      SilentOrbit shape — **not** `[ProtoContract]`) for the known types. ✅ done.
+
+### Step 3 — Regenerate `RustPlusContracts.proto` by parsing the decompiled SilentOrbit code
+
+> `Serializer.GetProto<AppMessage>()` is **not applicable** (no protobuf-net — see the
+> Finding section). `ProtoGen` is a parser over `decompiled/Rust.Data.decompiled.cs`.
+
+**Mechanism (verified against `AppMap`):**
+
+- **Scope.** Start from roots `AppRequest`, `AppMessage`, `AppBroadcast` and walk the
+  **transitive closure** of referenced message/enum types within namespace `ProtoBuf`.
+  Cross-check against the committed 45-message whitelist; anything new = a real addition to
+  flag, anything missing = a removal to review.
+- **Per message:** read field declarations (`public <ctype> <name>;`, skipping
+  `ShouldPool`/`_disposed`/`[NonSerialized]`) for name + C# type; parse the
+  `Deserialize(BufferStream, T instance, bool)` switch to map **field name → number**
+  (`case <wirekey>: → number = wirekey >> 3`).
+- **Type map** (declared C# type ⊕ `ProtocolParser.Read*`): `bool→bool`,
+  `byte[]/ReadBytes→bytes`, `ReadSingle→float`, `ReadDouble→double`, `string→string`,
+  `uint→uint32`, `int→int32`, `ulong→uint64`, `long→int64`, **`ReadZInt32→sint32`**,
+  `List<T>→repeated T`, enum/message type name → itself.
+- **Label:** `required` vs `optional` inferred from the `Serialize` method (required =
+  written unconditionally; optional = guarded by a null/default check).
+- **Enums:** parse C# `enum` bodies, honoring explicit values (`Switch = 1`) and implicit
+  ordinals.
+
+- [ ] Build `ProtoGen` (.NET 10 console tool) implementing the above; emit to `./out`.
+- [ ] **Normalize** to match the committed convention (this is what makes the diff signal
+      meaningful, not noise):
+      - field names camelCase → **snake_case** (§14 convention);
+      - `syntax = "proto2"` + `package RustPlusContracts` header;
+      - stable message/field ordering;
+      - **nesting policy** — committed proto nests `AppMap.Monument`; the server has a flat
+        top-level `Monument`. Decide: re-nest to match committed, or flatten + accept the
+        one-time diff. (Lean: re-nest, to keep the diff to real changes.)
+      - (Resolved during the refresh: the committed `IconType`/`IconColor` proto enums were
+        *redundant* with the library's own `NoteIcons`/`NoteColors` and unused in C#, so they were
+        dropped in favour of the server's plain `int32` — no special-casing needed.)
+- [ ] Wire `update-proto.sh` to run 1→2→3→normalize and write the candidate proto to
+      `./out/RustPlusContracts.proto`.
+
+**Diff & PR:**
+- [ ] `update-proto.sh` ends with a `diff` of `./out/RustPlusContracts.proto` against the
+      committed [src/RustPlusApi/Protobuf/RustPlusContracts.proto](src/RustPlusApi/Protobuf/RustPlusContracts.proto)
+      and a non-zero exit when they differ (CI-friendly).
+- [ ] **Reproducibility gate (the "Done when"):** on the *current* server build the diff
+      must be **empty after normalization** — prove the pipeline reproduces today's proto.
+- [ ] **One-time v2 refresh:** apply the real delta (expected `camerasEnabled`,
+      `timeOfDay`, `Monument`/`Note` names), rebuild (BuildTools regenerates), run the test
+      suite, and open the PR with the build id + diff in the description.
+- **Verify:** library builds on both TFMs with the refreshed proto; existing
+      `ProtobufRoundTripTests` stay green; any new fields surfaced are noted for follow-up
+      mapper work (`Extensions/*`).
+
+### Step 4 — Document the monthly rerun routine
+
+- [x] `README.md`: prerequisites (SteamCMD, ilspycmd, .NET 10), one-command usage, and the
+      **cadence**: Rust force-updates the **first Thursday of each month (~18:00–20:00 UTC)** —
+      re-run after the update lands, review the diff, ship any delta.
+- [x] Scheduled GitHub Action (`.github/workflows/ProtoRefresh.yml`) that **runs the pipeline
+      and opens/updates a `proto-drift` issue** on first-Thursday (+ manual `workflow_dispatch`) —
+      explicitly watching the authoritative server, **not** the community libs (drift-watch
+      against olijeffers0n/liamcottle is rejected in §6). Never auto-applies the proto.
+
+> Method D (live capture) and Method B (APK extraction) backups were **dropped** — Method A
+> (decompile) has proven reliable end-to-end, so the backup runbooks were not worth maintaining.
+
+---
+
+## Sequencing & estimate
+
+| Order | Step | Depends on | Nature | State |
+| --- | --- | --- | --- | --- |
+| 1 | Resolve Open Questions (spike) | — | investigation | ✅ done |
+| 2 | Step 1 fetch script | spike | scripting | ✅ done (run against build `23601104`) |
+| 3 | Step 2 decompile script | Step 1 | scripting | ✅ done |
+| 4 | Step 3 ProtoGen (C# parser) + normalize | Step 2 | the hard part | ✅ done |
+| 5 | Reproducibility gate | Step 3 | validation | ✅ done (now empty after refresh applied) |
+| 6 | One-time v2 proto refresh | gate | applied | ✅ done (build clean, 51 tests green) |
+| 7 | Step 4 docs + runbook (+opt. Action) | parallel w/ 2–4 | docs | ✅ done (Action still optional) |
+
+### Reproducibility-gate result (build `23601104`)
+
+The first run surfaced a **25-line, all-genuine diff** (the v2 refresh itself), since applied to
+the committed proto:
+
+- **New wire fields:** `AppCameraRays.time_of_day` (the §0 gap), `camera_position`/`camera_rotation`,
+  `ClanInfo.score`, `ClanInfo.Role.can_access_score_events`, `AppMarker.SellOrder.price_multiplier`,
+  `AppMarkerType.TravellingVendor`.
+- **Renames/fixes:** `AppMap.Monument.name → token` (the §0 gap), `AppMarkerType.Unknow → Undefined`
+  (committed typo).
+- **Type widening:** 4× `entity_id`/`id` `uint32 → uint64` (server wraps in `NetworkableId`, read as `ReadUInt64`).
+- **Note icon/colour adopted server truth:** `AppTeamInfo.Note` is now `int32 icon` /
+  `int32 colour_index` / `string label` and the redundant `IconType`/`IconColor` proto enums were
+  removed (the library already has its own `NoteIcons`/`NoteColors`; the mapper casts the ints).
+
+With the refresh applied, **`update-proto.sh` now exits clean (empty diff)** against the current
+server — so future monthly runs surface only *new* changes. The parser was validated by the
+~440 lines that reproduced byte-for-byte on the first run.
+
+## Risks & mitigations
+
+- **SilentOrbit codegen shape varies across messages** (the parser's core assumption) →
+  scope to the ~45-message companion subset (small, hand-verifiable); the reproducibility
+  gate against the committed proto catches any field the parser gets wrong.
+- **Decompiled camelCase ≠ committed snake_case** → the normalize step is mandatory, not
+  optional; lock it with a golden-diff check against today's server.
+- **Multi-GB SteamCMD download in CI** → keep fetch local/manual by default; the optional
+  Action only *triggers/notifies*, it doesn't have to download in-pipeline.
+- **Intentional library conventions diverging from the server** → review each diff and decide to
+  adopt or keep; the gate stays informative. (The `IconType`/`IconColor` case turned out redundant
+  and was dropped — see the gate-result note above.)
+- **Obfuscation / decompiler breakage** → if it ever happens, fix the `CONTRACT_DLL`/parser or
+  fall back to live-capture validation ad hoc; Method A has been reliable so no standing backup
+  runbook is maintained.
+
+## Acceptance checklist (maps to the §6 "Done when")
+
+- [x] `tools/update-proto/update-proto.sh` runs fetch → decompile → generate → diff end-to-end.
+- [x] On the current server build the output **matches the committed proto** modulo genuine
+      server changes (25-line, all-explained diff) — reproducibility proven.
+- [ ] One-time refreshed proto merged; library builds (both TFMs) and tests pass.
+- [x] README documents prerequisites, usage, and the first-Thursday cadence.

--- a/src/RustPlusApi/Data/Cameras/CameraEntity.cs
+++ b/src/RustPlusApi/Data/Cameras/CameraEntity.cs
@@ -4,7 +4,7 @@ namespace RustPlusApi.Data.Cameras;
 public sealed record CameraEntity
 {
     /// <summary>Unique entity identifier.</summary>
-    public uint EntityId { get; init; }
+    public ulong EntityId { get; init; }
 
     /// <summary>The kind of entity (player, tree, etc.).</summary>
     public CameraEntityType Type { get; init; }

--- a/src/RustPlusApi/Data/Cameras/CameraFrame.cs
+++ b/src/RustPlusApi/Data/Cameras/CameraFrame.cs
@@ -22,4 +22,13 @@ public record CameraFrame
 
     /// <summary>Entities visible in this frame.</summary>
     public IEnumerable<CameraEntity> Entities { get; init; } = [];
+
+    /// <summary>In-game time of day when the frame was captured, if reported.</summary>
+    public float? TimeOfDay { get; init; }
+
+    /// <summary>World-space position of the camera, if reported.</summary>
+    public Vector3? CameraPosition { get; init; }
+
+    /// <summary>World-space rotation of the camera, if reported.</summary>
+    public Vector3? CameraRotation { get; init; }
 }

--- a/src/RustPlusApi/Data/Clans/ClanInfo.cs
+++ b/src/RustPlusApi/Data/Clans/ClanInfo.cs
@@ -41,4 +41,7 @@ public sealed record ClanInfo
 
     /// <summary>Maximum number of members allowed in this clan, if capped.</summary>
     public int? MaxMemberCount { get; init; }
+
+    /// <summary>Clan score, if reported by the server.</summary>
+    public long? Score { get; init; }
 }

--- a/src/RustPlusApi/Data/Clans/ClanRole.cs
+++ b/src/RustPlusApi/Data/Clans/ClanRole.cs
@@ -35,4 +35,7 @@ public sealed record ClanRole
 
     /// <summary><see langword="true"/> if members with this role can view clan audit logs.</summary>
     public bool CanAccessLogs { get; init; }
+
+    /// <summary><see langword="true"/> if members with this role can view clan score events.</summary>
+    public bool CanAccessScoreEvents { get; init; }
 }

--- a/src/RustPlusApi/Data/Events/SmartSwitchEventArg.cs
+++ b/src/RustPlusApi/Data/Events/SmartSwitchEventArg.cs
@@ -6,5 +6,5 @@ namespace RustPlusApi.Data.Events;
 public sealed record SmartSwitchEventArg : SmartSwitchInfo
 {
     /// <summary>Entity ID of the smart switch that changed.</summary>
-    public uint Id { get; init; }
+    public ulong Id { get; init; }
 }

--- a/src/RustPlusApi/Data/Events/StorageMonitorEventArg.cs
+++ b/src/RustPlusApi/Data/Events/StorageMonitorEventArg.cs
@@ -6,5 +6,5 @@ namespace RustPlusApi.Data.Events;
 public sealed record StorageMonitorEventArg : StorageMonitorInfo
 {
     /// <summary>Entity ID of the storage monitor that changed.</summary>
-    public uint Id { get; init; }
+    public ulong Id { get; init; }
 }

--- a/src/RustPlusApi/Data/MapMarkers.cs
+++ b/src/RustPlusApi/Data/MapMarkers.cs
@@ -10,20 +10,23 @@ namespace RustPlusApi.Data;
 public sealed record MapMarkers
 {
     /// <summary>Markers of unknown or unrecognised type, keyed by marker ID.</summary>
-    public Dictionary<uint, UnknownMarker> UnknownMarkers { get; init; } = [];
+    public Dictionary<ulong, UnknownMarker> UnknownMarkers { get; init; } = [];
 
     /// <summary>Player position markers, keyed by marker ID.</summary>
-    public Dictionary<uint, PlayerMarker> PlayerMarkers { get; init; } = [];
+    public Dictionary<ulong, PlayerMarker> PlayerMarkers { get; init; } = [];
 
     /// <summary>Vending machine markers, keyed by marker ID.</summary>
-    public Dictionary<uint, VendingMachineMarker> VendingMachineMarkers { get; init; } = [];
+    public Dictionary<ulong, VendingMachineMarker> VendingMachineMarkers { get; init; } = [];
 
     /// <summary>CH-47 (Chinook helicopter) markers, keyed by marker ID.</summary>
-    public Dictionary<uint, Ch47Marker> Ch47Markers { get; init; } = [];
+    public Dictionary<ulong, Ch47Marker> Ch47Markers { get; init; } = [];
 
     /// <summary>Cargo ship markers, keyed by marker ID.</summary>
-    public Dictionary<uint, CargoShipMarker> CargoShipMarkers { get; init; } = [];
+    public Dictionary<ulong, CargoShipMarker> CargoShipMarkers { get; init; } = [];
 
     /// <summary>Patrol helicopter markers, keyed by marker ID.</summary>
-    public Dictionary<uint, PatrolHelicopterMarker> PatrolHelicopterMarkers { get; init; } = [];
+    public Dictionary<ulong, PatrolHelicopterMarker> PatrolHelicopterMarkers { get; init; } = [];
+
+    /// <summary>Travelling vendor markers, keyed by marker ID.</summary>
+    public Dictionary<ulong, TravellingVendorMarker> TravellingVendorMarkers { get; init; } = [];
 }

--- a/src/RustPlusApi/Data/Markers/Marker.cs
+++ b/src/RustPlusApi/Data/Markers/Marker.cs
@@ -4,7 +4,7 @@ namespace RustPlusApi.Data.Markers;
 public record Marker
 {
     /// <summary>Unique marker identifier assigned by the server.</summary>
-    public uint? Id { get; init; }
+    public ulong? Id { get; init; }
 
     /// <summary>Horizontal map coordinate (west → east).</summary>
     public float? X { get; init; }

--- a/src/RustPlusApi/Data/Markers/TravellingVendorMarker.cs
+++ b/src/RustPlusApi/Data/Markers/TravellingVendorMarker.cs
@@ -1,0 +1,4 @@
+namespace RustPlusApi.Data.Markers;
+
+/// <summary>Map marker for the Travelling Vendor (Rust+ marker type 9).</summary>
+public sealed record TravellingVendorMarker : Marker;

--- a/src/RustPlusApi/Data/VendingMachineItem.cs
+++ b/src/RustPlusApi/Data/VendingMachineItem.cs
@@ -29,4 +29,7 @@ public sealed record VendingMachineItem
 
     /// <summary>Maximum condition value of the item (0–1 scale).</summary>
     public float ItemMaxLife { get; init; }
+
+    /// <summary>Price multiplier applied to the order, if reported.</summary>
+    public float? PriceMultiplier { get; init; }
 }

--- a/src/RustPlusApi/Extensions/AppCameraToModel.cs
+++ b/src/RustPlusApi/Extensions/AppCameraToModel.cs
@@ -36,7 +36,10 @@ public static class AppCameraToModel
             SampleOffset = appCameraRays.SampleOffset,
             RayData = appCameraRays.RayData ?? [],
             Distance = appCameraRays.Distance,
-            Entities = appCameraRays.Entities.ToCameraEntities()
+            Entities = appCameraRays.Entities.ToCameraEntities(),
+            TimeOfDay = appCameraRays.ShouldSerializeTimeOfDay() ? appCameraRays.TimeOfDay : null,
+            CameraPosition = appCameraRays.CameraPosition?.ToVector3(),
+            CameraRotation = appCameraRays.CameraRotation?.ToVector3()
         };
     }
 
@@ -50,7 +53,10 @@ public static class AppCameraToModel
             SampleOffset = appCameraRays.SampleOffset,
             RayData = appCameraRays.RayData ?? [],
             Distance = appCameraRays.Distance,
-            Entities = appCameraRays.Entities.ToCameraEntities()
+            Entities = appCameraRays.Entities.ToCameraEntities(),
+            TimeOfDay = appCameraRays.ShouldSerializeTimeOfDay() ? appCameraRays.TimeOfDay : null,
+            CameraPosition = appCameraRays.CameraPosition?.ToVector3(),
+            CameraRotation = appCameraRays.CameraRotation?.ToVector3()
         };
     }
 

--- a/src/RustPlusApi/Extensions/AppClanInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppClanInfoToModel.cs
@@ -40,7 +40,8 @@ public static class AppClanInfoToModel
             Roles = clanInfo.Roles.ToClanRoles(),
             Members = clanInfo.Members.ToClanMembers(),
             Invites = clanInfo.Invites.ToClanInvites(),
-            MaxMemberCount = clanInfo.ShouldSerializeMaxMemberCount() ? clanInfo.MaxMemberCount : null
+            MaxMemberCount = clanInfo.ShouldSerializeMaxMemberCount() ? clanInfo.MaxMemberCount : null,
+            Score = clanInfo.ShouldSerializeScore() ? clanInfo.Score : null
         };
     }
 
@@ -70,7 +71,8 @@ public static class AppClanInfoToModel
             CanPromote = role.CanPromote,
             CanDemote = role.CanDemote,
             CanSetPlayerNotes = role.CanSetPlayerNotes,
-            CanAccessLogs = role.CanAccessLogs
+            CanAccessLogs = role.CanAccessLogs,
+            CanAccessScoreEvents = role.ShouldSerializeCanAccessScoreEvents() && role.CanAccessScoreEvents
         };
     }
 

--- a/src/RustPlusApi/Extensions/AppMapMarkerToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMapMarkerToModel.cs
@@ -15,21 +15,22 @@ public static class AppMapMarkerToModel
     /// <exception cref="ArgumentException">Thrown when a marker has an unrecognized type.</exception>
     public static MapMarkers ToMapMarkers(this AppMapMarkers appMapMarker)
     {
-        Dictionary<uint, UnknownMarker> unknownMarkers = [];
-        Dictionary<uint, PlayerMarker> playerMarkers = [];
+        Dictionary<ulong, UnknownMarker> unknownMarkers = [];
+        Dictionary<ulong, PlayerMarker> playerMarkers = [];
         // 2. Explosions: doesn't appear anymore in the API
-        Dictionary<uint, VendingMachineMarker> vendingMachineMarkers = [];
-        Dictionary<uint, Ch47Marker> ch47Markers = [];
-        Dictionary<uint, CargoShipMarker> cargoShipMarkers = [];
+        Dictionary<ulong, VendingMachineMarker> vendingMachineMarkers = [];
+        Dictionary<ulong, Ch47Marker> ch47Markers = [];
+        Dictionary<ulong, CargoShipMarker> cargoShipMarkers = [];
         // 6. Crates: doesn't appear anymore in the API
         // 7. GenericRadius: I don't know what is this
-        Dictionary<uint, PatrolHelicopterMarker> patrolHelicopterMarkers = [];
+        Dictionary<ulong, PatrolHelicopterMarker> patrolHelicopterMarkers = [];
+        Dictionary<ulong, TravellingVendorMarker> travellingVendorMarkers = [];
 
         foreach (var marker in appMapMarker.Markers)
         {
             switch (marker.Type)
             {
-                case AppMarkerType.Unknow:
+                case AppMarkerType.Undefined:
                     unknownMarkers.Add(marker.Id, marker.ToUnknownMarker());
                     break;
                 case AppMarkerType.Player:
@@ -56,6 +57,9 @@ public static class AppMapMarkerToModel
                 case AppMarkerType.PatrolHelicopter:
                     patrolHelicopterMarkers.Add(marker.Id, marker.ToPatrolHelicopterMarker());
                     break;
+                case AppMarkerType.TravellingVendor:
+                    travellingVendorMarkers.Add(marker.Id, marker.ToTravellingVendorMarker());
+                    break;
                 default:
                     throw new ArgumentException($"Unknown marker type: {marker.Type}");
             }
@@ -69,6 +73,7 @@ public static class AppMapMarkerToModel
             Ch47Markers = ch47Markers,
             CargoShipMarkers = cargoShipMarkers,
             PatrolHelicopterMarkers = patrolHelicopterMarkers,
+            TravellingVendorMarkers = travellingVendorMarkers,
         };
     }
 }

--- a/src/RustPlusApi/Extensions/AppMapToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMapToModel.cs
@@ -34,7 +34,8 @@ public static class AppMapToModel
     {
         return new ServerMapMonument
         {
-            Name = appMapMonument.Name,
+            // Server field is `token` (a localization key, e.g. "lighthouse"); exposed as Name.
+            Name = appMapMonument.Token,
             X = appMapMonument.X,
             Y = appMapMonument.Y
         };

--- a/src/RustPlusApi/Extensions/AppMarkerToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMarkerToModel.cs
@@ -66,7 +66,8 @@ public static class AppMarkerToModel
             IsItemBlueprint = sellOrder.ItemIsBlueprint,
             IsCurrencyBlueprint = sellOrder.CurrencyIsBlueprint,
             ItemLife = sellOrder.ItemCondition,
-            ItemMaxLife = sellOrder.ItemConditionMax
+            ItemMaxLife = sellOrder.ItemConditionMax,
+            PriceMultiplier = sellOrder.ShouldSerializePriceMultiplier() ? sellOrder.PriceMultiplier : null
         };
     }
 
@@ -106,6 +107,18 @@ public static class AppMarkerToModel
     public static PatrolHelicopterMarker ToPatrolHelicopterMarker(this AppMarker marker)
     {
         return new PatrolHelicopterMarker
+        {
+            Id = marker.Id,
+            X = marker.X,
+            Y = marker.Y
+        };
+    }
+
+    /// <summary>Maps a marker to a <see cref="TravellingVendorMarker"/>.</summary>
+    /// <param name="marker">The protobuf map marker.</param>
+    public static TravellingVendorMarker ToTravellingVendorMarker(this AppMarker marker)
+    {
+        return new TravellingVendorMarker
         {
             Id = marker.Id,
             X = marker.X,

--- a/src/RustPlusApi/Extensions/AppTeamInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppTeamInfoToModel.cs
@@ -88,8 +88,8 @@ public static class AppTeamInfoToModel
             X = note.X,
             Y = note.Y,
             Icon = (NoteIcons)note.Icon,
-            Color = (NoteColors)note.Colour,
-            Text = note.Name
+            Color = (NoteColors)note.ColourIndex,
+            Text = note.Label
         };
     }
 

--- a/src/RustPlusApi/Interfaces/IRustPlus.cs
+++ b/src/RustPlusApi/Interfaces/IRustPlus.cs
@@ -29,11 +29,11 @@ public interface IRustPlus : IRustPlusSocket
 
     /// <summary>Checks whether the player is subscribed to push notifications from a smart alarm.</summary>
     /// <param name="alarmId">Entity ID of the smart alarm.</param>
-    Task<Response<SubscriptionInfo?>> CheckSubscriptionAsync(uint alarmId);
+    Task<Response<SubscriptionInfo?>> CheckSubscriptionAsync(ulong alarmId);
 
     /// <summary>Returns the current state of a smart alarm entity.</summary>
     /// <param name="entityId">Entity ID of the alarm.</param>
-    Task<Response<AlarmInfo?>> GetAlarmInfoAsync(uint entityId);
+    Task<Response<AlarmInfo?>> GetAlarmInfoAsync(ulong entityId);
 
     /// <summary>Returns the full clan snapshot for the authenticated player's clan.</summary>
     Task<Response<ClanInfo?>> GetClanInfoAsync();
@@ -77,11 +77,11 @@ public interface IRustPlus : IRustPlusSocket
 
     /// <summary>Returns the current state of a smart switch entity.</summary>
     /// <param name="entityId">Entity ID of the smart switch.</param>
-    Task<Response<SmartSwitchInfo?>> GetSmartSwitchInfoAsync(uint entityId);
+    Task<Response<SmartSwitchInfo?>> GetSmartSwitchInfoAsync(ulong entityId);
 
     /// <summary>Returns the current contents and protection state of a storage monitor.</summary>
     /// <param name="entityId">Entity ID of the storage monitor.</param>
-    Task<Response<StorageMonitorInfo?>> GetStorageMonitorInfoAsync(uint entityId);
+    Task<Response<StorageMonitorInfo?>> GetStorageMonitorInfoAsync(ulong entityId);
 
     /// <summary>Returns recent team chat messages.</summary>
     Task<Response<TeamChatInfo?>> GetTeamChatAsync();
@@ -103,12 +103,12 @@ public interface IRustPlus : IRustPlusSocket
     /// <summary>Sets a smart switch to a specific on/off state.</summary>
     /// <param name="smartSwitchId">Entity ID of the smart switch.</param>
     /// <param name="smartSwitchValue"><see langword="true"/> to turn on, <see langword="false"/> to turn off.</param>
-    Task<Response<SmartSwitchInfo?>> SetSmartSwitchValueAsync(uint smartSwitchId, bool smartSwitchValue);
+    Task<Response<SmartSwitchInfo?>> SetSmartSwitchValueAsync(ulong smartSwitchId, bool smartSwitchValue);
 
     /// <summary>Subscribes or unsubscribes from push notifications for a smart alarm.</summary>
     /// <param name="entityId">Entity ID of the alarm.</param>
     /// <param name="doSubscribe"><see langword="true"/> to subscribe, <see langword="false"/> to unsubscribe.</param>
-    Task<Response<bool?>> SetSubscriptionAsync(uint entityId, bool doSubscribe = true);
+    Task<Response<bool?>> SetSubscriptionAsync(ulong entityId, bool doSubscribe = true);
 
     /// <summary>
     /// Pulses a smart switch on then off (or off then on) with the specified delay, implementing a
@@ -117,9 +117,9 @@ public interface IRustPlus : IRustPlusSocket
     /// <param name="entityId">Entity ID of the smart switch.</param>
     /// <param name="timeoutMilliseconds">Duration to hold the initial state before reverting, in milliseconds.</param>
     /// <param name="value">Initial state to pulse the switch to.</param>
-    Task<Response<SmartSwitchInfo?>> StrobeSmartSwitchAsync(uint entityId, int timeoutMilliseconds = 1000, bool value = true);
+    Task<Response<SmartSwitchInfo?>> StrobeSmartSwitchAsync(ulong entityId, int timeoutMilliseconds = 1000, bool value = true);
 
     /// <summary>Toggles a smart switch — turns it on if off, or off if on.</summary>
     /// <param name="entityId">Entity ID of the smart switch.</param>
-    Task<Response<SmartSwitchInfo?>> ToggleSmartSwitchAsync(uint entityId);
+    Task<Response<SmartSwitchInfo?>> ToggleSmartSwitchAsync(ulong entityId);
 }

--- a/src/RustPlusApi/Protobuf/RustPlusContracts.proto
+++ b/src/RustPlusApi/Protobuf/RustPlusContracts.proto
@@ -58,6 +58,7 @@ message ClanInfo {
 	repeated ClanInfo.Member members = 11;
 	repeated ClanInfo.Invite invites = 12;
 	optional int32 max_member_count = 13;
+	optional int64 score = 14;
 
 	message Role {
 		required int32 role_id = 1;
@@ -71,6 +72,7 @@ message ClanInfo {
 		required bool can_demote = 9;
 		required bool can_set_player_notes = 10;
 		required bool can_access_logs = 11;
+		optional bool can_access_score_events = 12;
 	}
 
 	message Member {
@@ -123,7 +125,7 @@ message AppRequest {
 	required uint32 seq = 1;
 	required uint64 player_id = 2;
 	required int32 player_token = 3;
-	optional uint32 entity_id = 4;
+	optional uint64 entity_id = 4;
 	optional AppEmpty get_info = 8;
 	optional AppEmpty get_time = 9;
 	optional AppEmpty get_map = 10;
@@ -243,7 +245,7 @@ message AppMap {
 	optional string background = 6;
 
 	message Monument {
-		required string name = 1;
+		required string token = 1;
 		required float x = 2;
 		required float y = 3;
 	}
@@ -289,34 +291,10 @@ message AppTeamInfo {
 		required int32 type = 2;
 		required float x = 3;
 		required float y = 4;
-		required IconType icon = 5;
-		required IconColor colour = 6;
-		optional string name = 7;
+		required int32 icon = 5;
+		required int32 colour_index = 6;
+		optional string label = 7;
 	}
-}
-
-enum IconType {
-	Default = 0;
-	Money = 1;
-	Home = 2;
-	Drop = 3;
-	Sight = 4;
-	Shield = 5;
-	Skull = 6;
-	Bed = 7;
-	Sleep = 8;
-	Gun = 9;
-	Rock = 10;
-	Chest = 11;
-}
-
-enum IconColor {
-	Yellow = 0;
-	Blue = 1;
-	Green = 2;
-	Red = 3;
-	Purple = 4;
-	Cyan = 5;
 }
 
 message AppTeamMessage {
@@ -332,7 +310,7 @@ message AppTeamChat {
 }
 
 message AppMarker {
-	required uint32 id = 1;
+	required uint64 id = 1;
 	required AppMarkerType type = 2;
 	required float x = 3;
 	required float y = 4;
@@ -356,11 +334,12 @@ message AppMarker {
 		required bool currency_is_blueprint = 7;
 		optional float item_condition = 8;
 		optional float item_condition_max = 9;
+		optional float price_multiplier = 10;
 	}
 }
 
 enum AppMarkerType {
-	Unknow = 0;
+	Undefined = 0;
 	Player = 1;
 	Explosion = 2;
 	VendingMachine = 3;
@@ -369,6 +348,7 @@ enum AppMarkerType {
 	Crate = 6;
 	GenericRadius = 7;
 	PatrolHelicopter = 8;
+	TravellingVendor = 9;
 }
 
 message AppMapMarkers {
@@ -405,7 +385,7 @@ message AppNewTeamMessage {
 }
 
 message AppEntityChanged {
-	required uint32 entity_id = 1;
+	required uint64 entity_id = 1;
 	required AppEntityPayload payload = 2;
 }
 
@@ -441,6 +421,9 @@ message AppCameraRays {
 	required bytes ray_data = 3;
 	required float distance = 4;
 	repeated AppCameraRays.Entity entities = 5;
+	optional float time_of_day = 6;
+	optional Vector3 camera_position = 7;
+	optional Vector3 camera_rotation = 8;
 
 	enum EntityType {
 		Tree = 1;
@@ -448,7 +431,7 @@ message AppCameraRays {
 	}
 
 	message Entity {
-		required uint32 entity_id = 1;
+		required uint64 entity_id = 1;
 		required EntityType type = 2;
 		required Vector3 position = 3;
 		required Vector3 rotation = 4;

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -120,7 +120,7 @@ public class RustPlus(string server, int port, ulong playerId, int playerToken, 
     /// <param name="entityId">The ID of the entity.</param>
     /// <param name="selector">The function to select the entity information from the response.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the entity information.</returns>
-    protected async Task<Response<T?>> GetEntityInfoAsync<T>(uint entityId, Func<AppMessage, T> selector)
+    protected async Task<Response<T?>> GetEntityInfoAsync<T>(ulong entityId, Func<AppMessage, T> selector)
     {
         var request = new AppRequest
         {
@@ -135,7 +135,7 @@ public class RustPlus(string server, int port, ulong playerId, int playerToken, 
     /// </summary>
     /// <param name="alarmId">The ID of the alarm entity.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the subscription information.</returns>
-    public async Task<Response<SubscriptionInfo?>> CheckSubscriptionAsync(uint alarmId)
+    public async Task<Response<SubscriptionInfo?>> CheckSubscriptionAsync(ulong alarmId)
     {
         var request = new AppRequest
         {
@@ -152,7 +152,7 @@ public class RustPlus(string server, int port, ulong playerId, int playerToken, 
     /// </summary>
     /// <param name="entityId">The ID of the alarm entity.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the alarm information.</returns>
-    public async Task<Response<AlarmInfo?>> GetAlarmInfoAsync(uint entityId)
+    public async Task<Response<AlarmInfo?>> GetAlarmInfoAsync(ulong entityId)
     {
         return await GetEntityInfoAsync<AlarmInfo?>(entityId, r => r.Response.EntityInfo.ToAlarmInfo()).ConfigureAwait(false);
     }
@@ -334,7 +334,7 @@ public class RustPlus(string server, int port, ulong playerId, int playerToken, 
     /// </summary>
     /// <param name="entityId">The ID of the smart switch entity.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the smart switch information.</returns>
-    public async Task<Response<SmartSwitchInfo?>> GetSmartSwitchInfoAsync(uint entityId)
+    public async Task<Response<SmartSwitchInfo?>> GetSmartSwitchInfoAsync(ulong entityId)
     {
         return await GetEntityInfoAsync<SmartSwitchInfo?>(
             entityId,
@@ -346,7 +346,7 @@ public class RustPlus(string server, int port, ulong playerId, int playerToken, 
     /// </summary>
     /// <param name="entityId">The ID of the storage monitor entity.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the storage monitor information.</returns>
-    public async Task<Response<StorageMonitorInfo?>> GetStorageMonitorInfoAsync(uint entityId)
+    public async Task<Response<StorageMonitorInfo?>> GetStorageMonitorInfoAsync(ulong entityId)
     {
         return await GetEntityInfoAsync<StorageMonitorInfo?>(
             entityId,
@@ -436,7 +436,7 @@ public class RustPlus(string server, int port, ulong playerId, int playerToken, 
     /// <param name="smartSwitchId">The ID of the smart switch entity.</param>
     /// <param name="smartSwitchValue">The value to set for the smart switch.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the updated smart switch information.</returns>
-    public async Task<Response<SmartSwitchInfo?>> SetSmartSwitchValueAsync(uint smartSwitchId, bool smartSwitchValue)
+    public async Task<Response<SmartSwitchInfo?>> SetSmartSwitchValueAsync(ulong smartSwitchId, bool smartSwitchValue)
     {
         var request = new AppRequest
         {
@@ -457,7 +457,7 @@ public class RustPlus(string server, int port, ulong playerId, int playerToken, 
     /// <param name="entityId">The ID of the entity.</param>
     /// <param name="doSubscribe">Specifies whether to subscribe or unsubscribe.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> indicating the success of the operation.</returns>
-    public async Task<Response<bool?>> SetSubscriptionAsync(uint entityId, bool doSubscribe = true)
+    public async Task<Response<bool?>> SetSubscriptionAsync(ulong entityId, bool doSubscribe = true)
     {
         var request = new AppRequest
         {
@@ -478,7 +478,7 @@ public class RustPlus(string server, int port, ulong playerId, int playerToken, 
     /// <param name="value">The initial value of the smart switch.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the updated smart switch information.</returns>
     public async Task<Response<SmartSwitchInfo?>> StrobeSmartSwitchAsync(
-        uint entityId,
+        ulong entityId,
         int timeoutMilliseconds = 1000,
         bool value = true)
     {
@@ -495,7 +495,7 @@ public class RustPlus(string server, int port, ulong playerId, int playerToken, 
     /// </summary>
     /// <param name="entityId">The ID of the smart switch entity.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the updated smart switch information.</returns>
-    public async Task<Response<SmartSwitchInfo?>> ToggleSmartSwitchAsync(uint entityId)
+    public async Task<Response<SmartSwitchInfo?>> ToggleSmartSwitchAsync(ulong entityId)
     {
         var entityInfo = await GetSmartSwitchInfoAsync(entityId).ConfigureAwait(false);
 

--- a/tools/update-proto/README.md
+++ b/tools/update-proto/README.md
@@ -73,9 +73,9 @@ authoritative for names/types/numbers/repeated and for new fields/messages/enums
 the committed proto's conventions that the binary does not carry — `required`/`optional` labels,
 declaration order, and hand-maintained well-known types (`Vector2/3/4`, `Color`, `Ray`).
 
-> **Not a drop-in replacement.** Some diffs are deliberate library refinements to keep (e.g.
-> richer `IconType`/`IconColor` enums where the server has plain `int32`). Review, don't blindly
-> overwrite.
+> **Review, don't blindly overwrite.** A diff is the *server's* current truth; decide per change
+> whether to adopt it (e.g. a field rename) or keep a deliberate library convention. With the v2
+> refresh applied, the gate is currently empty.
 
 Working dirs (`steamcmd/`, `rds/`, `decompiled/`, `out/`, `ProtoGen/bin|obj`) are gitignored.
 
@@ -84,3 +84,9 @@ Working dirs (`steamcmd/`, `rds/`, `decompiled/`, `out/`, `ProtoGen/bin|obj`) ar
 Rust force-updates on the **first Thursday of each month (~18:00–20:00 UTC)** — the only
 moment the contracts can change. After the update lands: re-run this pipeline, review the
 diff, ship any delta. We watch the **authoritative server**, never the community libs.
+
+This is automated by [`.github/workflows/ProtoRefresh.yml`](../../.github/workflows/ProtoRefresh.yml):
+every Thursday 21:00 UTC (gated to the first of the month) it runs the full pipeline and, on
+drift, opens/updates a `proto-drift` issue with the diff. It can also be run on demand via
+**workflow_dispatch**. It never auto-applies the proto — new fields usually need matching
+model/mapper changes.

--- a/v2-progress.md
+++ b/v2-progress.md
@@ -22,7 +22,7 @@ Last updated: 2026-06-05
 | 6 | Native credential acquisition | ☑ |
 | 7 | JSON cleanup | ☑ |
 | 8 | Docs & release (`2.0.0`) | ☑ |
-| ✶ | Proto-refresh tooling (`tools/update-proto/`) | ☑ tooling; ◐ apply refresh |
+| ✶ | Proto-refresh tooling (`tools/update-proto/`) + applied refresh | ☑ |
 | ✶ | One-time golden-payload capture | ☐ |
 
 ---
@@ -189,7 +189,7 @@ Last updated: 2026-06-05
 - [x] Decompile contract types with `ilspycmd` — `2-decompile.sh` (auto-installs ilspycmd, `--list` discovery, pipefail-safe). **Run end-to-end.** Target corrected to `Rust.Data.dll`.
 - [x] Regenerate `RustPlusContracts.proto` + diff — **⚠️ premise correction:** the server uses **SilentOrbit**, not protobuf-net (no `[ProtoContract]`, no protobuf-net dll), so `Serializer.GetProto<AppMessage>()` is **not applicable**. Built `ProtoGen` (Roslyn) which **parses the decompiled SilentOrbit C#** (field# from the dual `Deserialize` switch, type from decl + `ProtocolParser.Read*`, nesting from C# nested classes; labels/order/well-known-types preserved from committed). `update-proto.sh` runs the whole pipeline + diff gate. Regen reproduces the committed proto with a **25-line, all-genuine diff** (new fields incl. `time_of_day`; `Monument.name→token`; `entity_id` widening; `Unknow→Undefined`). _See [proto-refresh-plan.md](proto-refresh-plan.md) for the full result._
 - [x] Document monthly (first-Thursday) rerun routine — cadence in `tools/update-proto/README.md`. _(Method D/B backups dropped: Method A is reliable. Optional scheduled Action not added — left as a documented option.)_
-- [ ] **Follow-up:** apply the reviewed diff to `RustPlusContracts.proto` (one-time v2 refresh) + add `Data/*` mappers for any new fields, then PR.
+- [x] **One-time v2 refresh applied** — proto now matches the server byte-for-byte (`update-proto.sh` exits clean). Models/mappers updated: clan `Score` + role `CanAccessScoreEvents`, camera `TimeOfDay`/`CameraPosition`/`CameraRotation`, sell-order `PriceMultiplier`, new `TravellingVendorMarker` (+ dict/case), `Monument.name→token`, `Unknow→Undefined`, entity-id widening `uint→ulong` (models, `MapMarkers` dicts, `RustPlus`/`IRustPlus` params), and `Note` icon/colour adopted server truth (`int32`/`colour_index`/`label`; redundant `IconType`/`IconColor` proto enums dropped — library keeps its own `NoteIcons`/`NoteColors`). **Build clean (0 warnings), 51 tests green.** _(Regression tests for the new fields + the PR itself remain.)_
 
 ### One-time golden-payload capture (§15.4)
 


### PR DESCRIPTION
## Summary

Applies the one-time **v2 proto refresh** (derived authoritatively from the decompiled Rust dedicated server, build `23601104`, via `tools/update-proto`) and wires up a scheduled drift-check.

The committed `RustPlusContracts.proto` now reproduces **byte-for-byte** from a fresh server download — `tools/update-proto/update-proto.sh` exits clean (0 = no drift).

## Proto + API changes

**New wire fields** (model + mapper added):
- `AppCameraRays.time_of_day` / `camera_position` / `camera_rotation` → `CameraFrame` / `CameraRaysEventArg`
- `ClanInfo.score`, `ClanInfo.Role.can_access_score_events`
- `AppMarker.SellOrder.price_multiplier` → `VendingMachineItem`

**New marker type**: `AppMarkerType.TravellingVendor` (+ `TravellingVendorMarker` + routing; previously this would have thrown at runtime).

**Renames / fixes**:
- `AppMap.Monument.name → token`
- `AppMarkerType.Unknow → Undefined` (committed typo)
- `AppTeamInfo.Note` adopts server truth: `int32 icon` / `colour_index` / `label`; dropped the redundant `IconType`/`IconColor` proto enums (the library keeps its own `NoteIcons`/`NoteColors`, public API unchanged)

**⚠️ Breaking**: entity-id widening `uint32 → uint64` (server wraps IDs in `NetworkableId`, read as 64-bit). Touches `Marker.Id`, all `MapMarkers` dictionaries, `CameraEntity.EntityId`, the smart-switch/storage-monitor event args, and the `entityId`/`alarmId`/`smartSwitchId` params on `RustPlus`/`IRustPlus`. Intentional — fixes silent truncation.

## Tooling

Adds `.github/workflows/ProtoRefresh.yml`: runs the full pipeline every **first Thursday** (after Rust's monthly update) + on-demand (`workflow_dispatch`); on drift it opens/updates a `proto-drift` issue with the diff. It **never auto-applies** the proto, since new fields usually need matching mapper work.

## Verification

- Full solution builds **0 errors / 0 warnings** (warnings-as-errors)
- **51 tests pass** (3 skipped opt-in canaries)
- `update-proto.sh` regenerates the committed proto with an empty diff

## Follow-ups (not in this PR)

- Regression tests exercising the new fields/mappers
- The travelling-vendor marker is modeled minimally (id/x/y) — can be enriched later

🤖 Generated with [Claude Code](https://claude.com/claude-code)