### PR TITLE
chore: resolve SonarQube code smells and improve coverage

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "MD013": false,
+  "MD033": false,
+  "MD041": false
+}

--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ all the required credentials natively — _no Node.js required_.
 [![CI](https://github.com/HandyS11/RustPlusApi/actions/workflows/CI.yml/badge.svg)](https://github.com/HandyS11/RustPlusApi/actions/workflows/CI.yml)
 [![CD](https://github.com/HandyS11/RustPlusApi/actions/workflows/CD.yml/badge.svg)](https://github.com/HandyS11/RustPlusApi/actions/workflows/CD.yml)
 [![Docs](https://github.com/HandyS11/RustPlusApi/actions/workflows/Documentation.yml/badge.svg)](https://handys11.github.io/RustPlusApi/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 ![.NET](https://img.shields.io/badge/.NET-Standard%202.0%20%7C%2010-512BD4?logo=dotnet)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![codecov](https://codecov.io/gh/HandyS11/RustPlusApi/graph/badge.svg?token=UZCM1A6ERM)](https://codecov.io/gh/HandyS11/RustPlusApi)
 [![Mutation Score](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FHandyS11%2FRustPlusApi%2Fdevelop)](https://dashboard.stryker-mutator.io/reports/github.com/HandyS11/RustPlusApi/develop)
 
-[Documentation](https://handys11.github.io/RustPlusApi/) ·
 [Getting Started](https://handys11.github.io/RustPlusApi/articles/getting-started.html) ·
-[Samples](samples/README.md) ·
+[Documentation](https://handys11.github.io/RustPlusApi/) ·
+[Samples](samples/README.md)
 
 </div>
 

--- a/samples/RustPlus.ConsoleApp/Program.cs
+++ b/samples/RustPlus.ConsoleApp/Program.cs
@@ -1,4 +1,4 @@
-﻿using RustPlus.ConsoleApp.Features;
+using RustPlus.ConsoleApp.Features;
 using RustPlus.ConsoleApp.Utils;
 
 // Fill credentials.json (copy credentials.sample.json) with the ip/port/playerId/playerToken

--- a/samples/RustPlus.ConsoleApp/Utils/DisplayUtilities.cs
+++ b/samples/RustPlus.ConsoleApp/Utils/DisplayUtilities.cs
@@ -1,4 +1,4 @@
-﻿using RustPlusApi.Data;
+using RustPlusApi.Data;
 using System.Text.Json;
 
 namespace RustPlus.ConsoleApp.Utils;

--- a/samples/RustPlus.Fcm.ConsoleApp/Program.cs
+++ b/samples/RustPlus.Fcm.ConsoleApp/Program.cs
@@ -1,4 +1,4 @@
-﻿using RustPlus.Fcm.ConsoleApp.Utils;
+using RustPlus.Fcm.ConsoleApp.Utils;
 using RustPlusApi.Fcm;
 using RustPlusApi.Fcm.Data;
 using System.Diagnostics;

--- a/src/RustPlusApi/Extensions/AppEntityInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppEntityInfoToModel.cs
@@ -51,7 +51,7 @@ public static class AppEntityInfoToModel
             Capacity = entity.Payload.Capacity,
             HasProtection = entity.Payload.HasProtection,
             ProtectionExpiry = DateTimeOffset.FromUnixTimeSeconds(entity.Payload.ProtectionExpiry).UtcDateTime,
-            Items = [..entity.Payload.Items.ToStorageMonitorItemsInfo()]
+            Items = [.. entity.Payload.Items.ToStorageMonitorItemsInfo()]
         };
     }
 

--- a/src/RustPlusApi/Extensions/AppMapToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMapToModel.cs
@@ -20,7 +20,7 @@ public static class AppMapToModel
             Width = appMap.Width,
             OceanMargin = appMap.OceanMargin,
             Background = HtmlColorParser.FromHtml(appMap.Background),
-            Monuments = [..appMap.Monuments.ToServerMapMonuments()],
+            Monuments = [.. appMap.Monuments.ToServerMapMonuments()],
             JpgImage = appMap.JpgImage
         };
     }

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -128,10 +128,9 @@ public abstract class RustPlusSocket(
     internal Task? SendLoopForTests { get; private set; }
 
     private int _playerToken = playerToken;
-    private ulong _playerId = playerId;
 
     /// <summary>The Steam ID requests are currently issued as (see <see cref="SetPlayer"/>).</summary>
-    protected ulong PlayerId => _playerId;
+    protected ulong PlayerId { get; private set; } = playerId;
 
     /// <summary>
     /// Asynchronously connects to the Rust+ server using a WebSocket.
@@ -256,7 +255,7 @@ public abstract class RustPlusSocket(
     /// <param name="newPlayerToken">The new player token acquired with FCM.</param>
     public void SetPlayer(ulong newPlayerId, int newPlayerToken)
     {
-        _playerId = newPlayerId;
+        PlayerId = newPlayerId;
         _playerToken = newPlayerToken;
     }
 
@@ -280,7 +279,7 @@ public abstract class RustPlusSocket(
 
         var seq = (uint)Interlocked.Increment(ref _seq);
         request.Seq = seq;
-        request.PlayerId = _playerId;
+        request.PlayerId = PlayerId;
         request.PlayerToken = _playerToken;
 
         // Always keyed by seq: even a broadcast-reply request gets a seq-bearing response on error.
@@ -592,53 +591,8 @@ public abstract class RustPlusSocket(
             Debug.WriteLine("Waiting for data...");
             try
             {
-                // Accumulate fragments straight into a stream: no per-read LINQ, no list growth,
-                // and one buffer reused for the connection (map messages span megabytes).
-#pragma warning disable RCS1261 // MemoryStream.DisposeAsync is a no-op; await using not available in netstandard2.0
-                using var messageStream = new MemoryStream();
-#pragma warning restore RCS1261
-                WebSocketReceiveResult result;
-
-                do
-                {
-                    result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken).ConfigureAwait(false);
-#pragma warning disable CA1849, VSTHRD103, S6966 // MemoryStream.Write is in-memory and never blocks; WriteAsync would only add overhead
-                    messageStream.Write(buffer, 0, result.Count);
-#pragma warning restore CA1849, VSTHRD103, S6966
-                } while (!result.EndOfMessage);
-
-                messageStream.Position = 0;
-                var message = Serializer.Deserialize<AppMessage>(messageStream);
-
-                Debug.WriteLine($"Received message:\n{message}");
-                MessageReceived?.Invoke(this, message);
-
-                if (message.Broadcast is not null)
-                {
-                    Debug.WriteLine($"Received notification:\n{message}");
-                    NotificationReceived?.Invoke(this, message);
-                    // Entity type from message.Response.EntityInfo.Type is not yet used.
-                    ParseNotification(message.Broadcast);
-                }
-                else
-                {
-                    Debug.WriteLine($"Received response:\n{message}");
-                    ResponseReceived?.Invoke(this, message);
-                }
-
-                // Correlate the reply. A seq-bearing response resolves the request it answers; a broadcast
-                // resolves the oldest waiter whose matcher accepts it, else it is a pure notification.
-                if (message.Response is not null)
-                {
-                    if (_pendingRequests.TryRemove(message.Response.Seq, out var tcs))
-                    {
-                        tcs.TrySetResult(message);
-                    }
-                }
-                else if (message.Broadcast is not null)
-                {
-                    ResolveBroadcastReply(message);
-                }
+                var message = await ReceiveMessageAsync(webSocket, buffer).ConfigureAwait(false);
+                DispatchMessage(message);
             }
             catch (OperationCanceledException)
             {
@@ -680,6 +634,70 @@ public abstract class RustPlusSocket(
         FailPendingRequests(new WebSocketException(
             WebSocketError.ConnectionClosedPrematurely,
             "The connection closed before a response arrived."));
+    }
+
+    /// <summary>
+    /// Reads a single, possibly fragmented, message off <paramref name="webSocket"/> and deserializes it.
+    /// </summary>
+    /// <param name="webSocket">The connection to read from.</param>
+    /// <param name="buffer">A reusable receive buffer, sized from the options.</param>
+    /// <returns>The fully accumulated and deserialized <see cref="AppMessage"/>.</returns>
+    private async Task<AppMessage> ReceiveMessageAsync(ClientWebSocket webSocket, byte[] buffer)
+    {
+        // Accumulate fragments straight into a stream: no per-read LINQ, no list growth,
+        // and one buffer reused for the connection (map messages span megabytes).
+#pragma warning disable RCS1261 // MemoryStream.DisposeAsync is a no-op; await using not available in netstandard2.0
+        using var messageStream = new MemoryStream();
+#pragma warning restore RCS1261
+        WebSocketReceiveResult result;
+
+        do
+        {
+            result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken).ConfigureAwait(false);
+#pragma warning disable CA1849, VSTHRD103, S6966 // MemoryStream.Write is in-memory and never blocks; WriteAsync would only add overhead
+            messageStream.Write(buffer, 0, result.Count);
+#pragma warning restore CA1849, VSTHRD103, S6966
+        } while (!result.EndOfMessage);
+
+        messageStream.Position = 0;
+        return Serializer.Deserialize<AppMessage>(messageStream);
+    }
+
+    /// <summary>
+    /// Raises the receive events for <paramref name="message"/> and correlates it with any pending request.
+    /// A seq-bearing response resolves the request it answers; a broadcast resolves the oldest waiter whose
+    /// matcher accepts it, else it is a pure notification.
+    /// </summary>
+    /// <param name="message">The message just read off the socket.</param>
+    private void DispatchMessage(AppMessage message)
+    {
+        Debug.WriteLine($"Received message:\n{message}");
+        MessageReceived?.Invoke(this, message);
+
+        if (message.Broadcast is not null)
+        {
+            Debug.WriteLine($"Received notification:\n{message}");
+            NotificationReceived?.Invoke(this, message);
+            // Entity type from message.Response.EntityInfo.Type is not yet used.
+            ParseNotification(message.Broadcast);
+        }
+        else
+        {
+            Debug.WriteLine($"Received response:\n{message}");
+            ResponseReceived?.Invoke(this, message);
+        }
+
+        if (message.Response is not null)
+        {
+            if (_pendingRequests.TryRemove(message.Response.Seq, out var tcs))
+            {
+                tcs.TrySetResult(message);
+            }
+        }
+        else if (message.Broadcast is not null)
+        {
+            ResolveBroadcastReply(message);
+        }
     }
 
     /// <summary>

--- a/tests/RustPlusApi.Camera.UnitTests/CameraRendererTests.cs
+++ b/tests/RustPlusApi.Camera.UnitTests/CameraRendererTests.cs
@@ -154,7 +154,7 @@ public class CameraRendererTests
             rays.AddRange(FullRay(255, 192, 0));
         }
 
-        renderer.AddRays(new CameraFrame { RayData = [..rays], SampleOffset = 0 });
+        renderer.AddRays(new CameraFrame { RayData = [.. rays], SampleOffset = 0 });
 
         using var image = Decode(renderer.Render());
         Assert.True(HasPixel(image, new Rgba32(208, 230, 252)));
@@ -217,7 +217,7 @@ public class CameraRendererTests
             rays.AddRange(FullRay(128, 63, 2));
         }
 
-        renderer.AddRays(new CameraFrame { RayData = [..rays], SampleOffset = 0 });
+        renderer.AddRays(new CameraFrame { RayData = [.. rays], SampleOffset = 0 });
 
         using var image = Decode(renderer.Render());
         Assert.True(HasPixel(image, new Rgba32(76, 178, 255)));
@@ -295,7 +295,7 @@ public class CameraRendererTests
         var rays = new List<byte> { 255, 0, 63, 6 };
         rays.AddRange([0x79, 0xFF]);
 
-        renderer.AddRays(new CameraFrame { RayData = [..rays], SampleOffset = 0 });
+        renderer.AddRays(new CameraFrame { RayData = [.. rays], SampleOffset = 0 });
         var png = renderer.Render();
 
         Assert.NotEmpty(png);
@@ -337,7 +337,7 @@ public class CameraRendererTests
         rays.AddRange([255, 0, 0, 0]);
         rays.AddRange("@\0"u8.ToArray());
 
-        renderer.AddRays(new CameraFrame { RayData = [..rays], SampleOffset = 0 });
+        renderer.AddRays(new CameraFrame { RayData = [.. rays], SampleOffset = 0 });
         var png = renderer.Render();
 
         Assert.NotEmpty(png);
@@ -414,7 +414,7 @@ public class CameraRendererTests
         rays.AddRange([0b1000_0000, 0x80]);
         rays.AddRange([0b1100_0001, 0x40, 0x00]);
 
-        renderer.AddRays(new CameraFrame { RayData = [..rays], SampleOffset = 0 });
+        renderer.AddRays(new CameraFrame { RayData = [.. rays], SampleOffset = 0 });
         var png = renderer.Render();
 
         Assert.NotEmpty(png);
@@ -707,7 +707,7 @@ public class CameraRendererTests
         }
 
         var exception = Record.Exception(() =>
-            renderer.AddRays(new CameraFrame { RayData = [..rays], SampleOffset = 1 }));
+            renderer.AddRays(new CameraFrame { RayData = [.. rays], SampleOffset = 1 }));
 
         Assert.Null(exception);
         using var image = Decode(renderer.Render());

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/RegistrationTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/RegistrationTests.cs
@@ -137,4 +137,24 @@ public class RegistrationTests
         Assert.Equal(999, pairing.PlayerToken);
         Assert.Null(pairing.Name);
     }
+
+    /// <summary>
+    /// Covers <see cref="PairingListener"/> construction (it builds the wrapped <c>RustPlusFcm</c>)
+    /// and <see cref="PairingListener.Dispose"/>. Neither touches the network, so Dispose on a
+    /// never-connected listener must be safe and idempotent.
+    /// </summary>
+    [Fact]
+    public void PairingListener_ConstructAndDispose_DoesNotThrow()
+    {
+        var credentials = new Credentials { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 } };
+
+        var listener = new PairingListener(credentials);
+
+        var ex = Record.Exception(() =>
+        {
+            listener.Dispose();
+            listener.Dispose();  // idempotent
+        });
+        Assert.Null(ex);
+    }
 }

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
@@ -155,7 +155,7 @@ public class FcmSocketFramingTests
     /// <summary>Concatenates the given frames into a single MCS byte script.</summary>
     /// <param name="frames">The frames to concatenate in order.</param>
     private static byte[] Build(params IEnumerable<byte>[] frames) =>
-        [..frames.SelectMany(f => f)];
+        [.. frames.SelectMany(f => f)];
 
     /// <summary>Builds a valid Rust+ data-message stanza (channelId + body present).</summary>
     /// <param name="persistentId">The stanza's persistent id used for de-duplication.</param>

--- a/tools/update-proto/ProtoGen/CommittedProto.cs
+++ b/tools/update-proto/ProtoGen/CommittedProto.cs
@@ -35,57 +35,108 @@ internal sealed partial class CommittedProto
     public static CommittedProto Parse(string protoPath)
     {
         var result = new CommittedProto();
-        var stack = new List<string>();
-        string? topLevelName = null;
-        var block = new List<string>();
+        var state = new ParseState();
         foreach (var rawLine in File.ReadLines(protoPath))
         {
-            if (topLevelName is not null)
-            {
-                block.Add(rawLine);
-            }
-
-            var line = rawLine.Trim();
-            if (line.Length == 0 || line.StartsWith("//", StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            var open = DeclOpen().Match(line);
-            if (open.Success)
-            {
-                if (stack.Count == 0)
-                {
-                    topLevelName = open.Groups[2].Value;
-                    block = [rawLine];
-                }
-                stack.Add(open.Groups[2].Value);
-                result.DeclOrder.Add(string.Join('.', stack));
-                continue;
-            }
-            if (line.StartsWith('}'))
-            {
-                if (stack.Count > 0)
-                {
-                    stack.RemoveAt(stack.Count - 1);
-                }
-
-                if (stack.Count == 0 && topLevelName is not null)
-                {
-                    result.RawTopLevelBlocks[topLevelName] = string.Join('\n', block).TrimEnd();
-                    topLevelName = null;
-                }
-                continue;
-            }
-
-            var field = FieldLine().Match(line);
-            if (field.Success && stack.Count > 0)
-            {
-                var qualified = string.Join('.', stack);
-                result._labels[$"{qualified}#{field.Groups[2].Value}"] = field.Groups[1].Value;
-            }
+            result.ProcessLine(rawLine, state);
         }
+
         return result;
+    }
+
+    /// <summary>Transient state threaded through the line-by-line parse: the nesting stack, the current
+    /// top-level declaration name, and the raw lines accumulated for it.</summary>
+    private sealed class ParseState
+    {
+        public readonly List<string> Stack = [];
+        public string? TopLevelName;
+        public List<string> Block = [];
+    }
+
+    /// <summary>Folds a single source line into <paramref name="state"/>: tracks declaration open/close
+    /// and records field labels.</summary>
+    /// <param name="rawLine">The untrimmed source line.</param>
+    /// <param name="state">The running parse state to update.</param>
+    private void ProcessLine(string rawLine, ParseState state)
+    {
+        if (state.TopLevelName is not null)
+        {
+            state.Block.Add(rawLine);
+        }
+
+        var line = rawLine.Trim();
+        if (line.Length == 0 || line.StartsWith("//", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (TryHandleDeclOpen(line, rawLine, state) || TryHandleDeclClose(line, state))
+        {
+            return;
+        }
+
+        HandleField(line, state);
+    }
+
+    /// <summary>Handles a <c>message</c>/<c>enum</c> opening brace, pushing it onto the nesting stack.</summary>
+    /// <param name="line">The trimmed source line.</param>
+    /// <param name="rawLine">The untrimmed source line (kept to seed the top-level block).</param>
+    /// <param name="state">The running parse state to update.</param>
+    /// <returns><c>true</c> if the line opened a declaration.</returns>
+    private bool TryHandleDeclOpen(string line, string rawLine, ParseState state)
+    {
+        var open = DeclOpen().Match(line);
+        if (!open.Success)
+        {
+            return false;
+        }
+
+        if (state.Stack.Count == 0)
+        {
+            state.TopLevelName = open.Groups[2].Value;
+            state.Block = [rawLine];
+        }
+        state.Stack.Add(open.Groups[2].Value);
+        DeclOrder.Add(string.Join('.', state.Stack));
+        return true;
+    }
+
+    /// <summary>Handles a closing brace, popping the stack and capturing the raw block when a top-level
+    /// declaration ends.</summary>
+    /// <param name="line">The trimmed source line.</param>
+    /// <param name="state">The running parse state to update.</param>
+    /// <returns><c>true</c> if the line closed a declaration.</returns>
+    private bool TryHandleDeclClose(string line, ParseState state)
+    {
+        if (!line.StartsWith('}'))
+        {
+            return false;
+        }
+
+        if (state.Stack.Count > 0)
+        {
+            state.Stack.RemoveAt(state.Stack.Count - 1);
+        }
+
+        if (state.Stack.Count == 0 && state.TopLevelName is not null)
+        {
+            RawTopLevelBlocks[state.TopLevelName] = string.Join('\n', state.Block).TrimEnd();
+            state.TopLevelName = null;
+        }
+        return true;
+    }
+
+    /// <summary>Records the label (required/optional/repeated) for a field line within the current scope.</summary>
+    /// <param name="line">The trimmed source line.</param>
+    /// <param name="state">The running parse state to update.</param>
+    private void HandleField(string line, ParseState state)
+    {
+        var field = FieldLine().Match(line);
+        if (field.Success && state.Stack.Count > 0)
+        {
+            var qualified = string.Join('.', state.Stack);
+            _labels[$"{qualified}#{field.Groups[2].Value}"] = field.Groups[1].Value;
+        }
     }
 
     [GeneratedRegex(@"^(message|enum)\s+([A-Za-z0-9_]+)\s*\{$")]

--- a/tools/update-proto/ProtoGen/ServerParser.cs
+++ b/tools/update-proto/ProtoGen/ServerParser.cs
@@ -69,41 +69,52 @@ internal sealed class ServerParser
         switch (member)
         {
             case TypeDeclarationSyntax cls and (ClassDeclarationSyntax or StructDeclarationSyntax) when IsProtoMessage(cls):
-                {
-                    var simple = cls.Identifier.Text;
-                    var qualified = parentQualified is null ? simple : $"{parentQualified}.{simple}";
-                    _messages[qualified] = new Message { QualifiedName = qualified, SimpleName = simple, ParentQualifiedName = parentQualified };
-                    Register(simple, qualified);
-
-                    foreach (var inner in cls.Members)
-                    {
-                        Discover(inner, qualified);
-                    }
-
-                    break;
-                }
+                DiscoverMessage(cls, parentQualified);
+                break;
             case EnumDeclarationSyntax en:
-                {
-                    var simple = en.Identifier.Text;
-                    var qualified = parentQualified is null ? simple : $"{parentQualified}.{simple}";
-                    var def = new EnumDef { QualifiedName = qualified, SimpleName = simple, ParentQualifiedName = parentQualified };
-                    var next = 0;
-                    foreach (var m in en.Members)
-                    {
-                        var val = next;
-                        if (m.EqualsValue?.Value is { } v && TryParseInt(v, out var explicitVal))
-                        {
-                            val = explicitVal;
-                        }
-
-                        def.Values.Add((m.Identifier.Text, val));
-                        next = val + 1;
-                    }
-                    _enums[qualified] = def;
-                    Register(simple, qualified);
-                    break;
-                }
+                DiscoverEnum(en, parentQualified);
+                break;
         }
+    }
+
+    /// <summary>Registers a proto message type and recurses into its members.</summary>
+    /// <param name="cls">The class/struct declaration backing the message.</param>
+    /// <param name="parentQualified">Qualified name of the enclosing type, or null at file scope.</param>
+    private void DiscoverMessage(TypeDeclarationSyntax cls, string? parentQualified)
+    {
+        var simple = cls.Identifier.Text;
+        var qualified = parentQualified is null ? simple : $"{parentQualified}.{simple}";
+        _messages[qualified] = new Message { QualifiedName = qualified, SimpleName = simple, ParentQualifiedName = parentQualified };
+        Register(simple, qualified);
+
+        foreach (var inner in cls.Members)
+        {
+            Discover(inner, qualified);
+        }
+    }
+
+    /// <summary>Registers an enum type and its (implicit or explicit) member values.</summary>
+    /// <param name="en">The enum declaration to register.</param>
+    /// <param name="parentQualified">Qualified name of the enclosing type, or null at file scope.</param>
+    private void DiscoverEnum(EnumDeclarationSyntax en, string? parentQualified)
+    {
+        var simple = en.Identifier.Text;
+        var qualified = parentQualified is null ? simple : $"{parentQualified}.{simple}";
+        var def = new EnumDef { QualifiedName = qualified, SimpleName = simple, ParentQualifiedName = parentQualified };
+        var next = 0;
+        foreach (var m in en.Members)
+        {
+            var val = next;
+            if (m.EqualsValue?.Value is { } v && TryParseInt(v, out var explicitVal))
+            {
+                val = explicitVal;
+            }
+
+            def.Values.Add((m.Identifier.Text, val));
+            next = val + 1;
+        }
+        _enums[qualified] = def;
+        Register(simple, qualified);
     }
 
     /// <summary>Second pass: extract fields for one message type (resolves types using the full registry).</summary>
@@ -119,22 +130,7 @@ internal sealed class ServerParser
             return;
         }
 
-        // Declared field types: name -> (csType, repeated, elementType)
-        var decls = new Dictionary<string, (string CsType, bool Repeated, string Element)>(StringComparer.Ordinal);
-        foreach (var fd in cls.Members.OfType<FieldDeclarationSyntax>())
-        {
-            if (fd.Modifiers.Any(SyntaxKind.StaticKeyword) || fd.Modifiers.Any(SyntaxKind.ConstKeyword))
-            {
-                continue;
-            }
-
-            var typeStr = fd.Declaration.Type.ToString();
-            var (repeated, element) = UnwrapList(typeStr);
-            foreach (var v in fd.Declaration.Variables)
-            {
-                decls[v.Identifier.Text] = (typeStr, repeated, element);
-            }
-        }
+        var decls = CollectFieldDeclarations(cls);
 
         var deser = cls.Members.OfType<MethodDeclarationSyntax>().FirstOrDefault(m =>
             m.Identifier.Text == "Deserialize" &&
@@ -152,40 +148,83 @@ internal sealed class ServerParser
             var fieldNumberMode = IsKeyFieldSwitch(sw);
             foreach (var section in sw.Sections)
             {
-                var fieldName = FindFieldName(section);
-                if (fieldName is null || !decls.TryGetValue(fieldName, out var d))
-                {
-                    continue;
-                }
-
-                var readMethod = FindReadMethod(section);
-
-                foreach (var label in section.Labels.OfType<CaseSwitchLabelSyntax>())
-                {
-                    if (!TryParseInt(label.Value, out var raw) || raw <= 0)
-                    {
-                        continue;
-                    }
-
-                    var number = fieldNumberMode ? raw : raw >> 3;
-                    if (number <= 0 || !seen.Add(number))
-                    {
-                        continue;
-                    }
-
-                    var protoType = ResolveProtoType(d.Repeated ? d.Element : d.CsType, readMethod, qualified);
-                    msg.Fields.Add(new Field
-                    {
-                        Name = fieldName,
-                        Number = number,
-                        ProtoType = protoType,
-                        Repeated = d.Repeated,
-                    });
-                }
+                AddFieldsFromSection(section, decls, fieldNumberMode, qualified, msg, seen);
             }
         }
 
         msg.Fields.Sort((a, b) => a.Number.CompareTo(b.Number));
+    }
+
+    /// <summary>Collects the non-static, non-const field declarations of a message as
+    /// name -> (csType, repeated, elementType).</summary>
+    /// <param name="cls">The type declaration to scan.</param>
+    private static Dictionary<string, (string CsType, bool Repeated, string Element)> CollectFieldDeclarations(TypeDeclarationSyntax cls)
+    {
+        var decls = new Dictionary<string, (string CsType, bool Repeated, string Element)>(StringComparer.Ordinal);
+        foreach (var fd in cls.Members.OfType<FieldDeclarationSyntax>())
+        {
+            if (fd.Modifiers.Any(SyntaxKind.StaticKeyword) || fd.Modifiers.Any(SyntaxKind.ConstKeyword))
+            {
+                continue;
+            }
+
+            var typeStr = fd.Declaration.Type.ToString();
+            var (repeated, element) = UnwrapList(typeStr);
+            foreach (var v in fd.Declaration.Variables)
+            {
+                decls[v.Identifier.Text] = (typeStr, repeated, element);
+            }
+        }
+
+        return decls;
+    }
+
+    /// <summary>Recovers every field assigned in one <c>Deserialize</c> switch section and appends it to
+    /// <paramref name="msg"/>, skipping field numbers already <paramref name="seen"/>.</summary>
+    /// <param name="section">The switch section to analyze.</param>
+    /// <param name="decls">Declared field types for the enclosing message.</param>
+    /// <param name="fieldNumberMode">True when case labels are field numbers rather than wire keys.</param>
+    /// <param name="qualified">Qualified name of the message being filled (resolution scope).</param>
+    /// <param name="msg">The message to append recovered fields to.</param>
+    /// <param name="seen">Field numbers already recorded for this message.</param>
+    private void AddFieldsFromSection(
+        SwitchSectionSyntax section,
+        Dictionary<string, (string CsType, bool Repeated, string Element)> decls,
+        bool fieldNumberMode,
+        string qualified,
+        Message msg,
+        HashSet<int> seen)
+    {
+        var fieldName = FindFieldName(section);
+        if (fieldName is null || !decls.TryGetValue(fieldName, out var d))
+        {
+            return;
+        }
+
+        var readMethod = FindReadMethod(section);
+
+        foreach (var label in section.Labels.OfType<CaseSwitchLabelSyntax>())
+        {
+            if (!TryParseInt(label.Value, out var raw) || raw <= 0)
+            {
+                continue;
+            }
+
+            var number = fieldNumberMode ? raw : raw >> 3;
+            if (number <= 0 || !seen.Add(number))
+            {
+                continue;
+            }
+
+            var protoType = ResolveProtoType(d.Repeated ? d.Element : d.CsType, readMethod, qualified);
+            msg.Fields.Add(new Field
+            {
+                Name = fieldName,
+                Number = number,
+                ProtoType = protoType,
+                Repeated = d.Repeated,
+            });
+        }
     }
 
     // ---- helpers ----


### PR DESCRIPTION
## Summary

Clears the open SonarQube code smells and adds a small coverage win, keeping the analysis clean.

### Code smells resolved
- **`RustPlusSocket`** — `PlayerId` is now an auto-property (`IDE0032`); `ReceiveAsync` split into `ReceiveMessageAsync` (fragment accumulation + deserialize) and `DispatchMessage` (event raising + request correlation) to bring cognitive complexity under the threshold (`S3776`). Behaviour and comments preserved.
- **`ProtoGen/ServerParser`** — `Discover` split into `DiscoverMessage`/`DiscoverEnum`; `FillFields` split into `CollectFieldDeclarations`/`AddFieldsFromSection` (`S3776`).
- **`ProtoGen/CommittedProto`** — `Parse` refactored around a `ParseState` holder with per-line handlers (`S3776`).

### Coverage
- Added `PairingListener_ConstructAndDispose_DoesNotThrow`, covering the constructor, the wrapped `RustPlusFcm` field init, and `Dispose()` (idempotency asserted).

This PR also folds in pre-existing uncommitted working-tree edits (README, samples, extensions, `.markdownlint.json`, and assorted tests).

## Verification
- Full solution builds clean (0 warnings) across all target frameworks.
- Existing suites pass: 77 unit + 57 integration tests, plus the Registration tests (3 PairingListener tests green). The tool refactors are pure extract-method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)