### PR TITLE
feat!: ILogger logging + RustPlusConnection constructor

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
     <!-- netstandard2.0 polyfill: provides IAsyncDisposable + ValueTask (in-box on net10.0). -->
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="protobuf-net" Version="3.2.56" />
     <PackageVersion Include="protobuf-net.BuildTools" Version="3.2.52" />

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See [`samples/`](samples/README.md) for the full walkthrough. (You can still use
 **2. Talk to the server:**
 
 ```csharp
-using var rustPlus = new RustPlus(server, port, playerId, playerToken);
+using var rustPlus = new RustPlus(new RustPlusConnection(server, port, playerId, playerToken));
 await rustPlus.ConnectAsync();
 
 var info = await rustPlus.GetInfoAsync();

--- a/docs/articles/credentials.md
+++ b/docs/articles/credentials.md
@@ -56,7 +56,7 @@ CredentialsStore.Save("rustplus.config.json", credentials);
 // Step 8: pair in game; one await yields the RustPlus constructor args.
 using var listener = new PairingListener(credentials);
 ServerPairing pairing = await listener.WaitForServerPairingAsync();
-// new RustPlus(pairing.Ip, pairing.Port, pairing.PlayerId, pairing.PlayerToken)
+// new RustPlus(new RustPlusConnection(pairing.Ip, pairing.Port, pairing.PlayerId, pairing.PlayerToken))
 ```
 
 | Step | Component | Result |

--- a/docs/articles/fcm-notifications.md
+++ b/docs/articles/fcm-notifications.md
@@ -141,7 +141,7 @@ For the common "wait for the next server pairing" case, `RustPlusApi.Fcm.Registr
 ```csharp
 using var pairing = new PairingListener(credentials);
 ServerPairing server = await pairing.WaitForServerPairingAsync();
-using var rustPlus = new RustPlus(server.Ip, server.Port, server.PlayerId, server.PlayerToken);
+using var rustPlus = new RustPlus(new RustPlusConnection(server.Ip, server.Port, server.PlayerId, server.PlayerToken));
 ```
 
 See [Credentials](credentials.md) for how to obtain the FCM credentials.

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -50,7 +50,7 @@ All four arrive together in the server-pairing push notification.
 ```csharp
 using RustPlusApi;
 
-using var rustPlus = new RustPlus(server, port, playerId, playerToken);
+using var rustPlus = new RustPlus(new RustPlusConnection(server, port, playerId, playerToken));
 await rustPlus.ConnectAsync();
 
 var info = await rustPlus.GetInfoAsync();

--- a/docs/articles/logging.md
+++ b/docs/articles/logging.md
@@ -1,0 +1,17 @@
+# Logging
+
+Both clients are silent by default. Supply an `ILoggerFactory` through the options object to receive
+structured diagnostics (connect/receive/teardown lifecycle, dropped frames, unknown messages, errors):
+
+```csharp
+using Microsoft.Extensions.Logging;
+
+using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+
+using var rustPlus = new RustPlus(
+    new RustPlusConnection("127.0.0.1", 28082, playerId, playerToken),
+    new RustPlusSocketOptions { LoggerFactory = loggerFactory });
+```
+
+The FCM client accepts the same `LoggerFactory` on `RustPlusFcmSocketOptions`. When no factory is
+supplied, logging is a no-op (`NullLogger`) with zero overhead.

--- a/docs/articles/recipes.md
+++ b/docs/articles/recipes.md
@@ -30,7 +30,7 @@ listener.OnAlarmTriggered += async (_, alarm) =>
 {
     Console.WriteLine($"Alarm fired: {alarm?.Title} — turning on siren switch");
 
-    using var rustPlus = new RustPlus(ServerIp, ServerPort, PlayerId, PlayerToken);
+    using var rustPlus = new RustPlus(new RustPlusConnection(ServerIp, ServerPort, PlayerId, PlayerToken));
     await rustPlus.ConnectAsync();
 
     var result = await rustPlus.SetSmartSwitchValueAsync(SirenSwitchId, true);
@@ -60,7 +60,7 @@ const int    ServerPort = 28082;
 const ulong  PlayerId   = 76561198000000000UL;
 const int    PlayerToken = -123456789;
 
-using var rustPlus = new RustPlus(ServerIp, ServerPort, PlayerId, PlayerToken);
+using var rustPlus = new RustPlus(new RustPlusConnection(ServerIp, ServerPort, PlayerId, PlayerToken));
 await rustPlus.ConnectAsync();
 
 var response = await rustPlus.GetMapAsync();
@@ -101,7 +101,7 @@ const int    ServerPort  = 28082;
 const ulong  PlayerId    = 76561198000000000UL;  // your SteamID64 — used as the echo guard
 const int    PlayerToken = -123456789;
 
-using var rustPlus = new RustPlus(ServerIp, ServerPort, PlayerId, PlayerToken);
+using var rustPlus = new RustPlus(new RustPlusConnection(ServerIp, ServerPort, PlayerId, PlayerToken));
 
 rustPlus.OnTeamChatReceived += async (_, msg) =>
 {
@@ -144,7 +144,7 @@ const int    PlayerToken = -123456789;
 const string CameraId    = "CAM01";   // in-game identifier set on the computer station
 const int    FrameTarget = 10;        // accumulate 10 frames before saving
 
-using var rustPlus = new RustPlus(ServerIp, ServerPort, PlayerId, PlayerToken);
+using var rustPlus = new RustPlus(new RustPlusConnection(ServerIp, ServerPort, PlayerId, PlayerToken));
 await rustPlus.ConnectAsync();
 
 var sub = await rustPlus.SubscribeToCameraAsync(CameraId);
@@ -213,7 +213,7 @@ var pairing = await pairingListener.WaitForServerPairingAsync();
 Console.WriteLine($"Paired: {pairing.Ip}:{pairing.Port} (player {pairing.PlayerId})");
 
 // ── use the pairing values immediately ───────────────────────────────────────
-using var rustPlus = new RustPlus(pairing.Ip, pairing.Port, pairing.PlayerId, pairing.PlayerToken);
+using var rustPlus = new RustPlus(new RustPlusConnection(pairing.Ip, pairing.Port, pairing.PlayerId, pairing.PlayerToken));
 await rustPlus.ConnectAsync();
 
 var info = await rustPlus.GetInfoAsync();

--- a/docs/articles/rustplus-client.md
+++ b/docs/articles/rustplus-client.md
@@ -10,13 +10,18 @@ using var rustPlus = new RustPlus(new RustPlusConnection(server, port, playerId,
 await rustPlus.ConnectAsync();
 ```
 
-| Parameter | Meaning |
+`RustPlusConnection` is a record grouping the connection identity:
+
+| Property | Meaning |
 | --- | --- |
-| `server` | The server's IP address. |
-| `port` | The Rust+ companion port (not the in-game connect port). |
-| `playerId` | Your Steam ID. |
-| `playerToken` | The player token from pairing. |
-| `useFacepunchProxy` | Route through the Facepunch proxy instead of connecting directly. |
+| `Server` | The server's IP address. |
+| `Port` | The Rust+ companion port (not the in-game connect port). |
+| `PlayerId` | Your Steam ID. |
+| `PlayerToken` | The player token from pairing. |
+| `UseFacepunchProxy` | Route through the Facepunch proxy instead of connecting directly. |
+
+> `RustPlusConnection.ToString()` redacts `PlayerToken` (it prints as `***`) so the credential is not
+> accidentally leaked through logs or exceptions.
 
 ## Connection lifecycle
 

--- a/docs/articles/rustplus-client.md
+++ b/docs/articles/rustplus-client.md
@@ -6,7 +6,7 @@ typed, task-based API.
 ## Construct and connect
 
 ```csharp
-using var rustPlus = new RustPlus(server, port, playerId, playerToken, useFacepunchProxy: false);
+using var rustPlus = new RustPlus(new RustPlusConnection(server, port, playerId, playerToken, UseFacepunchProxy: false));
 await rustPlus.ConnectAsync();
 ```
 

--- a/docs/articles/samples.md
+++ b/docs/articles/samples.md
@@ -31,7 +31,7 @@ dotnet run --project samples/RustPlus.Register.ConsoleApp
   [discovery](credentials.md#browser-discovery-order)). Firefox/Safari won't work.
 - After the Steam login, open Rust → join your server → **Pair with Server**.
 - It prints the absolute path of the saved `rustplus.config.json` and the
-  `new RustPlus(ip, port, playerId, playerToken)` line to use with the other samples.
+  `new RustPlus(new RustPlusConnection(ip, port, playerId, playerToken))` line to use with the other samples.
 
 ## RustPlus.Fcm.ConsoleApp — listen for notifications
 

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -16,6 +16,8 @@
       href: cameras.md
     - name: FCM Notifications
       href: fcm-notifications.md
+    - name: Logging
+      href: logging.md
 - name: Resources
   items:
     - name: Samples

--- a/docs/articles/troubleshooting.md
+++ b/docs/articles/troubleshooting.md
@@ -19,7 +19,7 @@ the server-pairing push notification (`ServerPairing.Port`).
    pass `useFacepunchProxy: true` to route traffic through Facepunch's relay:
 
 ```csharp
-using var rustPlus = new RustPlus(server, port, playerId, playerToken, useFacepunchProxy: true);
+using var rustPlus = new RustPlus(new RustPlusConnection(server, port, playerId, playerToken, UseFacepunchProxy: true));
 ```
 
 See [Getting Started](getting-started.md) for the full connection example and [Credentials](credentials.md)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -141,6 +141,10 @@ Reports are written to `StrykerOutput/` (git-ignored). Thresholds (in `stryker-c
 break at 75%, low at 80%, high at 90%. The `.github/workflows/Mutation.yml` workflow runs the
 matrix weekly and on manual dispatch.
 
+Logging calls are excluded from mutation via `ignore-methods` (`Log*`, `CreateLogger`): the
+`[LoggerMessage]`-generated methods are non-functional diagnostics, so mutating their arguments
+would only produce equivalent or low-value mutants.
+
 ### Known limitation: the core `RustPlusApi.csproj` cannot be mutated
 
 `RustPlusApi.csproj` crashes Stryker 4.x (`CompilationException` in the rollback compiler) because
@@ -156,7 +160,7 @@ mutation score cannot be measured.
 | --- | --- | --- |
 | `RustPlusApi.Camera` | ~97.7% | Remaining survivors are equivalent (signed vs unsigned `>>` on `byte` values). |
 | `RustPlusApi.Fcm.Registration` | ~84.6% | Remaining: `ConfigureAwait`/`Task.Delay` (equivalent in tests) + `[ExcludeFromCodeCoverage]` Steam surface. |
-| `RustPlusApi.Fcm` | ~78.5% | Remaining: `Debug.WriteLine` log-string mutants, live-socket cleanup, and equivalent shift/xor mutants in `McsUtils`. |
+| `RustPlusApi.Fcm` | ~78.5% | Remaining: live-socket cleanup and equivalent shift/xor mutants in `McsUtils`; `Log*`/`CreateLogger` calls are suppressed via `ignore-methods`. |
 | `RustPlusApi` (core) | n/a | Cannot run — see limitation above. |
 
 ---
@@ -227,6 +231,19 @@ path)
 serialization behavior is already locked by `ProtobufRoundTripTests`, `McsRoundTripTests`, and
 `RegistrationTests`. The auto-generated `ShouldSerialize*` / `Reset*` / unused-field members
 accessed only by the protobuf-net runtime are not worth bespoke unit tests.
+
+### `[LoggerMessage]` generated log methods and `RustPlusConnection` record members
+
+**Files:** `src/RustPlusApi/RustPlusSocketLog.cs`, `src/RustPlusApi.Fcm/RustPlusFcmSocketLog.cs`,
+`src/RustPlusApi/RustPlusConnection.cs`
+
+**Justification:** The `[LoggerMessage]` source generator emits the partial log-method bodies with
+`[GeneratedCode]`, and the C# compiler emits the record's `Equals`/`GetHashCode`/`ToString`/
+`Deconstruct`/copy-constructor/equality members with `[CompilerGenerated]`. Both are already dropped
+by the `ExcludeByAttribute` rule (`GeneratedCodeAttribute`, `CompilerGeneratedAttribute`) in the
+`coverlet.runsettings` files, with positional property accessors handled by `SkipAutoProps`. No
+bespoke tests are required for these members; logging behaviour is exercised through the call sites
+in `RustPlusLoggingTests` / `FcmLoggingTests`.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ _disableBreadcrumb: true
 ```csharp
 using RustPlusApi;
 
-using var rustPlus = new RustPlus(server, port, playerId, playerToken);
+using var rustPlus = new RustPlus(new RustPlusConnection(server, port, playerId, playerToken));
 await rustPlus.ConnectAsync();
 
 var info = await rustPlus.GetInfoAsync();

--- a/samples/README.md
+++ b/samples/README.md
@@ -29,7 +29,7 @@ dotnet run --project samples/RustPlus.Register.ConsoleApp
   Firefox/Safari won't work — the Steam step drives Chrome via the DevTools protocol.
 - After Steam login, open Rust → join a server → **Pair with Server**.
 - It prints the absolute path of the saved `rustplus.config.json` and the
-  `new RustPlus(ip, port, playerId, playerToken)` line to use with the other samples.
+  `new RustPlus(new RustPlusConnection(ip, port, playerId, playerToken))` line to use with the other samples.
 
 ## 2. RustPlus.Fcm.ConsoleApp — listen for FCM notifications
 

--- a/samples/RustPlus.ConsoleApp/Program.cs
+++ b/samples/RustPlus.ConsoleApp/Program.cs
@@ -25,7 +25,7 @@ catch (Exception ex)
     return;
 }
 
-using var rustPlus = new RustPlusApi.RustPlus(credentials.Ip, credentials.Port, credentials.PlayerId, credentials.PlayerToken);
+using var rustPlus = new RustPlusApi.RustPlus(new RustPlusApi.RustPlusConnection(credentials.Ip, credentials.Port, credentials.PlayerId, credentials.PlayerToken));
 
 try
 {

--- a/samples/RustPlus.Register.ConsoleApp/Program.cs
+++ b/samples/RustPlus.Register.ConsoleApp/Program.cs
@@ -27,5 +27,5 @@ var pairing = await listener.WaitForServerPairingAsync();
 
 Console.WriteLine();
 Console.WriteLine("Paired! Use these arguments:");
-Console.WriteLine($"  new RustPlus(\"{pairing.Ip}\", {pairing.Port}, {pairing.PlayerId}, {pairing.PlayerToken});");
+Console.WriteLine($"  new RustPlus(new RustPlusConnection(\"{pairing.Ip}\", {pairing.Port}, {pairing.PlayerId}, {pairing.PlayerToken}));");
 Console.WriteLine($"  (server: {pairing.Name})");

--- a/src/RustPlusApi.Fcm.Registration/README.md
+++ b/src/RustPlusApi.Fcm.Registration/README.md
@@ -27,7 +27,7 @@ CredentialsStore.Save("rustplus.config.json", credentials);
 
 using var listener = new PairingListener(credentials);
 ServerPairing pairing = await listener.WaitForServerPairingAsync(); // pair in game
-var rustPlus = new RustPlus(pairing.Ip, pairing.Port, pairing.PlayerId, pairing.PlayerToken);
+var rustPlus = new RustPlus(new RustPlusConnection(pairing.Ip, pairing.Port, pairing.PlayerId, pairing.PlayerToken));
 ```
 
 ## Requirements & caveats

--- a/src/RustPlusApi.Fcm.Registration/ServerPairing.cs
+++ b/src/RustPlusApi.Fcm.Registration/ServerPairing.cs
@@ -2,7 +2,7 @@ namespace RustPlusApi.Fcm.Registration;
 
 /// <summary>
 /// The strongly-typed result of an in-game "Pair with Server" notification — exactly the four
-/// arguments needed for <c>new RustPlus(server, port, playerId, playerToken)</c>.
+/// arguments needed for <c>new RustPlus(new RustPlusConnection(server, port, playerId, playerToken))</c>.
 /// </summary>
 public sealed record ServerPairing
 {

--- a/src/RustPlusApi.Fcm/README.md
+++ b/src/RustPlusApi.Fcm/README.md
@@ -28,6 +28,18 @@ await listener.ConnectAsync();
 listener.Disconnect();
 ```
 
+## Logging
+
+```csharp
+using Microsoft.Extensions.Logging;
+
+using var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+
+var fcm = new RustPlusFcm(
+    credentials,
+    options: new RustPlusFcmSocketOptions { LoggerFactory = loggerFactory });
+```
+
 ## Credentials
 
 Get `credentials` natively with the

--- a/src/RustPlusApi.Fcm/RustPlusApi.Fcm.csproj
+++ b/src/RustPlusApi.Fcm/RustPlusApi.Fcm.csproj
@@ -22,6 +22,7 @@
 
     <ItemGroup>
         <PackageReference Include="protobuf-net" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     </ItemGroup>
 
     <!-- netstandard2.0 BCL gap: System.Text.Json (in-box on net10), plus IAsyncDisposable/ValueTask. -->

--- a/src/RustPlusApi.Fcm/RustPlusFcm.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcm.cs
@@ -2,7 +2,6 @@ using RustPlusApi.Fcm.Data;
 using RustPlusApi.Fcm.Data.Events;
 using RustPlusApi.Fcm.Extensions;
 using RustPlusApi.Fcm.Interfaces;
-using System.Diagnostics;
 using static RustPlusApi.Fcm.Utils.ResponseHelper;
 
 namespace RustPlusApi.Fcm;
@@ -89,7 +88,7 @@ public class RustPlusFcm(Credentials credentials, ICollection<string>? persisten
                 OnAlarmTriggered?.Invoke(this, message.Data.ToAlarmEvent());
                 break;
             default:
-                Debug.WriteLine($"Unknown channel: {message.Data.ChannelId}");
+                Logger.LogUnknownChannel(message.Data.ChannelId);
                 break;
         }
     }
@@ -115,7 +114,7 @@ public class RustPlusFcm(Credentials credentials, ICollection<string>? persisten
                 OnServerPairing?.Invoke(this, server);
                 break;
             default:
-                Debug.WriteLine($"Unknown pairing type: {body.Type}");
+                Logger.LogUnknownPairingType(body.Type);
                 break;
         }
     }
@@ -143,7 +142,7 @@ public class RustPlusFcm(Credentials credentials, ICollection<string>? persisten
                 OnStorageMonitorPairing?.Invoke(this, response);
                 break;
             default:
-                Debug.WriteLine($"Unknown entity type: {body.EntityType}");
+                Logger.LogUnknownEntityType(body.EntityType);
                 break;
         }
     }

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -1,9 +1,10 @@
 using McsProto;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using ProtoBuf;
 using RustPlusApi.Fcm.Data;
 using RustPlusApi.Fcm.Data.Events;
 using RustPlusApi.Fcm.Interfaces;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net.Security;
@@ -36,6 +37,11 @@ public abstract class RustPlusFcmSocket(Credentials credentials, ICollection<str
 
     /// <summary>Tuning values for this instance; options are init-only so the snapshot is stable.</summary>
     private readonly RustPlusFcmSocketOptions _options = options ?? new RustPlusFcmSocketOptions();
+
+    /// <summary>The client's logger; <c>NullLogger</c> when no factory was supplied.
+    /// Exposed to derived classes (e.g. <see cref="RustPlusFcm"/>).</summary>
+    private protected ILogger Logger { get; } =
+        (options?.LoggerFactory ?? NullLoggerFactory.Instance).CreateLogger("RustPlusApi.Fcm.RustPlusFcmSocket");
 
     private TcpClient? _tcpClient;
     private SslStream? _sslStream;
@@ -189,7 +195,7 @@ public abstract class RustPlusFcmSocket(Credentials credentials, ICollection<str
             _tcpClient = null;
             _transport = null;
 
-            Debug.WriteLine($"Exception occured on ConnectAsync: {ex}");
+            Logger.LogConnectFailed(ex);
             ErrorOccurred?.Invoke(this, ex);
             throw;
         }
@@ -318,7 +324,7 @@ public abstract class RustPlusFcmSocket(Credentials credentials, ICollection<str
         catch (Exception ex)
         {
             // A loop faulted because the transport was disposed mid-read/write: expected during teardown.
-            Debug.WriteLine($"Background loop faulted during teardown (expected): {ex}");
+            Logger.LogTeardownLoopFaulted(ex);
         }
     }
 
@@ -591,9 +597,7 @@ public abstract class RustPlusFcmSocket(Credentials credentials, ICollection<str
             return;
         }
 
-        Debug.WriteLine($"Responding to ping: Stream ID: {ping.StreamId}," +
-                        $"Last: {ping.LastStreamIdReceived}," +
-                        $"Status: {ping.Status}");
+        Logger.LogRespondingToPing(ping.StreamId, ping.LastStreamIdReceived, ping.Status);
         var pingResponse = new HeartbeatAck
         {
             StreamId = (ping.StreamId ?? 0) + 1,
@@ -630,7 +634,7 @@ public abstract class RustPlusFcmSocket(Credentials credentials, ICollection<str
             case McsProtoTag.KIqStanzaTag:
                 break;  // To investigate further, if needed
             default:
-                Debug.WriteLine($"Ignoring unrecognized tag: {e.Tag}");
+                Logger.LogUnrecognizedTag(e.Tag);
                 break;
         }
     }
@@ -651,7 +655,7 @@ public abstract class RustPlusFcmSocket(Credentials credentials, ICollection<str
 
         if (dataMessage?.AppDatas is not { Count: > 0 })
         {
-            Debug.WriteLine("⚠️ No AppData found in message");
+            Logger.LogNoAppData();
             return;
         }
 
@@ -660,7 +664,7 @@ public abstract class RustPlusFcmSocket(Credentials credentials, ICollection<str
         if (!appDataDict.TryGetValue("channelId", out var channelId) ||
             !appDataDict.TryGetValue("body", out var body))
         {
-            Debug.WriteLine("⚠️ Not a Rust+ notification - missing channelId or body");
+            Logger.LogNotRustNotification();
             return;
         }
 

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -40,7 +40,7 @@ public abstract class RustPlusFcmSocket(Credentials credentials, ICollection<str
 
     /// <summary>The client's logger; <c>NullLogger</c> when no factory was supplied.
     /// Exposed to derived classes (e.g. <see cref="RustPlusFcm"/>).</summary>
-    private protected ILogger Logger { get; } =
+    private protected readonly ILogger Logger =
         (options?.LoggerFactory ?? NullLoggerFactory.Instance).CreateLogger("RustPlusApi.Fcm.RustPlusFcmSocket");
 
     private TcpClient? _tcpClient;

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocketLog.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocketLog.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Logging;
+using static RustPlusApi.Fcm.Data.Tags;
+
+namespace RustPlusApi.Fcm;
+
+/// <summary>Source-generated, structured log messages for <see cref="RustPlusFcmSocket"/> and
+/// <see cref="RustPlusFcm"/>. Generated bodies carry <c>[GeneratedCode]</c> and are excluded from
+/// the coverage gate automatically.</summary>
+internal static partial class RustPlusFcmSocketLog
+{
+    [LoggerMessage(Level = LogLevel.Error, Message = "Exception occurred on ConnectAsync.")]
+    public static partial void LogConnectFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Background loop faulted during teardown (expected).")]
+    public static partial void LogTeardownLoopFaulted(this ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Trace, Message = "Responding to ping: StreamId={StreamId}, Last={Last}, Status={Status}")]
+    public static partial void LogRespondingToPing(this ILogger logger, int? streamId, int? last, long? status);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Ignoring unrecognized tag: {Tag}")]
+    public static partial void LogUnrecognizedTag(this ILogger logger, McsProtoTag tag);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "No AppData found in message.")]
+    public static partial void LogNoAppData(this ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Not a Rust+ notification - missing channelId or body.")]
+    public static partial void LogNotRustNotification(this ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Unknown channel: {ChannelId}")]
+    public static partial void LogUnknownChannel(this ILogger logger, string channelId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Unknown pairing type: {Type}")]
+    public static partial void LogUnknownPairingType(this ILogger logger, string type);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Unknown entity type: {EntityType}")]
+    public static partial void LogUnknownEntityType(this ILogger logger, int? entityType);
+}

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocketOptions.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocketOptions.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace RustPlusApi.Fcm;
 
 /// <summary>
@@ -18,4 +20,9 @@ public sealed class RustPlusFcmSocketOptions
     /// <see cref="HeartbeatInterval"/> so a single delayed ack doesn't kill a healthy connection.
     /// Default: 12 minutes.</summary>
     public TimeSpan InactivityTimeout { get; init; } = TimeSpan.FromMinutes(12);
+
+    /// <summary>Factory used to create the client's logger. When <see langword="null"/>, logging is
+    /// disabled (a no-op <c>NullLogger</c> is used). Supply one to route diagnostics into your
+    /// logging stack.</summary>
+    public ILoggerFactory? LoggerFactory { get; init; }
 }

--- a/src/RustPlusApi/README.md
+++ b/src/RustPlusApi/README.md
@@ -19,7 +19,7 @@ dotnet add package RustPlusApi
 ```csharp
 using RustPlusApi;
 
-using var rustPlus = new RustPlus(server, port, playerId, playerToken);
+using var rustPlus = new RustPlus(new RustPlusConnection(server, port, playerId, playerToken));
 await rustPlus.ConnectAsync();
 
 var info = await rustPlus.GetInfoAsync();          // Response<ServerInfo?>
@@ -32,6 +32,20 @@ rustPlus.OnSmartSwitchTriggered += (_, e) => { /* react to a smart switch */ };
 Every request returns a `Response<T>` (`IsSuccess` / `Error` / `Data`). Need credentials? Use the
 [`RustPlusApi.Fcm.Registration`](https://www.nuget.org/packages/RustPlusApi.Fcm.Registration)
 package.
+
+## Logging
+
+Pass an `ILoggerFactory` via the options to route the client's diagnostics into your logging stack:
+
+```csharp
+using Microsoft.Extensions.Logging;
+
+using var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+
+using var rustPlus = new RustPlus(
+    new RustPlusConnection("127.0.0.1", 28082, 76561198000000000, 123456789),
+    new RustPlusSocketOptions { LoggerFactory = loggerFactory });
+```
 
 ## Documentation
 

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -7,7 +7,6 @@ using RustPlusApi.Extensions;
 using RustPlusApi.Interfaces;
 using RustPlusApi.Utils;
 using RustPlusContracts;
-using System.Diagnostics;
 using ClanInfo = RustPlusApi.Data.Clans.ClanInfo;
 // ReSharper disable MemberCanBePrivate.Global
 
@@ -99,7 +98,7 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
             OnCameraRaysReceived?.Invoke(this, broadcast.CameraRays.ToCameraRaysEvent());
             return;
         }
-        Debug.WriteLine($"Unknown broadcast:\n{broadcast}");
+        Logger.LogUnknownBroadcast(broadcast);
     }
 
     /// <summary>

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -17,15 +17,11 @@ namespace RustPlusApi;
 /// Initializes a new instance of the <see cref="RustPlus"/> class,
 /// connecting to a Rust+ server using the specified parameters.
 /// </summary>
-/// <param name="server">The IP address of the Rust+ server.</param>
-/// <param name="port">The port dedicated for the Rust+ companion app (not the one used to connect in-game).</param>
-/// <param name="playerId">Your Steam ID.</param>
-/// <param name="playerToken">Your player token acquired with FCM.</param>
-/// <param name="useFacepunchProxy">Specifies whether to use the Facepunch proxy.</param>
+/// <param name="connection">The server endpoint and player credentials to connect as.</param>
 /// <param name="options">Tuning options (timeouts, keep-alive, buffer size); defaults are used when <see langword="null"/>.</param>
 /// <seealso cref="RustPlusSocket"/>
-public class RustPlus(string server, int port, ulong playerId, int playerToken, bool useFacepunchProxy = false, RustPlusSocketOptions? options = null)
-    : RustPlusSocket(server, port, playerId, playerToken, useFacepunchProxy, options), IRustPlus
+public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? options = null)
+    : RustPlusSocket(connection, options), IRustPlus
 {
     /// <summary>
     /// Occurs when a <see cref="SmartSwitchEventArg"/> is triggered by a smart switch or alarm.

--- a/src/RustPlusApi/RustPlusApi.csproj
+++ b/src/RustPlusApi/RustPlusApi.csproj
@@ -23,6 +23,7 @@
     <ItemGroup>
         <PackageReference Include="protobuf-net" />
         <PackageReference Include="protobuf-net.BuildTools" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     </ItemGroup>
 
     <!-- IAsyncDisposable / ValueTask + Channels are in-box on net10.0; netstandard2.0 needs the packages. -->

--- a/src/RustPlusApi/RustPlusConnection.cs
+++ b/src/RustPlusApi/RustPlusConnection.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using System.Text;
+
 namespace RustPlusApi;
 
 /// <summary>
@@ -15,4 +18,23 @@ public sealed record RustPlusConnection(
     int Port,
     ulong PlayerId,
     int PlayerToken,
-    bool UseFacepunchProxy = false);
+    bool UseFacepunchProxy = false)
+{
+    /// <summary>
+    /// Redacts <see cref="PlayerToken"/> (a credential) from the record's string form so it cannot leak
+    /// through logs, exceptions, or string interpolation. Equality is unaffected — the generated
+    /// <c>Equals</c>/<c>GetHashCode</c> still use every member, including the token.
+    /// </summary>
+    /// <param name="builder">The builder the record's <c>ToString</c> writes its members into.</param>
+    /// <returns><see langword="true"/> so the record renders its members between braces.</returns>
+    private bool PrintMembers(StringBuilder builder)
+    {
+        builder
+            .Append(nameof(Server)).Append(" = ").Append(Server)
+            .Append(", ").Append(nameof(Port)).Append(" = ").Append(Port.ToString(CultureInfo.InvariantCulture))
+            .Append(", ").Append(nameof(PlayerId)).Append(" = ").Append(PlayerId.ToString(CultureInfo.InvariantCulture))
+            .Append(", ").Append(nameof(PlayerToken)).Append(" = ***")
+            .Append(", ").Append(nameof(UseFacepunchProxy)).Append(" = ").Append(UseFacepunchProxy);
+        return true;
+    }
+}

--- a/src/RustPlusApi/RustPlusConnection.cs
+++ b/src/RustPlusApi/RustPlusConnection.cs
@@ -1,0 +1,18 @@
+namespace RustPlusApi;
+
+/// <summary>
+/// Connection identity for a <see cref="RustPlus"/> client: the server endpoint and the player
+/// credentials a request is issued as. Grouping these into one value keeps the
+/// <see cref="RustPlus"/> constructor readable at the call site.
+/// </summary>
+/// <param name="Server">The IP address of the Rust+ server.</param>
+/// <param name="Port">The port dedicated for the Rust+ companion app (not the one used to connect in-game).</param>
+/// <param name="PlayerId">Your Steam ID.</param>
+/// <param name="PlayerToken">Your player token acquired with FCM.</param>
+/// <param name="UseFacepunchProxy">Specifies whether to use the Facepunch proxy.</param>
+public sealed record RustPlusConnection(
+    string Server,
+    int Port,
+    ulong PlayerId,
+    int PlayerToken,
+    bool UseFacepunchProxy = false);

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -14,18 +14,10 @@ namespace RustPlusApi;
 /// <summary>
 /// A Rust+ API client made in C#.
 /// </summary>
-/// <param name="server">The IP address of the Rust+ server.</param>
-/// <param name="port">The port dedicated for the Rust+ companion app (not the one used to connect in-game).</param>
-/// <param name="playerId">Your Steam ID.</param>
-/// <param name="playerToken">Your player token acquired with FCM.</param>
-/// <param name="useFacepunchProxy">Specifies whether to use the Facepunch proxy.</param>
+/// <param name="connection">The server endpoint and player credentials to connect as.</param>
 /// <param name="options">Tuning options (timeouts, keep-alive, buffer size); defaults are used when <see langword="null"/>.</param>
 public abstract class RustPlusSocket(
-    string server,
-    int port,
-    ulong playerId,
-    int playerToken,
-    bool useFacepunchProxy = false,
+    RustPlusConnection connection,
     RustPlusSocketOptions? options = null)
     : IRustPlusSocket, IDisposable, IAsyncDisposable
 {
@@ -127,10 +119,10 @@ public abstract class RustPlusSocket(
     /// <summary>Test seam: the tracked send loop, so tests can assert it actually completed on teardown.</summary>
     internal Task? SendLoopForTests { get; private set; }
 
-    private int _playerToken = playerToken;
+    private int _playerToken = connection.PlayerToken;
 
     /// <summary>The Steam ID requests are currently issued as (see <see cref="SetPlayer"/>).</summary>
-    protected ulong PlayerId { get; private set; } = playerId;
+    protected ulong PlayerId { get; private set; } = connection.PlayerId;
 
     /// <summary>
     /// Asynchronously connects to the Rust+ server using a WebSocket.
@@ -173,9 +165,9 @@ public abstract class RustPlusSocket(
         var webSocket = new ClientWebSocket();
         webSocket.Options.KeepAliveInterval = _options.KeepAliveInterval;
 
-        var uri = useFacepunchProxy
-            ? new Uri($"wss://companion-rust.facepunch.com/game/{server}/{port}")
-            : new Uri($"ws://{server}:{port}");
+        var uri = connection.UseFacepunchProxy
+            ? new Uri($"wss://companion-rust.facepunch.com/game/{connection.Server}/{connection.Port}")
+            : new Uri($"ws://{connection.Server}:{connection.Port}");
 
         Connecting?.Invoke(this, EventArgs.Empty);
 

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -1,8 +1,9 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using ProtoBuf;
 using RustPlusApi.Interfaces;
 using RustPlusContracts;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Net.WebSockets;
 using System.Threading.Channels;
 using static System.GC;
@@ -23,6 +24,11 @@ public abstract class RustPlusSocket(
 {
     /// <summary>Tuning values for this instance; options are init-only so the snapshot is stable.</summary>
     private readonly RustPlusSocketOptions _options = options ?? new RustPlusSocketOptions();
+
+    /// <summary>The client logger; <c>NullLogger</c> when no factory was supplied. Exposed to derived
+    /// classes (e.g. <see cref="RustPlus"/>) so they log through the same categorised sink.</summary>
+    private protected readonly ILogger Logger =
+        (options?.LoggerFactory ?? NullLoggerFactory.Instance).CreateLogger("RustPlusApi.RustPlusSocket");
 
     /// <summary>Backoff applied after a non-fatal receive error so the loop cannot busy-spin on it.</summary>
     private static readonly TimeSpan ReceiveErrorBackoff = TimeSpan.FromMilliseconds(100);
@@ -182,7 +188,7 @@ public abstract class RustPlusSocket(
             // Surface the failure on the event *and* to the caller: awaiting ConnectAsync must never
             // "succeed" against a server that was never reached.
             webSocket.Dispose();
-            Debug.WriteLine($"Exception occured on ConnectAsync: {ex}");
+            Logger.LogConnectFailed(ex);
             ErrorOccurred?.Invoke(this, ex);
             throw;
         }
@@ -233,7 +239,7 @@ public abstract class RustPlusSocket(
         catch (Exception ex)
         {
             // The old loop faulting as its socket was torn down is expected; never block a reconnect on it.
-            Debug.WriteLine($"Previous receive loop faulted before reconnect (expected): {ex}");
+            Logger.LogPreviousReceiveLoopFaulted(ex);
         }
     }
 
@@ -458,7 +464,7 @@ public abstract class RustPlusSocket(
         {
             // A loop faulting as the transport is torn down is expected during teardown; never let it
             // escape disposal. The loops swallow their own cancellation, so this is a genuine I/O fault.
-            Debug.WriteLine($"Background loop faulted during teardown (expected): {ex}");
+            Logger.LogTeardownLoopFaulted(ex);
         }
     }
 
@@ -553,7 +559,7 @@ public abstract class RustPlusSocket(
         {
             // The socket broke under us (e.g. peer closed): surface it, stop draining, and fail the
             // in-flight requests now — none of them can ever be answered on this connection.
-            Debug.WriteLine($"Send loop stopped due to a WebSocketException: {ex}");
+            Logger.LogSendLoopFaulted(ex);
             ErrorOccurred?.Invoke(this, ex);
             FailPendingRequests(ex);
         }
@@ -576,11 +582,11 @@ public abstract class RustPlusSocket(
     {
         var buffer = new byte[_options.ReceiveBufferSize];
 
-        Debug.WriteLine("Receiving data from the Rust+ server...");
+        Logger.LogReceivingData();
 
         while (webSocket.State == WebSocketState.Open && !CancellationToken.IsCancellationRequested)
         {
-            Debug.WriteLine("Waiting for data...");
+            Logger.LogWaitingForData();
             try
             {
                 var message = await ReceiveMessageAsync(webSocket, buffer).ConfigureAwait(false);
@@ -596,14 +602,14 @@ public abstract class RustPlusSocket(
                 // A WebSocket error means the connection is broken; retrying would immediately throw again.
                 // Surface it and exit instead of busy-spinning on a dead socket. Fail the in-flight
                 // requests now rather than leaving each to hit its full request timeout.
-                Debug.WriteLine($"Disconnected from the Rust+ socket due to a WebSocketException: {ex}");
+                Logger.LogReceiveWebSocketFault(ex);
                 ErrorOccurred?.Invoke(this, ex);
                 FailPendingRequests(ex);
                 break;
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"Disconnected from the Rust+ socket due to an Exception: {ex}");
+                Logger.LogReceiveFault(ex);
                 ErrorOccurred?.Invoke(this, ex);
 
                 // Back off so a persistently failing receive cannot busy-spin the loop.
@@ -617,7 +623,7 @@ public abstract class RustPlusSocket(
                 }
             }
         }
-        Debug.WriteLine("Receive loop exited.");
+        Logger.LogReceiveLoopExited();
 
         // The loop also exits without an exception (server close frame, graceful disconnect). No
         // response can arrive any more, so fail whatever is still pending instead of letting each
@@ -663,19 +669,19 @@ public abstract class RustPlusSocket(
     /// <param name="message">The message just read off the socket.</param>
     private void DispatchMessage(AppMessage message)
     {
-        Debug.WriteLine($"Received message:\n{message}");
+        Logger.LogReceivedMessage(message);
         MessageReceived?.Invoke(this, message);
 
         if (message.Broadcast is not null)
         {
-            Debug.WriteLine($"Received notification:\n{message}");
+            Logger.LogReceivedNotification(message);
             NotificationReceived?.Invoke(this, message);
             // Entity type from message.Response.EntityInfo.Type is not yet used.
             ParseNotification(message.Broadcast);
         }
         else
         {
-            Debug.WriteLine($"Received response:\n{message}");
+            Logger.LogReceivedResponse(message);
             ResponseReceived?.Invoke(this, message);
         }
 
@@ -758,7 +764,7 @@ public abstract class RustPlusSocket(
     /// </summary>
     /// <param name="matches">The matcher supplied by the requester.</param>
     /// <param name="broadcast">The broadcast under consideration.</param>
-    private static bool SafeMatches(Func<AppBroadcast, bool> matches, AppBroadcast broadcast)
+    private bool SafeMatches(Func<AppBroadcast, bool> matches, AppBroadcast broadcast)
     {
         try
         {
@@ -766,7 +772,7 @@ public abstract class RustPlusSocket(
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Broadcast-reply matcher threw; treating as no match: {ex}");
+            Logger.LogMatcherThrew(ex);
             return false;
         }
     }

--- a/src/RustPlusApi/RustPlusSocketLog.cs
+++ b/src/RustPlusApi/RustPlusSocketLog.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging;
+
+namespace RustPlusApi;
+
+/// <summary>Source-generated, structured log messages for <see cref="RustPlusSocket"/> and
+/// <see cref="RustPlus"/>. Generated bodies carry <c>[GeneratedCode]</c> and are excluded from the
+/// coverage gate automatically.</summary>
+internal static partial class RustPlusSocketLog
+{
+    [LoggerMessage(Level = LogLevel.Information, Message = "Receiving data from the Rust+ server.")]
+    public static partial void LogReceivingData(this ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Trace, Message = "Waiting for data.")]
+    public static partial void LogWaitingForData(this ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Receive loop exited.")]
+    public static partial void LogReceiveLoopExited(this ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Trace, Message = "Received message: {Message}")]
+    public static partial void LogReceivedMessage(this ILogger logger, object message);
+
+    [LoggerMessage(Level = LogLevel.Trace, Message = "Received notification: {Message}")]
+    public static partial void LogReceivedNotification(this ILogger logger, object message);
+
+    [LoggerMessage(Level = LogLevel.Trace, Message = "Received response: {Message}")]
+    public static partial void LogReceivedResponse(this ILogger logger, object message);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Unknown broadcast received: {Broadcast}")]
+    public static partial void LogUnknownBroadcast(this ILogger logger, object broadcast);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Exception occurred on ConnectAsync.")]
+    public static partial void LogConnectFailed(this ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Previous receive loop faulted before reconnect (expected).")]
+    public static partial void LogPreviousReceiveLoopFaulted(this ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Background loop faulted during teardown (expected).")]
+    public static partial void LogTeardownLoopFaulted(this ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Send loop stopped due to a WebSocketException.")]
+    public static partial void LogSendLoopFaulted(this ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Disconnected from the Rust+ socket due to a WebSocketException.")]
+    public static partial void LogReceiveWebSocketFault(this ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Disconnected from the Rust+ socket due to an Exception.")]
+    public static partial void LogReceiveFault(this ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Broadcast-reply matcher threw; treating as no match.")]
+    public static partial void LogMatcherThrew(this ILogger logger, Exception exception);
+}

--- a/src/RustPlusApi/RustPlusSocketLog.cs
+++ b/src/RustPlusApi/RustPlusSocketLog.cs
@@ -43,7 +43,7 @@ internal static partial class RustPlusSocketLog
     [LoggerMessage(Level = LogLevel.Error, Message = "Disconnected from the Rust+ socket due to a WebSocketException.")]
     public static partial void LogReceiveWebSocketFault(this ILogger logger, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Disconnected from the Rust+ socket due to an Exception.")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Receive loop encountered a non-fatal exception; backing off before retrying.")]
     public static partial void LogReceiveFault(this ILogger logger, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Broadcast-reply matcher threw; treating as no match.")]

--- a/src/RustPlusApi/RustPlusSocketOptions.cs
+++ b/src/RustPlusApi/RustPlusSocketOptions.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace RustPlusApi;
 
 /// <summary>
@@ -22,4 +24,9 @@ public sealed class RustPlusSocketOptions
     /// <summary>The receive buffer size in bytes. Map images arrive as multi-megabyte messages, so
     /// a larger buffer means far fewer reads per message. Default: 64 KB.</summary>
     public int ReceiveBufferSize { get; init; } = 64 * 1024;
+
+    /// <summary>Factory used to create the client's logger. When <see langword="null"/>, logging is
+    /// disabled (a no-op <c>NullLogger</c> is used). Supply one to route diagnostics into your
+    /// logging stack.</summary>
+    public ILoggerFactory? LoggerFactory { get; init; }
 }

--- a/tests/RustPlusApi.Camera.UnitTests/stryker-config.json
+++ b/tests/RustPlusApi.Camera.UnitTests/stryker-config.json
@@ -6,6 +6,7 @@
     "reporters": ["html", "progress", "cleartext"],
     "thresholds": { "high": 90, "low": 80, "break": 75 },
     "mutate": ["!**/obj/**", "!**/bin/**"],
+    "ignore-methods": ["ConfigureAwait", "Log*", "CreateLogger", "SuppressFinalize"],
     "ignore-mutations": [],
     "project-info": { "module": "RustPlusApi.Camera" }
   }

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/stryker-config.json
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/stryker-config.json
@@ -6,6 +6,7 @@
     "reporters": ["html", "progress", "cleartext"],
     "thresholds": { "high": 90, "low": 80, "break": 75 },
     "mutate": ["!**/obj/**", "!**/bin/**"],
+    "ignore-methods": ["ConfigureAwait", "Log*", "CreateLogger", "SuppressFinalize"],
     "ignore-mutations": [],
     "project-info": { "module": "RustPlusApi.Fcm.Registration" }
   }

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmLoggingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmLoggingTests.cs
@@ -1,0 +1,39 @@
+using RustPlusApi.Fcm.Data;
+using Xunit;
+
+namespace RustPlusApi.Fcm.UnitTests;
+
+public class FcmLoggingTests
+{
+    private static Credentials AnyCredentials() =>
+        new() { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 } };
+
+    [Fact]
+    public void Constructor_WithNoOptions_DoesNotThrow()
+    {
+        using var socket = new TestSocket(AnyCredentials(), null);
+        Assert.NotNull(socket);
+    }
+
+    [Fact]
+    public void Constructor_WithOptionsButNoFactory_DoesNotThrow()
+    {
+        using var socket = new TestSocket(AnyCredentials(), new RustPlusFcmSocketOptions());
+        Assert.NotNull(socket);
+    }
+
+    [Fact]
+    public void Constructor_WithLoggerFactory_DoesNotThrow()
+    {
+        var factory = new SpyLoggerFactory();
+        using var socket = new TestSocket(AnyCredentials(),
+            new RustPlusFcmSocketOptions { LoggerFactory = factory });
+        Assert.NotNull(socket);
+    }
+
+    /// <summary>Concrete subclass: <see cref="RustPlusFcmSocket"/> is abstract.</summary>
+    /// <param name="credentials">The FCM credentials.</param>
+    /// <param name="options">Optional socket options.</param>
+    private sealed class TestSocket(Credentials credentials, RustPlusFcmSocketOptions? options)
+        : RustPlusFcmSocket(credentials, options: options);
+}

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmLoggingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmLoggingTests.cs
@@ -1,3 +1,5 @@
+using System;
+using Microsoft.Extensions.Logging;
 using RustPlusApi.Fcm.Data;
 using Xunit;
 
@@ -31,9 +33,32 @@ public class FcmLoggingTests
         Assert.NotNull(socket);
     }
 
+    [Fact]
+    public void ParseNotification_UnknownChannel_LogsWarning()
+    {
+        var factory = new SpyLoggerFactory();
+        using var fcm = new TestableRustPlusFcm(new RustPlusFcmSocketOptions { LoggerFactory = factory });
+
+        fcm.InvokeParseNotification(new FcmMessage
+        {
+            Data = new MessageData { ChannelId = "not-a-known-channel" }
+        });
+
+        Assert.Single(factory.Logger.Entries, e =>
+            e.Level == LogLevel.Warning && e.Message.Contains("Unknown channel", StringComparison.Ordinal));
+    }
+
     /// <summary>Concrete subclass: <see cref="RustPlusFcmSocket"/> is abstract.</summary>
     /// <param name="credentials">The FCM credentials.</param>
     /// <param name="options">Optional socket options.</param>
     private sealed class TestSocket(Credentials credentials, RustPlusFcmSocketOptions? options)
         : RustPlusFcmSocket(credentials, options: options);
+
+    /// <summary>Exposes the protected ParseNotification so the unknown-channel path can be driven.</summary>
+    /// <param name="options">Socket options supplying the logger factory under test.</param>
+    private sealed class TestableRustPlusFcm(RustPlusFcmSocketOptions options)
+        : RustPlusFcm(new Credentials { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 } }, options: options)
+    {
+        public void InvokeParseNotification(FcmMessage message) => ParseNotification(message);
+    }
 }

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
@@ -427,7 +427,7 @@ public class FcmSocketFramingTests
     public async Task UnrecognizedTag_HeartbeatAck_IsIgnored_NoNotificationAndNoThrow()
     {
         // HeartbeatAck is a known protobuf type but has no explicit handling in OnMessage,
-        // so it falls through to the default arm (Debug.WriteLine + ignore).
+        // so it falls through to the default arm (Logger.LogUnrecognizedTag + ignore).
         await using var socket = NewSocket();
         var raised = false;
         socket.NotificationReceived += (_, _) => raised = true;

--- a/tests/RustPlusApi.Fcm.UnitTests/SpyLogger.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/SpyLogger.cs
@@ -7,7 +7,7 @@ public sealed class SpyLogger : ILogger
 {
     public List<(LogLevel Level, string Message)> Entries { get; } = [];
 
-    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
     public bool IsEnabled(LogLevel logLevel) => true;
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,

--- a/tests/RustPlusApi.Fcm.UnitTests/SpyLogger.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/SpyLogger.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Logging;
+
+namespace RustPlusApi.Fcm.UnitTests;
+
+public sealed class SpyLogger : ILogger
+{
+    public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+        Func<TState, Exception?, string> formatter)
+        => Entries.Add((logLevel, formatter(state, exception)));
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
+    }
+}
+
+public sealed class SpyLoggerFactory : ILoggerFactory
+{
+    public SpyLogger Logger { get; } = new();
+    public ILogger CreateLogger(string categoryName) => Logger;
+    public void AddProvider(ILoggerProvider provider) { }
+    public void Dispose() { }
+}

--- a/tests/RustPlusApi.Fcm.UnitTests/SpyLogger.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/SpyLogger.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 
 namespace RustPlusApi.Fcm.UnitTests;
 
+/// <summary>In-memory logger capturing entries so tests can assert level + message.</summary>
 public sealed class SpyLogger : ILogger
 {
     public List<(LogLevel Level, string Message)> Entries { get; } = [];
@@ -20,6 +21,7 @@ public sealed class SpyLogger : ILogger
     }
 }
 
+/// <summary>Factory that hands out a single shared <see cref="SpyLogger"/> for assertions.</summary>
 public sealed class SpyLoggerFactory : ILoggerFactory
 {
     public SpyLogger Logger { get; } = new();

--- a/tests/RustPlusApi.Fcm.UnitTests/stryker-config.json
+++ b/tests/RustPlusApi.Fcm.UnitTests/stryker-config.json
@@ -6,7 +6,7 @@
     "reporters": ["html", "progress", "cleartext"],
     "thresholds": { "high": 90, "low": 80, "break": 75 },
     "mutate": ["!**/obj/**", "!**/bin/**"],
-    "ignore-methods": ["ConfigureAwait", "Debug.WriteLine", "SuppressFinalize"],
+    "ignore-methods": ["ConfigureAwait", "Log*", "CreateLogger", "SuppressFinalize"],
     "ignore-mutations": [],
     "project-info": { "module": "RustPlusApi.Fcm" }
   }

--- a/tests/RustPlusApi.IntegrationTests/CameraClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/CameraClientTests.cs
@@ -21,7 +21,7 @@ public class CameraClientTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var response = await client.SubscribeToCameraAsync("CAM01").WaitAsync(Timeout);
@@ -36,7 +36,7 @@ public class CameraClientTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var input = await client.SendCameraInputAsync(CameraButtons.Forward | CameraButtons.FirePrimary)
@@ -52,7 +52,7 @@ public class CameraClientTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
 
         var received = new TaskCompletionSource<CameraRaysEventArg>(
             TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/RustPlusApi.IntegrationTests/ClanNexusClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/ClanNexusClientTests.cs
@@ -20,7 +20,7 @@ public class ClanNexusClientTests
     {
         var server = new MockRustPlusServer(responder);
         server.Start();
-        var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
         return (server, client);
     }

--- a/tests/RustPlusApi.IntegrationTests/ClientErrorPathTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/ClientErrorPathTests.cs
@@ -17,7 +17,7 @@ public class ClientErrorPathTests
     {
         var server = new MockRustPlusServer(req => MockResponses.Error(req.Seq, "no_permission"));
         server.Start();
-        var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
         return (server, client);
     }

--- a/tests/RustPlusApi.IntegrationTests/EntityClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/EntityClientTests.cs
@@ -50,7 +50,7 @@ public class EntityClientTests
     {
         var server = new MockRustPlusServer(EntityResponder);
         server.Start();
-        var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
         return (server, client);
     }
@@ -59,7 +59,7 @@ public class EntityClientTests
     {
         var server = new MockRustPlusServer();
         server.Start();
-        var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
         return (server, client);
     }
@@ -93,7 +93,7 @@ public class EntityClientTests
             return new AppMessage { Response = resp };
         });
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var response = await client.GetAlarmInfoAsync(1).WaitAsync(Timeout);
@@ -119,7 +119,7 @@ public class EntityClientTests
             return new AppMessage { Response = resp };
         });
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var response = await client.GetStorageMonitorInfoAsync(1).WaitAsync(Timeout);

--- a/tests/RustPlusApi.IntegrationTests/RustPlusClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/RustPlusClientTests.cs
@@ -21,7 +21,7 @@ public class RustPlusClientTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var response = await client.GetInfoAsync().WaitAsync(Timeout);
@@ -38,7 +38,7 @@ public class RustPlusClientTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var response = await client.GetTimeAsync().WaitAsync(Timeout);
@@ -55,7 +55,7 @@ public class RustPlusClientTests
         await using var server = new MockRustPlusServer(
             request => MockResponses.Error(request.Seq, "not_found"));
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var response = await client.GetInfoAsync().WaitAsync(Timeout);
@@ -70,7 +70,7 @@ public class RustPlusClientTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
 
         var received = new TaskCompletionSource<TeamMessageEventArg>(
             TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/RustPlusApi.IntegrationTests/SocketCorrelationTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketCorrelationTests.cs
@@ -31,7 +31,7 @@ public class SocketCorrelationTests
             return MockResponses.Default(req);
         });
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var requestTask = client.GetInfoAsync();
@@ -56,7 +56,7 @@ public class SocketCorrelationTests
         // The server never replies, so the request stays pending until the caller's token cancels it.
         await using var server = new MockRustPlusServer(_ => null);
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         using var cts = new CancellationTokenSource();
@@ -80,7 +80,7 @@ public class SocketCorrelationTests
         await using var server = new MockRustPlusServer(req =>
             req.SetEntityValue is not null ? null : MockResponses.Default(req));
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         var otherSwitchEvent = new TaskCompletionSource<Data.Events.SmartSwitchEventArg>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         client.OnSmartSwitchTriggered += (_, e) => otherSwitchEvent.TrySetResult(e);
@@ -115,7 +115,7 @@ public class SocketCorrelationTests
         await using var server = new MockRustPlusServer(req =>
             req.SendTeamMessage is not null ? null : MockResponses.Default(req));
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
 
         await client.ConnectAsync().WaitAsync(Timeout);
         await client.GetInfoAsync().WaitAsync(Timeout); // round-trip so the server registers the socket
@@ -151,7 +151,7 @@ public class SocketCorrelationTests
             return MockResponses.Default(req);
         });
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
 
         await client.ConnectAsync().WaitAsync(Timeout);
         await client.GetInfoAsync().WaitAsync(Timeout); // round-trip so the server registers the socket
@@ -178,7 +178,7 @@ public class SocketCorrelationTests
         // Proves the caller token flows the whole public path: GetInfoAsync → ProcessRequestAsync → SendRequestAsync.
         await using var server = new MockRustPlusServer(_ => null);
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         using var cts = new CancellationTokenSource();

--- a/tests/RustPlusApi.IntegrationTests/SocketErrorTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketErrorTests.cs
@@ -20,7 +20,7 @@ public class SocketErrorTests
         // timeout (default 30 s). Killing the transport must fault it right away instead.
         var server = new MockRustPlusServer(_ => null);
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, 1, 1);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, 1, 1));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var requestTask = client.SendRequestAsync(new AppRequest { GetInfo = new AppEmpty() });
@@ -41,7 +41,7 @@ public class SocketErrorTests
         // No response can arrive after the close, so the request must fail fast, not time out.
         await using var server = new MockRustPlusServer(_ => null);
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, 1, 1);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, 1, 1));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var requestTask = client.SendRequestAsync(new AppRequest { GetInfo = new AppEmpty() });
@@ -60,7 +60,7 @@ public class SocketErrorTests
         await using var server = new MockRustPlusServer(_ => null);
         server.Start();
         var options = new RustPlusSocketOptions { RequestTimeout = TimeSpan.FromMilliseconds(500) };
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, 1, 1, options: options);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, 1, 1), options);
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var ex = await Assert.ThrowsAsync<TimeoutException>(
@@ -72,7 +72,7 @@ public class SocketErrorTests
     public async Task ConnectAsync_ToDeadPort_RaisesErrorOccurredAndThrows()
     {
         // Port 1 (or any closed loopback port) makes the WebSocket connect throw -> ErrorOccurred + rethrow.
-        await using var client = new RustPlus("127.0.0.1", 1, 1, 1);
+        await using var client = new RustPlus(new RustPlusConnection("127.0.0.1", 1, 1, 1));
         var error = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
         client.ErrorOccurred += (_, ex) => error.TrySetResult(ex);
 
@@ -90,7 +90,7 @@ public class SocketErrorTests
     {
         var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, 1, 1);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, 1, 1));
         var signalled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         client.ErrorOccurred += (_, _) => signalled.TrySetResult(true);
 
@@ -110,7 +110,7 @@ public class SocketErrorTests
     {
         // useFacepunchProxy=true exercises the wss:// URL branch in ConnectAsync; connecting
         // to the Facepunch host will fail in CI, triggering ErrorOccurred + rethrow.
-        await using var client = new RustPlus("example.invalid", 28083, 1, 1, useFacepunchProxy: true);
+        await using var client = new RustPlus(new RustPlusConnection("example.invalid", 28083, 1, 1, UseFacepunchProxy: true));
         var error = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
         client.ErrorOccurred += (_, ex) => error.TrySetResult(ex);
 

--- a/tests/RustPlusApi.IntegrationTests/SocketLifecycleTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketLifecycleTests.cs
@@ -178,7 +178,7 @@ public class SocketLifecycleTests
         // Round-trip so server registers the active socket.
         await client.GetInfoAsync().WaitAsync(Timeout);
 
-        // A broadcast with no recognized payload exercises the Debug.WriteLine fall-through in ParseNotification.
+        // A broadcast with no recognized payload exercises the Logger.LogUnknownBroadcast path in ParseNotification.
         await server.BroadcastAsync(new AppBroadcast());
         await Task.Delay(200);
 

--- a/tests/RustPlusApi.IntegrationTests/SocketLifecycleTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketLifecycleTests.cs
@@ -22,7 +22,7 @@ public class SocketLifecycleTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
 
         var events = new List<string>();
         client.Connecting += (_, _) => events.Add("connecting");
@@ -53,7 +53,7 @@ public class SocketLifecycleTests
             return MockResponses.Default(req);
         });
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         client.SetPlayer(42, 7);
@@ -65,14 +65,14 @@ public class SocketLifecycleTests
     [Fact]
     public void IsConnected_BeforeConnect_IsFalse()
     {
-        using var client = new RustPlus(MockRustPlusServer.Host, 1, PlayerId, PlayerToken);
+        using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, 1, PlayerId, PlayerToken));
         Assert.False(client.IsConnected);
     }
 
     [Fact]
     public async Task DisconnectAsync_WhenNotConnected_ReturnsImmediately()
     {
-        await using var client = new RustPlus(MockRustPlusServer.Host, 1, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, 1, PlayerId, PlayerToken));
         await client.DisconnectAsync().WaitAsync(Timeout); // early return, no throw
         Assert.False(client.IsConnected);
     }
@@ -82,7 +82,7 @@ public class SocketLifecycleTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var disconnecting = false;
@@ -101,7 +101,7 @@ public class SocketLifecycleTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
 
         await client.ConnectAsync().WaitAsync(Timeout);
         var first = await client.GetInfoAsync().WaitAsync(Timeout);
@@ -124,7 +124,7 @@ public class SocketLifecycleTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => client.ConnectAsync().WaitAsync(Timeout));
@@ -134,7 +134,7 @@ public class SocketLifecycleTests
     [Fact]
     public async Task ConnectAsync_AfterDispose_ThrowsObjectDisposed()
     {
-        var client = new RustPlus(MockRustPlusServer.Host, 1, PlayerId, PlayerToken);
+        var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, 1, PlayerId, PlayerToken));
         await client.DisposeAsync();
 
         await Assert.ThrowsAsync<ObjectDisposedException>(() => client.ConnectAsync());
@@ -145,7 +145,7 @@ public class SocketLifecycleTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         var received = new TaskCompletionSource<StorageMonitorEventArg>(TaskCreationOptions.RunContinuationsAsynchronously);
         client.OnStorageMonitorTriggered += (_, e) => received.TrySetResult(e);
 
@@ -173,7 +173,7 @@ public class SocketLifecycleTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
         // Round-trip so server registers the active socket.
         await client.GetInfoAsync().WaitAsync(Timeout);
@@ -190,7 +190,7 @@ public class SocketLifecycleTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
         await client.GetInfoAsync().WaitAsync(Timeout);
 
@@ -261,7 +261,7 @@ public class SocketLifecycleTests
             return MockResponses.Default(req);
         });
         server.Start();
-        await using var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var requestTask = client.GetInfoAsync();

--- a/tests/RustPlusApi.IntegrationTests/SocketTeardownTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketTeardownTests.cs
@@ -18,7 +18,7 @@ public class SocketTeardownTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        var client = new RustPlus(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken);
+        var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
         await client.GetInfoAsync().WaitAsync(Timeout);
 

--- a/tests/RustPlusApi.NetFrameworkSmoke/Program.cs
+++ b/tests/RustPlusApi.NetFrameworkSmoke/Program.cs
@@ -8,7 +8,7 @@ internal static class Program
 {
     private static void Main()
     {
-        using var rustPlus = new RustPlus("127.0.0.1", 28083, 76561198000000000UL, 123456789);
+        using var rustPlus = new RustPlus(new RustPlusConnection("127.0.0.1", 28083, 76561198000000000UL, 123456789));
         System.Console.WriteLine("Constructed RustPlus: connected=" + rustPlus.IsConnected);
     }
 }

--- a/tests/RustPlusApi.UnitTests/RustPlusConnectionTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusConnectionTests.cs
@@ -1,0 +1,38 @@
+using System;
+using Xunit;
+
+namespace RustPlusApi.UnitTests;
+
+public class RustPlusConnectionTests
+{
+    [Fact]
+    public void ToString_RedactsPlayerToken()
+    {
+        var connection = new RustPlusConnection("12.34.56.78", 28082, 76561198000000000UL, 1234567890);
+
+        var text = connection.ToString();
+
+        // The credential must never appear in the string form.
+        Assert.DoesNotContain("1234567890", text, StringComparison.Ordinal);
+        Assert.Contains("PlayerToken = ***", text, StringComparison.Ordinal);
+
+        // Non-sensitive fields stay visible for debuggability.
+        Assert.Contains("Server = 12.34.56.78", text, StringComparison.Ordinal);
+        Assert.Contains("Port = 28082", text, StringComparison.Ordinal);
+        Assert.Contains("PlayerId = 76561198000000000", text, StringComparison.Ordinal);
+        Assert.Contains("UseFacepunchProxy = False", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Equality_UsesEveryMember_DespiteRedactedToString()
+    {
+        var a = new RustPlusConnection("host", 1, 2UL, 3);
+        var b = new RustPlusConnection("host", 1, 2UL, 3);
+        var differentToken = a with { PlayerToken = 99 };
+
+        Assert.Equal(a, b);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        // Redacting the token from ToString must not collapse equality: the token is still compared.
+        Assert.NotEqual(a, differentToken);
+    }
+}

--- a/tests/RustPlusApi.UnitTests/RustPlusLoggingTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusLoggingTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging;
+using RustPlusContracts;
+using Xunit;
+
+namespace RustPlusApi.UnitTests;
+
+public class RustPlusLoggingTests
+{
+    private static RustPlusConnection AnyConnection() => new("127.0.0.1", 1, 1UL, 1);
+
+    [Fact]
+    public void Constructor_WithNoOptions_DoesNotThrow()
+    {
+        using var client = new RustPlus(AnyConnection());
+        Assert.False(client.IsConnected);
+    }
+
+    [Fact]
+    public void Constructor_WithOptionsButNoFactory_DoesNotThrow()
+    {
+        using var client = new RustPlus(AnyConnection(), new RustPlusSocketOptions());
+        Assert.False(client.IsConnected);
+    }
+
+    [Fact]
+    public void Constructor_WithLoggerFactory_DoesNotThrow()
+    {
+        var factory = new SpyLoggerFactory();
+        using var client = new RustPlus(AnyConnection(), new RustPlusSocketOptions { LoggerFactory = factory });
+        Assert.False(client.IsConnected);
+    }
+
+    [Fact]
+    public void UnknownBroadcast_LogsWarning()
+    {
+        var factory = new SpyLoggerFactory();
+        using var client = new TestableRustPlus(new RustPlusSocketOptions { LoggerFactory = factory });
+
+        client.InvokeParseNotification(new AppBroadcast());
+
+        Assert.Contains(factory.Logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    /// <summary>Exposes the protected ParseNotification so the unknown-broadcast path can be driven.</summary>
+    /// <param name="options">Socket options to forward to the base constructor.</param>
+    private sealed class TestableRustPlus(RustPlusSocketOptions options)
+        : RustPlus(new RustPlusConnection("127.0.0.1", 1, 1UL, 1), options)
+    {
+        public void InvokeParseNotification(AppBroadcast broadcast) => ParseNotification(broadcast);
+    }
+}

--- a/tests/RustPlusApi.UnitTests/RustPlusLoggingTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusLoggingTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.Logging;
 using RustPlusContracts;
 using Xunit;
@@ -38,7 +39,8 @@ public class RustPlusLoggingTests
 
         client.InvokeParseNotification(new AppBroadcast());
 
-        Assert.Contains(factory.Logger.Entries, e => e.Level == LogLevel.Warning);
+        Assert.Single(factory.Logger.Entries, e =>
+            e.Level == LogLevel.Warning && e.Message.Contains("Unknown broadcast", StringComparison.Ordinal));
     }
 
     /// <summary>Exposes the protected ParseNotification so the unknown-broadcast path can be driven.</summary>

--- a/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
@@ -14,7 +14,7 @@ namespace RustPlusApi.UnitTests;
 public class RustPlusParseNotificationTests
 {
     /// <summary>Exposes the protected members of <see cref="RustPlus"/> for direct unit testing.</summary>
-    private sealed class TestRustPlus() : RustPlus("127.0.0.1", 1, 1, 1)
+    private sealed class TestRustPlus() : RustPlus(new RustPlusConnection("127.0.0.1", 1, 1, 1))
     {
         public void Feed(AppBroadcast? b) => ParseNotification(b);
 

--- a/tests/RustPlusApi.UnitTests/SpyLogger.cs
+++ b/tests/RustPlusApi.UnitTests/SpyLogger.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Logging;
+
+namespace RustPlusApi.UnitTests;
+
+/// <summary>In-memory logger capturing entries so tests can assert level + message.</summary>
+public sealed class SpyLogger : ILogger
+{
+    public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+        Func<TState, Exception?, string> formatter)
+        => Entries.Add((logLevel, formatter(state, exception)));
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
+    }
+}
+
+/// <summary>Factory that hands out a single shared <see cref="SpyLogger"/> for assertions.</summary>
+public sealed class SpyLoggerFactory : ILoggerFactory
+{
+    public SpyLogger Logger { get; } = new();
+    public ILogger CreateLogger(string categoryName) => Logger;
+    public void AddProvider(ILoggerProvider provider) { }
+    public void Dispose() { }
+}

--- a/tests/RustPlusApi.UnitTests/SpyLogger.cs
+++ b/tests/RustPlusApi.UnitTests/SpyLogger.cs
@@ -7,7 +7,7 @@ public sealed class SpyLogger : ILogger
 {
     public List<(LogLevel Level, string Message)> Entries { get; } = [];
 
-    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
     public bool IsEnabled(LogLevel logLevel) => true;
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,


### PR DESCRIPTION
## Summary

Two related improvements to the socket libraries (`RustPlusApi`, `RustPlusApi.Fcm`):

- **Consumer observability via `ILogger`.** Both clients now accept an `ILoggerFactory` on their options (`RustPlusSocketOptions.LoggerFactory` / `RustPlusFcmSocketOptions.LoggerFactory`) and resolve a `NullLogger`-default logger (zero overhead when unconfigured). Every `Debug.WriteLine` in the socket lifecycle was replaced with `[LoggerMessage]` source-generated, leveled, structured logs. Adds `Microsoft.Extensions.Logging.Abstractions` (10.0.8) via Central Package Management.
- **Constructor clarity (breaking).** `RustPlus`'s six positional parameters are grouped into a new `RustPlusConnection` record, so call sites read `new RustPlus(new RustPlusConnection(server, port, playerId, playerToken), options)`. The old constructor is removed (clean v2-style break). `RustPlusFcm` is unchanged in shape (it only gains the `LoggerFactory` option).

Docs, READMEs, the DocFX site (new Logging guide), the coverage-exclusion notes, and the Stryker `ignore-methods` (`Log*`, `CreateLogger`) are all updated accordingly.

### Notes
- Log payload params for protobuf types are typed `object` in the core log class because `AppMessage`/`AppBroadcast` are emitted by `protobuf-net.BuildTools` and the `[LoggerMessage]` generator can't reference another generator's output in the same compilation. The FCM log class uses concrete types (its proto types are code-first).
- Logger category is a fixed string per socket (a field initializer can't call `GetType()`).
- Scope: the two socket libraries only. `RustPlusApi.Fcm.Registration` and `RustPlusApi.Camera` are intentionally out of scope.

## Test Plan
- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] Full suite green: 300 tests × {net8.0, net10.0}
- [x] Coverage gate green: line 96.79% / branch 91.70% (floor 95/90)
- [x] `RustPlusApi.NetFrameworkSmoke` builds (net48 consumer reachability via netstandard2.0)
- [x] New tests: `RustPlusLoggingTests`, `FcmLoggingTests` (constructor/factory branches + unknown-broadcast/unknown-channel warning emission)

🤖 Generated with [Claude Code](https://claude.com/claude-code)