### PR TITLE
chore: ReSharper formatting, SonarQube fixes, landing-page CTA alignment

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,6 +15,13 @@
         "reportgenerator"
       ],
       "rollForward": false
+    },
+    "jetbrains.resharper.globaltools": {
+      "version": "2026.1.2",
+      "commands": [
+        "jb"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -433,6 +433,8 @@ resharper_unused_auto_property_accessor_global_highlighting = none
 resharper_wrap_object_and_collection_initializer_style = chop_always
 resharper_place_simple_initializer_on_single_line = false
 resharper_wrap_linq_expressions = chop_always
+resharper_csharp_wrap_parameters_style = chop_if_long
+resharper_csharp_place_method_parameter_on_same_line = false
 
 [**/Migrations/*.cs]
 generated_code = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -430,7 +430,7 @@ resharper_convert_to_extension_block_highlighting = none
 resharper_unused_auto_property_accessor_global_highlighting = none
 
 # ReSharper formatting — align with dotnet format to prevent CI drift
-resharper_wrap_object_and_collection_initializer_style = chop_always
+resharper_wrap_object_and_collection_initializer_style = chop_if_long
 resharper_place_simple_initializer_on_single_line = false
 resharper_wrap_linq_expressions = chop_always
 resharper_csharp_wrap_parameters_style = chop_if_long

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,83 @@
+#!/bin/sh
+# pre-push: run the ReSharper formatter on the files being pushed and block
+# the push when it produces changes, so unformatted code never leaves the
+# machine. Bypass for emergencies with `git push --no-verify`.
+set -u
+
+repo_root=$(git rev-parse --show-toplevel) || exit 1
+cd "$repo_root" || exit 1
+
+default_branch=origin/develop
+
+# Collect the files touched by the commits being pushed (stdin lines:
+# "<local ref> <local sha> <remote ref> <remote sha>").
+changed=""
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+    # Deleting a remote branch pushes the zero sha — nothing to format.
+    case "$local_sha" in
+        *[!0]*) ;;
+        *) continue ;;
+    esac
+
+    case "$remote_sha" in
+        *[!0]*) base=$remote_sha ;;
+        *)
+            # New remote branch: compare against the default branch when
+            # possible, otherwise format everything the branch contains.
+            base=$(git merge-base "$local_sha" "$default_branch" 2>/dev/null) \
+                || base=$(git rev-list --max-parents=0 "$local_sha" | tail -n 1)
+            ;;
+    esac
+
+    files=$(git diff --name-only --diff-filter=ACMR "$base" "$local_sha" -- \
+        '*.cs' '*.csproj' '*.props' '*.targets')
+    changed=$(printf '%s\n%s' "$changed" "$files")
+done
+
+changed=$(printf '%s' "$changed" | sort -u | sed '/^$/d')
+[ -z "$changed" ] && exit 0
+
+# Only files that still exist in the working tree can be cleaned up.
+existing=""
+for f in $changed; do
+    [ -f "$f" ] && existing=$(printf '%s\n%s' "$existing" "$f")
+done
+existing=$(printf '%s' "$existing" | sed '/^$/d')
+[ -z "$existing" ] && exit 0
+
+include=$(printf '%s' "$existing" | paste -sd ';' -)
+
+echo "pre-push: checking ReSharper formatting on $(printf '%s\n' "$existing" | wc -l) file(s)..."
+
+dotnet tool restore >/dev/null || exit 1
+
+# Hash each file's working-tree diff so we can tell exactly which files the
+# formatter modifies (pre-existing local edits must not trip the check).
+hash_diffs() {
+    for f in $existing; do
+        printf '%s %s\n' "$(git diff -- "$f" | git hash-object --stdin)" "$f"
+    done
+}
+
+before=$(hash_diffs)
+
+dotnet jb cleanupcode RustPlusApi.sln \
+    --profile="Built-in: Reformat Code" \
+    --include="$include" \
+    --no-build \
+    --verbosity=ERROR || exit 1
+
+after=$(hash_diffs)
+
+if [ "$before" != "$after" ]; then
+    echo ""
+    echo "pre-push: formatting issues found — the formatter changed:"
+    printf '%s\n%s\n' "$before" "$after" | sort | uniq -u | cut -d' ' -f2- | sort -u | sed 's/^/  /'
+    echo ""
+    echo "Review the changes, amend/commit them, then push again."
+    echo "(Bypass once with: git push --no-verify)"
+    exit 1
+fi
+
+echo "pre-push: formatting OK."
+exit 0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,46 +1,46 @@
 <Project>
-	<PropertyGroup>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-	</PropertyGroup>
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 
-    <PropertyGroup>
-      <!-- Placeholder for local builds only: CD packs with -p:Version=<tag> on release (see CD.yml),
+  <PropertyGroup>
+    <!-- Placeholder for local builds only: CD packs with -p:Version=<tag> on release (see CD.yml),
            so a local `dotnet pack` always produces 1.0.0. -->
-      <Version>1.0.0</Version>
-      <IsPackable>false</IsPackable>
-    </PropertyGroup>
+    <Version>1.0.0</Version>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-	<PropertyGroup>
-        <AnalysisLevel>latest-all</AnalysisLevel>
-        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-	</PropertyGroup>
+  <PropertyGroup>
+    <AnalysisLevel>latest-all</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Roslynator.Analyzers">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Roslynator.Formatting.Analyzers">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Roslynator.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Roslynator.Formatting.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,17 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <!-- Point git at the committed hooks (.githooks/pre-push formats before pushing).
+       Idempotent and best-effort: skipped on CI and outside a git clone. -->
+  <Target Name="ConfigureGitHooks" BeforeTargets="Build"
+          Condition="'$(CI)' == '' AND '$(ContinuousIntegrationBuild)' != 'true' AND Exists('$(MSBuildThisFileDirectory).git')">
+    <Exec Command="git config core.hooksPath .githooks"
+          WorkingDirectory="$(MSBuildThisFileDirectory)"
+          ContinueOnError="true"
+          StandardOutputImportance="low"
+          StandardErrorImportance="low" />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
       <PrivateAssets>all</PrivateAssets>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <configuration>
     <packageSources>
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />

--- a/docs/development/formatting.md
+++ b/docs/development/formatting.md
@@ -1,0 +1,46 @@
+# Code Formatting
+
+The solution is formatted with the **ReSharper command-line formatter**
+([`JetBrains.ReSharper.GlobalTools`](https://www.jetbrains.com/help/resharper/CleanupCode.html)),
+pinned in the dotnet tool manifest (`.config/dotnet-tools.json`) so every contributor runs the
+same version. Formatting rules come from the repository `.editorconfig`.
+
+---
+
+## Formatting manually
+
+```sh
+dotnet tool restore
+dotnet jb cleanupcode RustPlusApi.sln --profile="Built-in: Reformat Code"
+```
+
+The *Built-in: Reformat Code* profile only reformats — it never applies code-style rewrites or
+syntax changes.
+
+---
+
+## The pre-push hook
+
+A committed [`pre-push` hook](https://github.com/HandyS11/RustPlusApi/blob/develop/.githooks/pre-push)
+keeps unformatted code from leaving your machine:
+
+1. It collects the `*.cs`, `*.csproj`, `*.props` and `*.targets` files touched by the commits
+   being pushed (new branches are compared against `origin/develop`).
+2. It runs the formatter scoped to just those files.
+3. If the formatter changes anything, the push is **rejected** and the fixed files are left in
+   your working tree — review them, amend or commit, then push again.
+
+Pre-existing local edits are ignored: only files the formatter itself modifies fail the check.
+
+### Setup
+
+None. Building any project once (`dotnet build`) points git at the committed hooks via
+`git config core.hooksPath .githooks` (a target in `Directory.Build.props`; skipped on CI).
+
+### Bypassing
+
+For emergencies only:
+
+```sh
+git push --no-verify
+```

--- a/docs/development/toc.yml
+++ b/docs/development/toc.yml
@@ -1,4 +1,6 @@
 - name: Testing & Quality
   href: testing.md
+- name: Code Formatting
+  href: formatting.md
 - name: Building the Docs
   href: building-docs.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ _disableBreadcrumb: true
   </p>
   <div class="rp-cta">
     <a class="btn btn-primary" href="articles/getting-started.md">Get Started</a>
-    <a class="btn btn-outline-secondary" href="xref:RustPlusApi">API Reference</a>
+    <a class="btn btn-outline-secondary" href="api/RustPlusApi.yml">API Reference</a>
   </div>
   <p class="rp-badges">
     <img src="https://img.shields.io/badge/.NET-Standard%202.0%20%7C%2010-512BD4?logo=dotnet" alt=".NET" />

--- a/docs/template/public/main.css
+++ b/docs/template/public/main.css
@@ -164,13 +164,6 @@ header {
 
 .rp-card:hover {
   color: inherit;
-}
-
-.rp-card h3 {
-  color: rgb(var(--bs-link-color-rgb));
-}
-
-.rp-card:hover {
   border-color: var(--rp-rust);
   box-shadow: 0 0 20px rgba(206, 65, 43, 0.25);
   transform: translateY(-2px);
@@ -183,6 +176,7 @@ header {
 }
 
 .rp-card h3 {
+  color: rgb(var(--bs-link-color-rgb));
   font-size: 1.05rem;
   margin: 0 0 0.4rem;
 }
@@ -192,7 +186,6 @@ header {
   margin: 0;
   opacity: 0.85;
 }
-
 
 /* ---------- tables ---------- */
 .table thead th {

--- a/samples/RustPlus.ConsoleApp/Features/GetMap.cs
+++ b/samples/RustPlus.ConsoleApp/Features/GetMap.cs
@@ -15,8 +15,10 @@ internal sealed class GetMap(IRustPlus rustPlus)
 
         var map = response.Data!;
         Console.WriteLine("Map:");
-        Console.WriteLine($"  Size:        {map.Width?.ToString("D", System.Globalization.CultureInfo.InvariantCulture) ?? "?"} x {map.Height?.ToString("D", System.Globalization.CultureInfo.InvariantCulture) ?? "?"} game units");
-        Console.WriteLine($"  Ocean margin: {map.OceanMargin?.ToString("D", System.Globalization.CultureInfo.InvariantCulture) ?? "?"}");
+        Console.WriteLine(
+            $"  Size:        {map.Width?.ToString("D", System.Globalization.CultureInfo.InvariantCulture) ?? "?"} x {map.Height?.ToString("D", System.Globalization.CultureInfo.InvariantCulture) ?? "?"} game units");
+        Console.WriteLine(
+            $"  Ocean margin: {map.OceanMargin?.ToString("D", System.Globalization.CultureInfo.InvariantCulture) ?? "?"}");
         Console.WriteLine($"  Monuments:   {map.Monuments?.Count ?? 0}");
 
         if (map.JpgImage is { Length: > 0 })

--- a/samples/RustPlus.ConsoleApp/Features/LiveEvents.cs
+++ b/samples/RustPlus.ConsoleApp/Features/LiveEvents.cs
@@ -8,8 +8,12 @@ internal sealed class LiveEvents(IRustPlus rustPlus)
 {
     public Task RunAsync()
     {
-        void OnSmartSwitch(object? _, SmartSwitchEventArg e) => DisplayUtilities.DisplayEvent("SmartSwitchTriggered", e);
-        void OnStorageMonitor(object? _, StorageMonitorEventArg e) => DisplayUtilities.DisplayEvent("StorageMonitorTriggered", e);
+        void OnSmartSwitch(object? _, SmartSwitchEventArg e) =>
+            DisplayUtilities.DisplayEvent("SmartSwitchTriggered", e);
+
+        void OnStorageMonitor(object? _, StorageMonitorEventArg e) =>
+            DisplayUtilities.DisplayEvent("StorageMonitorTriggered", e);
+
         void OnTeamChat(object? _, TeamMessageEventArg e) => DisplayUtilities.DisplayEvent("TeamChatReceived", e);
         void OnClanChat(object? _, ClanMessageEventArg e) => DisplayUtilities.DisplayEvent("ClanChatReceived", e);
         void OnClanChanged(object? _, ClanChangedEventArg e) => DisplayUtilities.DisplayEvent("ClanChanged", e);

--- a/samples/RustPlus.ConsoleApp/Program.cs
+++ b/samples/RustPlus.ConsoleApp/Program.cs
@@ -25,7 +25,8 @@ catch (Exception ex)
     return;
 }
 
-using var rustPlus = new RustPlusApi.RustPlus(new RustPlusApi.RustPlusConnection(credentials.Ip, credentials.Port, credentials.PlayerId, credentials.PlayerToken));
+using var rustPlus = new RustPlusApi.RustPlus(new RustPlusApi.RustPlusConnection(credentials.Ip, credentials.Port,
+    credentials.PlayerId, credentials.PlayerToken));
 
 try
 {
@@ -55,6 +56,7 @@ await Menu.RunAsync("Main menu",
                 Console.WriteLine("App key cannot be empty.");
                 return Task.CompletedTask;
             }
+
             return new GetNexusAuth(rustPlus).GetNexusAuthAsync(appKey);
         }))),
     new MenuItem("Team Features", () => Menu.RunAsync("Team",
@@ -71,6 +73,7 @@ await Menu.RunAsync("Main menu",
                 Console.WriteLine("Message cannot be empty.");
                 return Task.CompletedTask;
             }
+
             return new SendTeamMessage(rustPlus).SendTeamMessageAsync(message);
         }))),
     new MenuItem("Clan Features", () => Menu.RunAsync("Clan",
@@ -85,6 +88,7 @@ await Menu.RunAsync("Main menu",
                 Console.WriteLine("Message cannot be empty.");
                 return Task.CompletedTask;
             }
+
             return new SendClanMessage(rustPlus).SendClanMessageAsync(message);
         }),
         new MenuItem("Set Clan MOTD", () =>
@@ -96,6 +100,7 @@ await Menu.RunAsync("Main menu",
                 Console.WriteLine("Message cannot be empty.");
                 return Task.CompletedTask;
             }
+
             return new SetClanMotd(rustPlus).SetClanMotdAsync(message);
         }))),
     new MenuItem("Electricity Features", () => Menu.RunAsync("Electricity",

--- a/samples/RustPlus.ConsoleApp/Utils/CameraAsciiRenderer.cs
+++ b/samples/RustPlus.ConsoleApp/Utils/CameraAsciiRenderer.cs
@@ -29,6 +29,7 @@ internal static class CameraAsciiRenderer
                 var index = (int)(luminance * (Ramp.Length - 1));
                 line[x] = Ramp[index];
             }
+
             Console.WriteLine(new string(line));
         }
     }

--- a/samples/RustPlus.ConsoleApp/Utils/CredentialsReaderUtility.cs
+++ b/samples/RustPlus.ConsoleApp/Utils/CredentialsReaderUtility.cs
@@ -22,7 +22,8 @@ internal static class CredentialsReaderUtility
         return config;
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Instantiated by JSON deserialization.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1812:AvoidUninstantiatedInternalClasses",
+        Justification = "Instantiated by JSON deserialization.")]
     internal sealed record Credentials
     {
         public required string Ip { get; init; }

--- a/samples/RustPlus.ConsoleApp/Utils/EntityIdStore.cs
+++ b/samples/RustPlus.ConsoleApp/Utils/EntityIdStore.cs
@@ -26,6 +26,7 @@ internal sealed class EntityIdStore
                 {
                     return remembered;
                 }
+
                 Console.WriteLine("A value is required, please try again.");
                 continue;
             }
@@ -47,6 +48,7 @@ internal sealed class EntityIdStore
             {
                 return id;
             }
+
             Console.WriteLine("Invalid input, please try again.");
             _lastUsed.Remove(kind); // don't keep an unparseable value as "last"
         }

--- a/samples/RustPlus.ConsoleApp/Utils/JsonUtilities.cs
+++ b/samples/RustPlus.ConsoleApp/Utils/JsonUtilities.cs
@@ -7,8 +7,7 @@ internal static class JsonUtilities
 {
     public static readonly JsonSerializerOptions JsonOptions = new()
     {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        WriteIndented = true
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, WriteIndented = true
     };
 
     public static readonly JsonSerializerOptions JsonConfigOptions = new()

--- a/samples/RustPlus.Fcm.ConsoleApp/Program.cs
+++ b/samples/RustPlus.Fcm.ConsoleApp/Program.cs
@@ -20,8 +20,10 @@ try
 catch (FileNotFoundException)
 {
     Console.WriteLine($"Config file not found at: {configPath}");
-    Console.WriteLine("Run the RustPlus.Register.ConsoleApp sample first (or 'npx @liamcottle/rustplus.js fcm-register'),");
-    Console.WriteLine("then copy the resulting rustplus.config.json next to this project (or pass its path as an argument).");
+    Console.WriteLine(
+        "Run the RustPlus.Register.ConsoleApp sample first (or 'npx @liamcottle/rustplus.js fcm-register'),");
+    Console.WriteLine(
+        "then copy the resulting rustplus.config.json next to this project (or pass its path as an argument).");
     return;
 }
 catch (Exception ex)
@@ -47,7 +49,8 @@ listener.OnPairing += (_, pairing) =>
     Debug.WriteLine($"[PAIRING]:\n{JsonSerializer.Serialize(pairing, JsonUtilities.JsonOptions)}");
 };
 
-listener.OnServerPairing += (_, pairing) => Console.WriteLine($"[SERVER PAIRING]:\n{JsonSerializer.Serialize(pairing, JsonUtilities.JsonOptions)}");
+listener.OnServerPairing += (_, pairing) =>
+    Console.WriteLine($"[SERVER PAIRING]:\n{JsonSerializer.Serialize(pairing, JsonUtilities.JsonOptions)}");
 
 listener.OnEntityPairing += (_, pairing) =>
 {
@@ -55,10 +58,14 @@ listener.OnEntityPairing += (_, pairing) =>
     Debug.WriteLine($"[ENTITY PAIRING]:\n{JsonSerializer.Serialize(pairing, JsonUtilities.JsonOptions)}");
 };
 
-listener.OnSmartSwitchPairing += (_, pairing) => Console.WriteLine($"[SMART SWITCH PAIRING]:\n{JsonSerializer.Serialize(pairing, JsonUtilities.JsonOptions)}");
-listener.OnStorageMonitorPairing += (_, pairing) => Console.WriteLine($"[STORAGE MONITOR PAIRING]:\n{JsonSerializer.Serialize(pairing, JsonUtilities.JsonOptions)}");
-listener.OnSmartAlarmPairing += (_, pairing) => Console.WriteLine($"[SMART ALARM PAIRING]:\n{JsonSerializer.Serialize(pairing, JsonUtilities.JsonOptions)}");
-listener.OnAlarmTriggered += (_, alarm) => Console.WriteLine($"[ALARM TRIGGERED]:\n{JsonSerializer.Serialize(alarm, JsonUtilities.JsonOptions)}");
+listener.OnSmartSwitchPairing += (_, pairing) =>
+    Console.WriteLine($"[SMART SWITCH PAIRING]:\n{JsonSerializer.Serialize(pairing, JsonUtilities.JsonOptions)}");
+listener.OnStorageMonitorPairing += (_, pairing) =>
+    Console.WriteLine($"[STORAGE MONITOR PAIRING]:\n{JsonSerializer.Serialize(pairing, JsonUtilities.JsonOptions)}");
+listener.OnSmartAlarmPairing += (_, pairing) =>
+    Console.WriteLine($"[SMART ALARM PAIRING]:\n{JsonSerializer.Serialize(pairing, JsonUtilities.JsonOptions)}");
+listener.OnAlarmTriggered += (_, alarm) =>
+    Console.WriteLine($"[ALARM TRIGGERED]:\n{JsonSerializer.Serialize(alarm, JsonUtilities.JsonOptions)}");
 
 try
 {

--- a/samples/RustPlus.Fcm.ConsoleApp/Utils/CredentialsReaderUtilities.cs
+++ b/samples/RustPlus.Fcm.ConsoleApp/Utils/CredentialsReaderUtilities.cs
@@ -10,7 +10,10 @@ namespace RustPlus.Fcm.ConsoleApp.Utils;
 
 internal static class CredentialsReaderUtilities
 {
-    private static readonly JsonSerializerOptions NativeOptions = new() { PropertyNameCaseInsensitive = true };
+    private static readonly JsonSerializerOptions NativeOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
 
     /// <summary>
     /// Loads credentials from either the native format written by
@@ -76,39 +79,36 @@ internal static class CredentialsReaderUtilities
     }
 }
 
-[SuppressMessage("Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Instantiated by JSON deserialization.")]
+[SuppressMessage("Performance", "CA1812:AvoidUninstantiatedInternalClasses",
+    Justification = "Instantiated by JSON deserialization.")]
 internal sealed record JavaScriptConfig
 {
-    [JsonPropertyName("fcm_credentials")]
-    public FcmCredentialsSection? FcmCredentials { get; init; }
+    [JsonPropertyName("fcm_credentials")] public FcmCredentialsSection? FcmCredentials { get; init; }
 
-    [JsonPropertyName("expo_push_token")]
-    public string? ExpoPushToken { get; init; }
+    [JsonPropertyName("expo_push_token")] public string? ExpoPushToken { get; init; }
 }
 
-[SuppressMessage("Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Instantiated by JSON deserialization.")]
+[SuppressMessage("Performance", "CA1812:AvoidUninstantiatedInternalClasses",
+    Justification = "Instantiated by JSON deserialization.")]
 internal sealed record FcmCredentialsSection
 {
-    [JsonPropertyName("gcm")]
-    public GcmSection? Gcm { get; init; }
+    [JsonPropertyName("gcm")] public GcmSection? Gcm { get; init; }
 
-    [JsonPropertyName("fcm")]
-    public FcmSection? Fcm { get; init; }
+    [JsonPropertyName("fcm")] public FcmSection? Fcm { get; init; }
 }
 
-[SuppressMessage("Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Instantiated by JSON deserialization.")]
+[SuppressMessage("Performance", "CA1812:AvoidUninstantiatedInternalClasses",
+    Justification = "Instantiated by JSON deserialization.")]
 internal sealed record GcmSection
 {
-    [JsonPropertyName("androidId")]
-    public string AndroidId { get; init; } = null!;
+    [JsonPropertyName("androidId")] public string AndroidId { get; init; } = null!;
 
-    [JsonPropertyName("securityToken")]
-    public string SecurityToken { get; init; } = null!;
+    [JsonPropertyName("securityToken")] public string SecurityToken { get; init; } = null!;
 }
 
-[SuppressMessage("Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Instantiated by JSON deserialization.")]
+[SuppressMessage("Performance", "CA1812:AvoidUninstantiatedInternalClasses",
+    Justification = "Instantiated by JSON deserialization.")]
 internal sealed record FcmSection
 {
-    [JsonPropertyName("token")]
-    public string Token { get; init; } = null!;
+    [JsonPropertyName("token")] public string Token { get; init; } = null!;
 }

--- a/samples/RustPlus.Fcm.ConsoleApp/Utils/JsonUtilities.cs
+++ b/samples/RustPlus.Fcm.ConsoleApp/Utils/JsonUtilities.cs
@@ -7,7 +7,6 @@ internal static class JsonUtilities
 {
     public static readonly JsonSerializerOptions JsonOptions = new()
     {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        WriteIndented = true
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, WriteIndented = true
     };
 }

--- a/samples/RustPlus.Register.ConsoleApp/Program.cs
+++ b/samples/RustPlus.Register.ConsoleApp/Program.cs
@@ -27,5 +27,6 @@ var pairing = await listener.WaitForServerPairingAsync();
 
 Console.WriteLine();
 Console.WriteLine("Paired! Use these arguments:");
-Console.WriteLine($"  new RustPlus(new RustPlusConnection(\"{pairing.Ip}\", {pairing.Port}, {pairing.PlayerId}, {pairing.PlayerToken}));");
+Console.WriteLine(
+    $"  new RustPlus(new RustPlusConnection(\"{pairing.Ip}\", {pairing.Port}, {pairing.PlayerId}, {pairing.PlayerToken}));");
 Console.WriteLine($"  (server: {pairing.Name})");

--- a/src/RustPlusApi.Camera/CameraRenderer.cs
+++ b/src/RustPlusApi.Camera/CameraRenderer.cs
@@ -1,5 +1,4 @@
 using RustPlusApi.Data.Cameras;
-
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -28,6 +27,7 @@ public sealed class CameraRenderer(int width, int height)
     private static readonly Rgba32 SkyColour = new(208, 230, 252);
 
     private readonly short[] _samplePositionBuffer = BuildSamplePositionBuffer(width, height);
+
     /// <summary>Raw decoded samples (distance 0-1023, alignment 0-63, material). Normalised at render time.</summary>
     private readonly (int Distance, int Alignment, int Material)?[] _output = new (int, int, int)?[width * height];
 

--- a/src/RustPlusApi.Extensions.DependencyInjection/RustPlusFactory.cs
+++ b/src/RustPlusApi.Extensions.DependencyInjection/RustPlusFactory.cs
@@ -10,7 +10,8 @@ namespace RustPlusApi.Extensions.DependencyInjection;
 /// </summary>
 /// <param name="loggerFactory">The host's logger factory; <see langword="null"/> disables client logging.</param>
 /// <param name="options">The configured socket tuning options.</param>
-internal sealed class RustPlusFactory(ILoggerFactory? loggerFactory, IOptions<RustPlusSocketOptions> options) : IRustPlusFactory
+internal sealed class RustPlusFactory(ILoggerFactory? loggerFactory, IOptions<RustPlusSocketOptions> options)
+    : IRustPlusFactory
 {
     /// <inheritdoc />
     public IRustPlus Create(RustPlusConnection connection)

--- a/src/RustPlusApi.Extensions.DependencyInjection/RustPlusServiceCollectionExtensions.cs
+++ b/src/RustPlusApi.Extensions.DependencyInjection/RustPlusServiceCollectionExtensions.cs
@@ -6,7 +6,9 @@ using RustPlusApi;
 using RustPlusApi.Extensions.DependencyInjection;
 using RustPlusApi.Interfaces;
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure — MS convention for DI extension methods
 namespace Microsoft.Extensions.DependencyInjection;
+#pragma warning restore IDE0130
 
 /// <summary>Registers <see cref="IRustPlus"/> clients and the <see cref="IRustPlusFactory"/> into a service collection.</summary>
 public static class RustPlusServiceCollectionExtensions

--- a/src/RustPlusApi.Fcm.Extensions.DependencyInjection/RustPlusFcmFactory.cs
+++ b/src/RustPlusApi.Fcm.Extensions.DependencyInjection/RustPlusFcmFactory.cs
@@ -11,7 +11,8 @@ namespace RustPlusApi.Fcm.Extensions.DependencyInjection;
 /// </summary>
 /// <param name="loggerFactory">The host's logger factory; <see langword="null"/> disables listener logging.</param>
 /// <param name="options">The configured tuning options.</param>
-internal sealed class RustPlusFcmFactory(ILoggerFactory? loggerFactory, IOptions<RustPlusFcmSocketOptions> options) : IRustPlusFcmFactory
+internal sealed class RustPlusFcmFactory(ILoggerFactory? loggerFactory, IOptions<RustPlusFcmSocketOptions> options)
+    : IRustPlusFcmFactory
 {
     /// <inheritdoc />
     public IRustPlusFcm Create(Credentials credentials, ICollection<string>? persistentIds = null)

--- a/src/RustPlusApi.Fcm.Extensions.DependencyInjection/RustPlusFcmServiceCollectionExtensions.cs
+++ b/src/RustPlusApi.Fcm.Extensions.DependencyInjection/RustPlusFcmServiceCollectionExtensions.cs
@@ -6,7 +6,9 @@ using RustPlusApi.Fcm.Data;
 using RustPlusApi.Fcm.Extensions.DependencyInjection;
 using RustPlusApi.Fcm.Interfaces;
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure — MS convention for DI extension methods
 namespace Microsoft.Extensions.DependencyInjection;
+#pragma warning restore IDE0130
 
 /// <summary>Registers <see cref="IRustPlusFcm"/> listeners and the <see cref="IRustPlusFcmFactory"/> into a service collection.</summary>
 public static class RustPlusFcmServiceCollectionExtensions

--- a/src/RustPlusApi.Fcm.Registration/CredentialsStore.cs
+++ b/src/RustPlusApi.Fcm.Registration/CredentialsStore.cs
@@ -9,7 +9,10 @@ namespace RustPlusApi.Fcm.Registration;
 /// </summary>
 public static class CredentialsStore
 {
-    private static readonly JsonSerializerOptions Options = new() { WriteIndented = true };
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = true
+    };
 
     /// <summary>Serializes <paramref name="credentials"/> to an indented JSON string.</summary>
     /// <param name="credentials">The credentials to serialize.</param>

--- a/src/RustPlusApi.Fcm.Registration/FcmRegistration.cs
+++ b/src/RustPlusApi.Fcm.Registration/FcmRegistration.cs
@@ -33,7 +33,10 @@ public sealed class FcmRegistration(HttpClient? httpClient = null, int steamLogi
         return new Credentials
         {
             Gcm = gcm,
-            Fcm = new FcmToken { Token = fcmToken },
+            Fcm = new FcmToken
+            {
+                Token = fcmToken
+            },
             ExpoPushToken = expoToken
         };
     }
@@ -49,11 +52,13 @@ public sealed class FcmRegistration(HttpClient? httpClient = null, int steamLogi
     /// registration; the guard (missing ExpoPushToken) is unit-tested, the remainder is only
     /// validatable by a real run against the live endpoints.</remarks>
     [ExcludeFromCodeCoverage]
-    public async Task<string> RegisterWithRustPlusAsync(Credentials credentials, CancellationToken cancellationToken = default)
+    public async Task<string> RegisterWithRustPlusAsync(Credentials credentials,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(credentials.ExpoPushToken))
         {
-            throw new InvalidOperationException("Credentials are missing the Expo push token; call AcquireCredentialsAsync first.");
+            throw new InvalidOperationException(
+                "Credentials are missing the Expo push token; call AcquireCredentialsAsync first.");
         }
 
         var steamToken = await _steamLoginService.LoginAsync(cancellationToken).ConfigureAwait(false);

--- a/src/RustPlusApi.Fcm.Registration/Protobuf/CheckinContracts.cs
+++ b/src/RustPlusApi.Fcm.Registration/Protobuf/CheckinContracts.cs
@@ -13,14 +13,19 @@ public sealed class ChromeBuildProto
     {
         /// <summary>Windows.</summary>
         Win = 1,
+
         /// <summary>macOS.</summary>
         Mac = 2,
+
         /// <summary>Linux.</summary>
         Linux = 3,
+
         /// <summary>Chrome OS.</summary>
         Cros = 4,
+
         /// <summary>iOS.</summary>
         Ios = 5,
+
         /// <summary>Android.</summary>
         Android = 6
     }
@@ -30,24 +35,31 @@ public sealed class ChromeBuildProto
     {
         /// <summary>Stable channel.</summary>
         Stable = 1,
+
         /// <summary>Beta channel.</summary>
         Beta = 2,
+
         /// <summary>Dev channel.</summary>
         Dev = 3,
+
         /// <summary>Canary channel.</summary>
         Canary = 4,
+
         /// <summary>Unknown channel.</summary>
         Unknown = 5
     }
 
     /// <summary>Host platform.</summary>
-    [ProtoMember(1)] public PlatformType? Platform { get; set; }
+    [ProtoMember(1)]
+    public PlatformType? Platform { get; set; }
 
     /// <summary>Chrome version string (e.g. <c>63.0.3234.0</c>).</summary>
-    [ProtoMember(2)] public string? ChromeVersion { get; set; }
+    [ProtoMember(2)]
+    public string? ChromeVersion { get; set; }
 
     /// <summary>Chrome release channel.</summary>
-    [ProtoMember(3)] public ChannelType? Channel { get; set; }
+    [ProtoMember(3)]
+    public ChannelType? Channel { get; set; }
 }
 
 /// <summary>Android check-in descriptor embedded in the check-in request.</summary>
@@ -59,22 +71,28 @@ public sealed class AndroidCheckinProto
     {
         /// <summary>Android OS device.</summary>
         DeviceAndroidOs = 1,
+
         /// <summary>iOS device.</summary>
         DeviceIosOs = 2,
+
         /// <summary>Chrome browser (used by push-receiver).</summary>
         DeviceChromeBrowser = 3,
+
         /// <summary>Chrome OS device.</summary>
         DeviceChromeOs = 4
     }
 
     /// <summary>Timestamp of the last successful check-in, in milliseconds since epoch.</summary>
-    [ProtoMember(2)] public long? LastCheckinMsec { get; set; }
+    [ProtoMember(2)]
+    public long? LastCheckinMsec { get; set; }
 
     /// <summary>Device type reported to GCM.</summary>
-    [ProtoMember(12)] public DeviceType? Type { get; set; }
+    [ProtoMember(12)]
+    public DeviceType? Type { get; set; }
 
     /// <summary>Chrome build details included when <see cref="Type"/> is <see cref="DeviceType.DeviceChromeBrowser"/>.</summary>
-    [ProtoMember(13)] public ChromeBuildProto? ChromeBuild { get; set; }
+    [ProtoMember(13)]
+    public ChromeBuildProto? ChromeBuild { get; set; }
 }
 
 /// <summary>Protobuf request body for the GCM check-in endpoint.</summary>
@@ -82,19 +100,24 @@ public sealed class AndroidCheckinProto
 public sealed class AndroidCheckinRequest
 {
     /// <summary>Existing Android ID, or zero for the first check-in.</summary>
-    [ProtoMember(2)] public long? Id { get; set; }
+    [ProtoMember(2)]
+    public long? Id { get; set; }
 
     /// <summary>Android check-in descriptor.</summary>
-    [ProtoMember(4)] public AndroidCheckinProto? Checkin { get; set; }
+    [ProtoMember(4)]
+    public AndroidCheckinProto? Checkin { get; set; }
 
     /// <summary>Existing security token, or zero for the first check-in.</summary>
-    [ProtoMember(13, DataFormat = DataFormat.FixedSize)] public ulong? SecurityToken { get; set; }
+    [ProtoMember(13, DataFormat = DataFormat.FixedSize)]
+    public ulong? SecurityToken { get; set; }
 
     /// <summary>Check-in protocol version (3 for the Chrome-browser flow).</summary>
-    [ProtoMember(14)] public int? Version { get; set; }
+    [ProtoMember(14)]
+    public int? Version { get; set; }
 
     /// <summary>User serial number (0 for the default user).</summary>
-    [ProtoMember(22)] public int? UserSerialNumber { get; set; }
+    [ProtoMember(22)]
+    public int? UserSerialNumber { get; set; }
 }
 
 /// <summary>Protobuf response body from the GCM check-in endpoint.</summary>
@@ -102,11 +125,14 @@ public sealed class AndroidCheckinRequest
 public sealed class AndroidCheckinResponse
 {
     /// <summary><see langword="true"/> when the check-in was accepted by the server.</summary>
-    [ProtoMember(1)] public bool? StatsOk { get; set; }
+    [ProtoMember(1)]
+    public bool? StatsOk { get; set; }
 
     /// <summary>The assigned Android ID (GCM device identity).</summary>
-    [ProtoMember(7, DataFormat = DataFormat.FixedSize)] public ulong? AndroidId { get; set; }
+    [ProtoMember(7, DataFormat = DataFormat.FixedSize)]
+    public ulong? AndroidId { get; set; }
 
     /// <summary>The security token paired with <see cref="AndroidId"/>.</summary>
-    [ProtoMember(8, DataFormat = DataFormat.FixedSize)] public ulong? SecurityToken { get; set; }
+    [ProtoMember(8, DataFormat = DataFormat.FixedSize)]
+    public ulong? SecurityToken { get; set; }
 }

--- a/src/RustPlusApi.Fcm.Registration/RegistrationConstants.cs
+++ b/src/RustPlusApi.Fcm.Registration/RegistrationConstants.cs
@@ -51,7 +51,8 @@ public static class RegistrationConstants
     public const string FcmRegisterUrl = "https://android.clients.google.com/c2dm/register3";
 
     /// <summary>Firebase Installations Service (FIS) endpoint for the Rust Companion project.</summary>
-    public const string FirebaseInstallationsUrl = "https://firebaseinstallations.googleapis.com/v1/projects/" + ProjectId + "/installations";
+    public const string FirebaseInstallationsUrl =
+        "https://firebaseinstallations.googleapis.com/v1/projects/" + ProjectId + "/installations";
 
     /// <summary>Expo push token exchange endpoint.</summary>
     public const string ExpoPushTokenUrl = "https://exp.host/--/api/v2/push/getExpoPushToken";

--- a/src/RustPlusApi.Fcm.Registration/Steps/AndroidFcmRegister.cs
+++ b/src/RustPlusApi.Fcm.Registration/Steps/AndroidFcmRegister.cs
@@ -120,7 +120,8 @@ public sealed class AndroidFcmRegister(HttpClient? httpClient = null)
     /// <param name="firebaseInstallationToken">Firebase installation auth token from <see cref="InstallAsync"/>.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <exception cref="InvalidOperationException">Thrown when FCM registration fails after multiple attempts.</exception>
-    public async Task<string> RegisterFcmAsync(Gcm gcm, string firebaseInstallationToken,
+    public async Task<string> RegisterFcmAsync(Gcm gcm,
+        string firebaseInstallationToken,
         CancellationToken cancellationToken = default)
     {
         var form = new Dictionary<string, string>

--- a/src/RustPlusApi.Fcm.Registration/Steps/AndroidFcmRegister.cs
+++ b/src/RustPlusApi.Fcm.Registration/Steps/AndroidFcmRegister.cs
@@ -73,8 +73,7 @@ public sealed class AndroidFcmRegister(HttpClient? httpClient = null)
 
         return new Gcm
         {
-            AndroidId = response.AndroidId ?? 0,
-            SecurityToken = response.SecurityToken ?? 0
+            AndroidId = response.AndroidId ?? 0, SecurityToken = response.SecurityToken ?? 0
         };
     }
 

--- a/src/RustPlusApi.Fcm.Registration/Steps/AndroidFcmRegister.cs
+++ b/src/RustPlusApi.Fcm.Registration/Steps/AndroidFcmRegister.cs
@@ -94,7 +94,10 @@ public sealed class AndroidFcmRegister(HttpClient? httpClient = null)
         });
 
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
-        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, url) { Content = content };
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = content
+        };
         requestMessage.Headers.TryAddWithoutValidation("x-goog-api-key", RegistrationConstants.ApiKey);
         requestMessage.Headers.TryAddWithoutValidation("X-Android-Package", RegistrationConstants.AndroidPackageName);
         requestMessage.Headers.TryAddWithoutValidation("X-Android-Cert", RegistrationConstants.AndroidPackageCert);
@@ -117,7 +120,8 @@ public sealed class AndroidFcmRegister(HttpClient? httpClient = null)
     /// <param name="firebaseInstallationToken">Firebase installation auth token from <see cref="InstallAsync"/>.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <exception cref="InvalidOperationException">Thrown when FCM registration fails after multiple attempts.</exception>
-    public async Task<string> RegisterFcmAsync(Gcm gcm, string firebaseInstallationToken, CancellationToken cancellationToken = default)
+    public async Task<string> RegisterFcmAsync(Gcm gcm, string firebaseInstallationToken,
+        CancellationToken cancellationToken = default)
     {
         var form = new Dictionary<string, string>
         {
@@ -151,7 +155,8 @@ public sealed class AndroidFcmRegister(HttpClient? httpClient = null)
             var securityToken = gcm.SecurityToken.ToString(CultureInfo.InvariantCulture);
             requestMessage.Headers.TryAddWithoutValidation("Authorization", $"AidLogin {androidId}:{securityToken}");
 
-            using var httpResponse = await _httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+            using var httpResponse =
+                await _httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
 #if NET10_0_OR_GREATER
             var responseText = await httpResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else

--- a/src/RustPlusApi.Fcm.Registration/Steps/RustCompanionClient.cs
+++ b/src/RustPlusApi.Fcm.Registration/Steps/RustCompanionClient.cs
@@ -26,10 +26,7 @@ public sealed class RustCompanionClient(HttpClient? httpClient = null)
     {
         var body = JsonSerializer.Serialize(new
         {
-            AuthToken = steamAuthToken,
-            DeviceId = deviceId,
-            PushKind = 3,
-            PushToken = expoPushToken
+            AuthToken = steamAuthToken, DeviceId = deviceId, PushKind = 3, PushToken = expoPushToken
         });
 
         using var content = new StringContent(body, Encoding.UTF8, "application/json");

--- a/src/RustPlusApi.Fcm.Registration/Steps/SteamLoginService.cs
+++ b/src/RustPlusApi.Fcm.Registration/Steps/SteamLoginService.cs
@@ -169,9 +169,7 @@ public sealed class SteamLoginService(int port = 3000)
     {
         var payload = JsonSerializer.Serialize(new
         {
-            id,
-            method,
-            @params = parameters
+            id, method, @params = parameters
         });
         var bytes = Encoding.UTF8.GetBytes(payload);
         await socket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, cancellationToken)

--- a/src/RustPlusApi.Fcm.Registration/Steps/SteamLoginService.cs
+++ b/src/RustPlusApi.Fcm.Registration/Steps/SteamLoginService.cs
@@ -82,7 +82,8 @@ public sealed class SteamLoginService(int port = 3000)
 
     // --- DevTools protocol ---
 
-    private async Task<ClientWebSocket> ConnectAndInjectAsync(int debugPort, string startUrl,
+    private async Task<ClientWebSocket> ConnectAndInjectAsync(int debugPort,
+        string startUrl,
         CancellationToken cancellationToken)
     {
         var pageWebSocketUrl = await GetPageWebSocketUrlAsync(debugPort, cancellationToken).ConfigureAwait(false);
@@ -160,7 +161,10 @@ public sealed class SteamLoginService(int port = 3000)
         throw new InvalidOperationException("Chrome DevTools endpoint did not become available.");
     }
 
-    private static async Task SendAsync(ClientWebSocket socket, int id, string method, object parameters,
+    private static async Task SendAsync(ClientWebSocket socket,
+        int id,
+        string method,
+        object parameters,
         CancellationToken cancellationToken)
     {
         var payload = JsonSerializer.Serialize(new

--- a/src/RustPlusApi.Fcm.Registration/Steps/SteamLoginService.cs
+++ b/src/RustPlusApi.Fcm.Registration/Steps/SteamLoginService.cs
@@ -82,7 +82,8 @@ public sealed class SteamLoginService(int port = 3000)
 
     // --- DevTools protocol ---
 
-    private async Task<ClientWebSocket> ConnectAndInjectAsync(int debugPort, string startUrl, CancellationToken cancellationToken)
+    private async Task<ClientWebSocket> ConnectAndInjectAsync(int debugPort, string startUrl,
+        CancellationToken cancellationToken)
     {
         var pageWebSocketUrl = await GetPageWebSocketUrlAsync(debugPort, cancellationToken).ConfigureAwait(false);
 
@@ -104,31 +105,45 @@ public sealed class SteamLoginService(int port = 3000)
             $".catch(function () {{ window.location.href = '{callback}?token=' + encodeURIComponent(a.Token); }});" +
             " } } catch (e) {} } };";
 
-        await SendAsync(socket, 1, "Page.enable", new { }, cancellationToken).ConfigureAwait(false);
-        await SendAsync(socket, 2, "Page.addScriptToEvaluateOnNewDocument", new { source = shim }, cancellationToken).ConfigureAwait(false);
-        await SendAsync(socket, 3, "Page.navigate", new { url = startUrl }, cancellationToken).ConfigureAwait(false);
+        await SendAsync(socket, 1, "Page.enable", new
+        {
+        }, cancellationToken).ConfigureAwait(false);
+        await SendAsync(socket, 2, "Page.addScriptToEvaluateOnNewDocument", new
+        {
+            source = shim
+        }, cancellationToken).ConfigureAwait(false);
+        await SendAsync(socket, 3, "Page.navigate", new
+        {
+            url = startUrl
+        }, cancellationToken).ConfigureAwait(false);
 
         return socket;
     }
 
     private static async Task<string> GetPageWebSocketUrlAsync(int debugPort, CancellationToken cancellationToken)
     {
-        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        using var http = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(5)
+        };
 
         for (var attempt = 0; attempt < 50; attempt++)
         {
             try
             {
 #if NET10_0_OR_GREATER
-                var json = await http.GetStringAsync(new Uri($"http://localhost:{debugPort}/json"), cancellationToken).ConfigureAwait(false);
+                var json = await http.GetStringAsync(new Uri($"http://localhost:{debugPort}/json"), cancellationToken)
+                    .ConfigureAwait(false);
 #else
-                var json = await http.GetStringAsync(new Uri($"http://localhost:{debugPort}/json")).ConfigureAwait(false);
+                var json =
+                    await http.GetStringAsync(new Uri($"http://localhost:{debugPort}/json")).ConfigureAwait(false);
 #endif
                 using var document = JsonDocument.Parse(json);
                 foreach (var target in document.RootElement.EnumerateArray())
                 {
                     if (target.TryGetProperty("type", out var type) && type.GetString() == "page"
-                        && target.TryGetProperty("webSocketDebuggerUrl", out var url))
+                                                                    && target.TryGetProperty("webSocketDebuggerUrl",
+                                                                        out var url))
                     {
                         return url.GetString()!;
                     }
@@ -145,11 +160,18 @@ public sealed class SteamLoginService(int port = 3000)
         throw new InvalidOperationException("Chrome DevTools endpoint did not become available.");
     }
 
-    private static async Task SendAsync(ClientWebSocket socket, int id, string method, object parameters, CancellationToken cancellationToken)
+    private static async Task SendAsync(ClientWebSocket socket, int id, string method, object parameters,
+        CancellationToken cancellationToken)
     {
-        var payload = JsonSerializer.Serialize(new { id, method, @params = parameters });
+        var payload = JsonSerializer.Serialize(new
+        {
+            id,
+            method,
+            @params = parameters
+        });
         var bytes = Encoding.UTF8.GetBytes(payload);
-        await socket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, cancellationToken).ConfigureAwait(false);
+        await socket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private static async Task DrainAsync(ClientWebSocket socket, CancellationToken cancellationToken)
@@ -159,7 +181,8 @@ public sealed class SteamLoginService(int port = 3000)
         {
             while (socket.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
             {
-                var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken).ConfigureAwait(false);
+                var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken)
+                    .ConfigureAwait(false);
                 if (result.MessageType == WebSocketMessageType.Close)
                 {
                     break;
@@ -177,10 +200,10 @@ public sealed class SteamLoginService(int port = 3000)
     private static Process LaunchChrome(string workDir, string profileDir, int debugPort)
     {
         var (executable, prefixArguments) = ResolveChromeLaunch(workDir)
-            ?? throw new InvalidOperationException(
-                "Could not find Chrome/Chromium, which is required for the Steam login step. " +
-                "Install Google Chrome or Chromium (native or Flatpak), or set the CHROME_PATH " +
-                "environment variable to the executable.");
+                                            ?? throw new InvalidOperationException(
+                                                "Could not find Chrome/Chromium, which is required for the Steam login step. " +
+                                                "Install Google Chrome or Chromium (native or Flatpak), or set the CHROME_PATH " +
+                                                "environment variable to the executable.");
 
         Directory.CreateDirectory(profileDir);
 
@@ -188,13 +211,14 @@ public sealed class SteamLoginService(int port = 3000)
         {
             $"--user-data-dir={profileDir}",
             $"--remote-debugging-port={debugPort.ToString(System.Globalization.CultureInfo.InvariantCulture)}",
-            "--no-first-run",
-            "--no-default-browser-check",
-            "about:blank"
+            "--no-first-run", "--no-default-browser-check", "about:blank"
         };
         var arguments = prefixArguments.Concat(chromeArguments).ToArray();
 
-        var startInfo = new ProcessStartInfo(executable) { UseShellExecute = false };
+        var startInfo = new ProcessStartInfo(executable)
+        {
+            UseShellExecute = false
+        };
 #if NET10_0_OR_GREATER
         foreach (var argument in arguments)
         {
@@ -208,7 +232,8 @@ public sealed class SteamLoginService(int port = 3000)
                ?? throw new InvalidOperationException("Failed to launch Chrome/Chromium.");
     }
 
-    private static readonly string[] FlatpakAppIds = ["com.google.Chrome", "org.chromium.Chromium", "com.github.Eloston.UngoogledChromium"];
+    private static readonly string[] FlatpakAppIds =
+        ["com.google.Chrome", "org.chromium.Chromium", "com.github.Eloston.UngoogledChromium"];
 
     /// <summary>Resolves a native Chrome/Chromium binary, or a Flatpak launcher, with any prefix args.</summary>
     /// <param name="workDir">Temporary working directory passed to Flatpak's <c>--filesystem</c> flag when needed.</param>
@@ -238,8 +263,7 @@ public sealed class SteamLoginService(int port = 3000)
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var locations = new[]
         {
-            $"/var/lib/flatpak/app/{appId}",
-            Path.Combine(home, ".local", "share", "flatpak", "app", appId),
+            $"/var/lib/flatpak/app/{appId}", Path.Combine(home, ".local", "share", "flatpak", "app", appId),
         };
         return Array.Exists(locations, Directory.Exists);
     }
@@ -361,7 +385,9 @@ public sealed class SteamLoginService(int port = 3000)
     private static void TryDisposeSocket(ClientWebSocket? socket)
     {
         try
-        { socket?.Dispose(); }
+        {
+            socket?.Dispose();
+        }
         catch (Exception ex) { Debug.WriteLine($"[{nameof(SteamLoginService)}] Socket dispose failed: {ex.Message}"); }
     }
 

--- a/src/RustPlusApi.Fcm/Extensions/BodyToEventModel.cs
+++ b/src/RustPlusApi.Fcm/Extensions/BodyToEventModel.cs
@@ -19,9 +19,7 @@ public static class BodyToEventModel
     {
         return new EntityEvent
         {
-            EntityType = body.EntityType,
-            EntityId = body.EntityId,
-            EntityName = body.EntityName
+            EntityType = body.EntityType, EntityId = body.EntityId, EntityName = body.EntityName
         };
     }
 

--- a/src/RustPlusApi.Fcm/Extensions/MessageDataToEventModel.cs
+++ b/src/RustPlusApi.Fcm/Extensions/MessageDataToEventModel.cs
@@ -12,8 +12,7 @@ public static class MessageDataToEventModel
     {
         return new AlarmEvent
         {
-            Title = data.Title,
-            Message = data.Message
+            Title = data.Title, Message = data.Message
         };
     }
 }

--- a/src/RustPlusApi.Fcm/ProtoBuf/Mcs.cs
+++ b/src/RustPlusApi.Fcm/ProtoBuf/Mcs.cs
@@ -13,13 +13,16 @@ namespace McsProto;
 public sealed class HeartbeatPing
 {
     /// <summary>Monotonically increasing stream counter.</summary>
-    [ProtoMember(1)] public int? StreamId { get; set; }
+    [ProtoMember(1)]
+    public int? StreamId { get; set; }
 
     /// <summary>Last stream ID acknowledged by the sender.</summary>
-    [ProtoMember(2)] public int? LastStreamIdReceived { get; set; }
+    [ProtoMember(2)]
+    public int? LastStreamIdReceived { get; set; }
 
     /// <summary>Connection status flags.</summary>
-    [ProtoMember(3)] public long? Status { get; set; }
+    [ProtoMember(3)]
+    public long? Status { get; set; }
 }
 
 /// <summary>TAG: 1 — Heartbeat acknowledgment sent in response to a <see cref="HeartbeatPing"/>.</summary>
@@ -27,13 +30,16 @@ public sealed class HeartbeatPing
 public sealed class HeartbeatAck
 {
     /// <summary>Monotonically increasing stream counter.</summary>
-    [ProtoMember(1)] public int? StreamId { get; set; }
+    [ProtoMember(1)]
+    public int? StreamId { get; set; }
 
     /// <summary>Last stream ID acknowledged by the sender.</summary>
-    [ProtoMember(2)] public int? LastStreamIdReceived { get; set; }
+    [ProtoMember(2)]
+    public int? LastStreamIdReceived { get; set; }
 
     /// <summary>Connection status flags.</summary>
-    [ProtoMember(3)] public long? Status { get; set; }
+    [ProtoMember(3)]
+    public long? Status { get; set; }
 }
 
 /// <summary>Error detail attached to a <see cref="LoginResponse"/> or <see cref="IqStanza"/>.</summary>
@@ -41,16 +47,20 @@ public sealed class HeartbeatAck
 public sealed class ErrorInfo
 {
     /// <summary>Numeric error code.</summary>
-    [ProtoMember(1, IsRequired = true)] public int Code { get; set; }
+    [ProtoMember(1, IsRequired = true)]
+    public int Code { get; set; }
 
     /// <summary>Human-readable error description.</summary>
-    [ProtoMember(2)] public string? Message { get; set; }
+    [ProtoMember(2)]
+    public string? Message { get; set; }
 
     /// <summary>Error type string.</summary>
-    [ProtoMember(3)] public string? Type { get; set; }
+    [ProtoMember(3)]
+    public string? Type { get; set; }
 
     /// <summary>Optional protocol extension payload attached to the error.</summary>
-    [ProtoMember(4)] public Extension? Extension { get; set; }
+    [ProtoMember(4)]
+    public Extension? Extension { get; set; }
 }
 
 /// <summary>A key/value configuration setting exchanged during MCS login.</summary>
@@ -58,10 +68,12 @@ public sealed class ErrorInfo
 public sealed class Setting
 {
     /// <summary>Setting name.</summary>
-    [ProtoMember(1, IsRequired = true)] public string Name { get; set; } = null!;
+    [ProtoMember(1, IsRequired = true)]
+    public string Name { get; set; } = null!;
 
     /// <summary>Setting value.</summary>
-    [ProtoMember(2, IsRequired = true)] public string Value { get; set; } = null!;
+    [ProtoMember(2, IsRequired = true)]
+    public string Value { get; set; } = null!;
 }
 
 /// <summary>Heartbeat statistics uploaded to the server for diagnostics.</summary>
@@ -69,13 +81,16 @@ public sealed class Setting
 public sealed class HeartbeatStat
 {
     /// <summary>IP address of the MCS endpoint.</summary>
-    [ProtoMember(1, IsRequired = true)] public string Ip { get; set; } = null!;
+    [ProtoMember(1, IsRequired = true)]
+    public string Ip { get; set; } = null!;
 
     /// <summary><see langword="true"/> if the heartbeat timed out.</summary>
-    [ProtoMember(2, IsRequired = true)] public bool Timeout { get; set; }
+    [ProtoMember(2, IsRequired = true)]
+    public bool Timeout { get; set; }
 
     /// <summary>Configured heartbeat interval, in milliseconds.</summary>
-    [ProtoMember(3, IsRequired = true)] public int IntervalMs { get; set; }
+    [ProtoMember(3, IsRequired = true)]
+    public int IntervalMs { get; set; }
 }
 
 /// <summary>Server-driven heartbeat configuration returned in <see cref="LoginResponse"/>.</summary>
@@ -83,13 +98,16 @@ public sealed class HeartbeatStat
 public sealed class HeartbeatConfig
 {
     /// <summary>Whether the client should upload <see cref="HeartbeatStat"/> data.</summary>
-    [ProtoMember(1)] public bool? UploadStat { get; set; }
+    [ProtoMember(1)]
+    public bool? UploadStat { get; set; }
 
     /// <summary>IP address to use for heartbeat probes.</summary>
-    [ProtoMember(2)] public string? Ip { get; set; }
+    [ProtoMember(2)]
+    public string? Ip { get; set; }
 
     /// <summary>Heartbeat interval the server requests, in milliseconds.</summary>
-    [ProtoMember(3)] public int? IntervalMs { get; set; }
+    [ProtoMember(3)]
+    public int? IntervalMs { get; set; }
 }
 
 /// <summary>Client-reported connectivity event, bundled into <see cref="LoginRequest.ClientEvents"/>.</summary>
@@ -101,34 +119,44 @@ public sealed class ClientEvent
     {
         /// <summary>Unknown / unset event.</summary>
         Unknown = 0,
+
         /// <summary>Some events were discarded due to capacity.</summary>
         DiscardedEvents = 1,
+
         /// <summary>A connection attempt failed.</summary>
         FailedConnection = 2,
+
         /// <summary>A connection attempt succeeded.</summary>
         SuccessfulConnection = 3,
     }
 
     /// <summary>Lowercase to avoid clashing with the nested <see cref="Type"/> enum.</summary>
-    [ProtoMember(1)] public Type? type { get; set; }
+    [ProtoMember(1)]
+    public Type? type { get; set; }
 
     /// <summary>Number of events discarded (set for <see cref="Type.DiscardedEvents"/>).</summary>
-    [ProtoMember(100)] public uint? NumberDiscardedEvents { get; set; }
+    [ProtoMember(100)]
+    public uint? NumberDiscardedEvents { get; set; }
 
     /// <summary>Network type code (e.g. 1 = WiFi).</summary>
-    [ProtoMember(200)] public int? NetworkType { get; set; }
+    [ProtoMember(200)]
+    public int? NetworkType { get; set; }
 
     /// <summary>UTC epoch milliseconds when the connection attempt started.</summary>
-    [ProtoMember(202)] public ulong? TimeConnectionStartedMs { get; set; }
+    [ProtoMember(202)]
+    public ulong? TimeConnectionStartedMs { get; set; }
 
     /// <summary>UTC epoch milliseconds when the connection attempt ended.</summary>
-    [ProtoMember(203)] public ulong? TimeConnectionEndedMs { get; set; }
+    [ProtoMember(203)]
+    public ulong? TimeConnectionEndedMs { get; set; }
 
     /// <summary>OS-level error code when the connection failed.</summary>
-    [ProtoMember(204)] public int? ErrorCode { get; set; }
+    [ProtoMember(204)]
+    public int? ErrorCode { get; set; }
 
     /// <summary>UTC epoch milliseconds when the connection was fully established.</summary>
-    [ProtoMember(300)] public ulong? TimeConnectionEstablishedMs { get; set; }
+    [ProtoMember(300)]
+    public ulong? TimeConnectionEstablishedMs { get; set; }
 }
 
 /// <summary>TAG: 2 — MCS login request sent immediately after the TLS handshake.</summary>
@@ -143,55 +171,72 @@ public sealed class LoginRequest
     }
 
     /// <summary>Client ID string (e.g. <c>chrome-63.0.3234.0</c>).</summary>
-    [ProtoMember(1, IsRequired = true)] public string Id { get; set; } = null!;
+    [ProtoMember(1, IsRequired = true)]
+    public string Id { get; set; } = null!;
 
     /// <summary>Domain for the XMPP JID (always <c>mcs.android.com</c>).</summary>
-    [ProtoMember(2, IsRequired = true)] public string Domain { get; set; } = null!;
+    [ProtoMember(2, IsRequired = true)]
+    public string Domain { get; set; } = null!;
 
     /// <summary>GCM Android ID, used as the XMPP user part.</summary>
-    [ProtoMember(3, IsRequired = true)] public string User { get; set; } = null!;
+    [ProtoMember(3, IsRequired = true)]
+    public string User { get; set; } = null!;
 
     /// <summary>GCM Android ID, used as the XMPP resource part.</summary>
-    [ProtoMember(4, IsRequired = true)] public string Resource { get; set; } = null!;
+    [ProtoMember(4, IsRequired = true)]
+    public string Resource { get; set; } = null!;
 
     /// <summary>GCM security token used to authenticate.</summary>
-    [ProtoMember(5, IsRequired = true)] public string AuthToken { get; set; } = null!;
+    [ProtoMember(5, IsRequired = true)]
+    public string AuthToken { get; set; } = null!;
 
     /// <summary>Android device ID string (hex-encoded Android ID prefixed with <c>android-</c>).</summary>
-    [ProtoMember(6)] public string? DeviceId { get; set; }
+    [ProtoMember(6)]
+    public string? DeviceId { get; set; }
 
     /// <summary>Last RMQ (reliable message queue) ID seen by the client, for resumption.</summary>
-    [ProtoMember(7)] public long? LastRmqId { get; set; }
+    [ProtoMember(7)]
+    public long? LastRmqId { get; set; }
 
     /// <summary>Client configuration settings.</summary>
-    [ProtoMember(8)] public List<Setting> Settings { get; } = [];
+    [ProtoMember(8)]
+    public List<Setting> Settings { get; } = [];
 
     /// <summary>Persistent IDs the client has already processed and wants the server to skip.</summary>
-    [ProtoMember(10)] public List<string> ReceivedPersistentIds { get; } = [];
+    [ProtoMember(10)]
+    public List<string> ReceivedPersistentIds { get; } = [];
 
     /// <summary>Whether the client supports adaptive heartbeat intervals.</summary>
-    [ProtoMember(12)] public bool? AdaptiveHeartbeat { get; set; }
+    [ProtoMember(12)]
+    public bool? AdaptiveHeartbeat { get; set; }
 
     /// <summary>Heartbeat statistics from the previous session, if any.</summary>
-    [ProtoMember(13)] public HeartbeatStat? HeartbeatStat { get; set; }
+    [ProtoMember(13)]
+    public HeartbeatStat? HeartbeatStat { get; set; }
 
     /// <summary>Whether the client supports RMQ2 (reliable message queue v2).</summary>
-    [ProtoMember(14)] public bool? UseRmq2 { get; set; }
+    [ProtoMember(14)]
+    public bool? UseRmq2 { get; set; }
 
     /// <summary>Google account ID, if authenticated.</summary>
-    [ProtoMember(15)] public long? AccountId { get; set; }
+    [ProtoMember(15)]
+    public long? AccountId { get; set; }
 
     /// <summary>Lowercase to avoid clashing with the nested <see cref="AuthService"/> enum.</summary>
-    [ProtoMember(16)] public AuthService? auth_service { get; set; }
+    [ProtoMember(16)]
+    public AuthService? auth_service { get; set; }
 
     /// <summary>Network type code at the time of login (e.g. 1 = WiFi).</summary>
-    [ProtoMember(17)] public int? NetworkType { get; set; }
+    [ProtoMember(17)]
+    public int? NetworkType { get; set; }
 
     /// <summary>Connection status flags.</summary>
-    [ProtoMember(18)] public long? Status { get; set; }
+    [ProtoMember(18)]
+    public long? Status { get; set; }
 
     /// <summary>Client connectivity events from the previous session.</summary>
-    [ProtoMember(22)] public List<ClientEvent> ClientEvents { get; } = [];
+    [ProtoMember(22)]
+    public List<ClientEvent> ClientEvents { get; } = [];
 }
 
 /// <summary>TAG: 3 — Server response to a <see cref="LoginRequest"/>.</summary>
@@ -199,28 +244,36 @@ public sealed class LoginRequest
 public sealed class LoginResponse
 {
     /// <summary>The XMPP JID assigned to this session by the server.</summary>
-    [ProtoMember(1, IsRequired = true)] public string Id { get; set; } = null!;
+    [ProtoMember(1, IsRequired = true)]
+    public string Id { get; set; } = null!;
 
     /// <summary>Full JID including resource, if assigned.</summary>
-    [ProtoMember(2)] public string? Jid { get; set; }
+    [ProtoMember(2)]
+    public string? Jid { get; set; }
 
     /// <summary>Error detail if the login was rejected.</summary>
-    [ProtoMember(3)] public ErrorInfo? Error { get; set; }
+    [ProtoMember(3)]
+    public ErrorInfo? Error { get; set; }
 
     /// <summary>Server configuration settings for the session.</summary>
-    [ProtoMember(4)] public List<Setting> Settings { get; } = [];
+    [ProtoMember(4)]
+    public List<Setting> Settings { get; } = [];
 
     /// <summary>Initial stream ID assigned by the server.</summary>
-    [ProtoMember(5)] public int? StreamId { get; set; }
+    [ProtoMember(5)]
+    public int? StreamId { get; set; }
 
     /// <summary>Last stream ID the server has received from the client.</summary>
-    [ProtoMember(6)] public int? LastStreamIdReceived { get; set; }
+    [ProtoMember(6)]
+    public int? LastStreamIdReceived { get; set; }
 
     /// <summary>Server-requested heartbeat configuration.</summary>
-    [ProtoMember(7)] public HeartbeatConfig? HeartbeatConfig { get; set; }
+    [ProtoMember(7)]
+    public HeartbeatConfig? HeartbeatConfig { get; set; }
 
     /// <summary>Server UTC timestamp at the moment the response was generated, in milliseconds.</summary>
-    [ProtoMember(8)] public long? ServerTimestamp { get; set; }
+    [ProtoMember(8)]
+    public long? ServerTimestamp { get; set; }
 }
 
 /// <summary>XMPP stream-level error sent before the server closes the connection.</summary>
@@ -228,10 +281,12 @@ public sealed class LoginResponse
 public sealed class StreamErrorStanza
 {
     /// <summary>XMPP stream error condition name (e.g. <c>conflict</c>).</summary>
-    [ProtoMember(1, IsRequired = true)] public string Type { get; set; } = null!;
+    [ProtoMember(1, IsRequired = true)]
+    public string Type { get; set; } = null!;
 
     /// <summary>Optional human-readable description of the error.</summary>
-    [ProtoMember(2)] public string? Text { get; set; }
+    [ProtoMember(2)]
+    public string? Text { get; set; }
 }
 
 /// <summary>TAG: 4 — Signals that the server is closing the connection.</summary>
@@ -243,10 +298,12 @@ public sealed class Close;
 public sealed class Extension
 {
     /// <summary>Extension type identifier.</summary>
-    [ProtoMember(1, IsRequired = true)] public int Id { get; set; }
+    [ProtoMember(1, IsRequired = true)]
+    public int Id { get; set; }
 
     /// <summary>Raw binary payload of the extension.</summary>
-    [ProtoMember(2, IsRequired = true)] public byte[] Data { get; set; } = null!;
+    [ProtoMember(2, IsRequired = true)]
+    public byte[] Data { get; set; } = null!;
 }
 
 /// <summary>TAG: 7 — XMPP IQ (info/query) stanza used for server-initiated operations.</summary>
@@ -258,49 +315,64 @@ public sealed class IqStanza
     {
         /// <summary>Request information.</summary>
         Get = 0,
+
         /// <summary>Set or update a value.</summary>
         Set = 1,
+
         /// <summary>Successful response to a Get or Set.</summary>
         Result = 2,
+
         /// <summary>Error response.</summary>
         IqError = 3,
     }
 
     /// <summary>RMQ message ID for reliable delivery tracking.</summary>
-    [ProtoMember(1)] public long? RmqId { get; set; }
+    [ProtoMember(1)]
+    public long? RmqId { get; set; }
 
     /// <summary>IQ stanza type.</summary>
-    [ProtoMember(2, IsRequired = true)] public IqType Type { get; set; }
+    [ProtoMember(2, IsRequired = true)]
+    public IqType Type { get; set; }
 
     /// <summary>Stanza ID for matching requests and responses.</summary>
-    [ProtoMember(3, IsRequired = true)] public string Id { get; set; } = null!;
+    [ProtoMember(3, IsRequired = true)]
+    public string Id { get; set; } = null!;
 
     /// <summary>Sender JID.</summary>
-    [ProtoMember(4)] public string? From { get; set; }
+    [ProtoMember(4)]
+    public string? From { get; set; }
 
     /// <summary>Recipient JID.</summary>
-    [ProtoMember(5)] public string? To { get; set; }
+    [ProtoMember(5)]
+    public string? To { get; set; }
 
     /// <summary>Error detail if this is an error response.</summary>
-    [ProtoMember(6)] public ErrorInfo? Error { get; set; }
+    [ProtoMember(6)]
+    public ErrorInfo? Error { get; set; }
 
     /// <summary>Protocol extension payload.</summary>
-    [ProtoMember(7)] public Extension? Extension { get; set; }
+    [ProtoMember(7)]
+    public Extension? Extension { get; set; }
 
     /// <summary>Persistent message ID for deduplication on reconnect.</summary>
-    [ProtoMember(8)] public string? PersistentId { get; set; }
+    [ProtoMember(8)]
+    public string? PersistentId { get; set; }
 
     /// <summary>Stream ID of this message.</summary>
-    [ProtoMember(9)] public int? StreamId { get; set; }
+    [ProtoMember(9)]
+    public int? StreamId { get; set; }
 
     /// <summary>Last stream ID received by the sender.</summary>
-    [ProtoMember(10)] public int? LastStreamIdReceived { get; set; }
+    [ProtoMember(10)]
+    public int? LastStreamIdReceived { get; set; }
 
     /// <summary>Google account ID associated with this stanza.</summary>
-    [ProtoMember(11)] public long? AccountId { get; set; }
+    [ProtoMember(11)]
+    public long? AccountId { get; set; }
 
     /// <summary>Status flags.</summary>
-    [ProtoMember(12)] public long? Status { get; set; }
+    [ProtoMember(12)]
+    public long? Status { get; set; }
 }
 
 /// <summary>A key/value pair of application-specific data carried inside a <see cref="DataMessageStanza"/>.</summary>
@@ -308,10 +380,12 @@ public sealed class IqStanza
 public sealed class AppData
 {
     /// <summary>Data key.</summary>
-    [ProtoMember(1, IsRequired = true)] public string Key { get; set; } = null!;
+    [ProtoMember(1, IsRequired = true)]
+    public string Key { get; set; } = null!;
 
     /// <summary>Data value.</summary>
-    [ProtoMember(2, IsRequired = true)] public string Value { get; set; } = null!;
+    [ProtoMember(2, IsRequired = true)]
+    public string Value { get; set; } = null!;
 }
 
 /// <summary>TAG: 8 — A push notification data message delivered from the FCM upstream.</summary>
@@ -319,58 +393,76 @@ public sealed class AppData
 public sealed class DataMessageStanza
 {
     /// <summary>Application-level message ID.</summary>
-    [ProtoMember(2)] public string? Id { get; set; }
+    [ProtoMember(2)]
+    public string? Id { get; set; }
 
     /// <summary>Sender address (GCM sender ID or project number).</summary>
-    [ProtoMember(3, IsRequired = true)] public string From { get; set; } = null!;
+    [ProtoMember(3, IsRequired = true)]
+    public string From { get; set; } = null!;
 
     /// <summary>Recipient address.</summary>
-    [ProtoMember(4)] public string? To { get; set; }
+    [ProtoMember(4)]
+    public string? To { get; set; }
 
     /// <summary>Application package name / category that identifies the target app.</summary>
-    [ProtoMember(5, IsRequired = true)] public string Category { get; set; } = null!;
+    [ProtoMember(5, IsRequired = true)]
+    public string Category { get; set; } = null!;
 
     /// <summary>FCM registration token of the recipient device.</summary>
-    [ProtoMember(6)] public string? Token { get; set; }
+    [ProtoMember(6)]
+    public string? Token { get; set; }
 
     /// <summary>Application-defined key/value pairs carrying the notification payload.</summary>
-    [ProtoMember(7)] public List<AppData> AppDatas { get; } = [];
+    [ProtoMember(7)]
+    public List<AppData> AppDatas { get; } = [];
 
     /// <summary><see langword="true"/> if the message was delivered from a trusted server.</summary>
-    [ProtoMember(8)] public bool? FromTrustedServer { get; set; }
+    [ProtoMember(8)]
+    public bool? FromTrustedServer { get; set; }
 
     /// <summary>Persistent message ID used for deduplication on reconnect.</summary>
-    [ProtoMember(9)] public string? PersistentId { get; set; }
+    [ProtoMember(9)]
+    public string? PersistentId { get; set; }
 
     /// <summary>Stream ID of this message.</summary>
-    [ProtoMember(10)] public int? StreamId { get; set; }
+    [ProtoMember(10)]
+    public int? StreamId { get; set; }
 
     /// <summary>Last stream ID received by the sender.</summary>
-    [ProtoMember(11)] public int? LastStreamIdReceived { get; set; }
+    [ProtoMember(11)]
+    public int? LastStreamIdReceived { get; set; }
 
     /// <summary>FCM registration ID of the device.</summary>
-    [ProtoMember(13)] public string? RegId { get; set; }
+    [ProtoMember(13)]
+    public string? RegId { get; set; }
 
     /// <summary>Google account user ID associated with this message.</summary>
-    [ProtoMember(16)] public long? DeviceUserId { get; set; }
+    [ProtoMember(16)]
+    public long? DeviceUserId { get; set; }
 
     /// <summary>Time-to-live for the message, in seconds.</summary>
-    [ProtoMember(17)] public int? Ttl { get; set; }
+    [ProtoMember(17)]
+    public int? Ttl { get; set; }
 
     /// <summary>UTC epoch milliseconds when the message was enqueued on the FCM server.</summary>
-    [ProtoMember(18)] public long? Sent { get; set; }
+    [ProtoMember(18)]
+    public long? Sent { get; set; }
 
     /// <summary>Number of messages queued ahead of this one at the time of delivery.</summary>
-    [ProtoMember(19)] public int? Queued { get; set; }
+    [ProtoMember(19)]
+    public int? Queued { get; set; }
 
     /// <summary>Status flags.</summary>
-    [ProtoMember(20)] public long? Status { get; set; }
+    [ProtoMember(20)]
+    public long? Status { get; set; }
 
     /// <summary>Raw binary payload, if present.</summary>
-    [ProtoMember(21)] public byte[]? RawData { get; set; }
+    [ProtoMember(21)]
+    public byte[]? RawData { get; set; }
 
     /// <summary><see langword="true"/> if the client should ack this message immediately without batching.</summary>
-    [ProtoMember(24)] public bool? ImmediateAck { get; set; }
+    [ProtoMember(24)]
+    public bool? ImmediateAck { get; set; }
 }
 
 /// <summary>Acknowledges receipt of all messages up to the current stream ID.</summary>
@@ -382,5 +474,6 @@ public sealed class StreamAck;
 public sealed class SelectiveAck
 {
     /// <summary>Persistent IDs of the messages being acknowledged.</summary>
-    [ProtoMember(1)] public List<string> Ids { get; } = [];
+    [ProtoMember(1)]
+    public List<string> Ids { get; } = [];
 }

--- a/src/RustPlusApi.Fcm/RustPlusFcm.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcm.cs
@@ -16,7 +16,11 @@ namespace RustPlusApi.Fcm;
 /// <param name="options">Tuning options (heartbeat interval, inactivity timeout); defaults are used when <see langword="null"/>.</param>
 /// <param name="loggerFactory">Routes the client's diagnostics into your logging stack; logging is
 /// disabled (a no-op <c>NullLogger</c>) when <see langword="null"/>.</param>
-public class RustPlusFcm(Credentials credentials, ICollection<string>? persistentIds = null, RustPlusFcmSocketOptions? options = null, ILoggerFactory? loggerFactory = null)
+public class RustPlusFcm(
+    Credentials credentials,
+    ICollection<string>? persistentIds = null,
+    RustPlusFcmSocketOptions? options = null,
+    ILoggerFactory? loggerFactory = null)
     : RustPlusFcmSocket(credentials, persistentIds, options, loggerFactory), IRustPlusFcm
 {
     /// <summary>

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -47,8 +47,7 @@ public abstract class RustPlusFcmSocket(
         ? new RustPlusFcmSocketOptions()
         : new()
         {
-            HeartbeatInterval = options.HeartbeatInterval,
-            InactivityTimeout = options.InactivityTimeout,
+            HeartbeatInterval = options.HeartbeatInterval, InactivityTimeout = options.InactivityTimeout,
         };
 
     /// <summary>The client's logger; <c>NullLogger</c> when no factory was supplied.
@@ -79,8 +78,7 @@ public abstract class RustPlusFcmSocket(
 
     private readonly JsonSerializerOptions _parsingOptions = new()
     {
-        PropertyNameCaseInsensitive = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        PropertyNameCaseInsensitive = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
     /// <summary>
@@ -180,8 +178,7 @@ public abstract class RustPlusFcmSocket(
                 {
                     new Setting
                     {
-                        Name = "new_vc",
-                        Value = "1"
+                        Name = "new_vc", Value = "1"
                     }
                 },
                 ClientEvents =
@@ -498,8 +495,7 @@ public abstract class RustPlusFcmSocket(
             {
                 await OnMessageAsync(new MessageEventArgs
                 {
-                    Tag = messageTag,
-                    Object = Activator.CreateInstance(type)
+                    Tag = messageTag, Object = Activator.CreateInstance(type)
                 }).ConfigureAwait(false);
                 return;
             }
@@ -511,8 +507,7 @@ public abstract class RustPlusFcmSocket(
 
             await OnMessageAsync(new MessageEventArgs
             {
-                Tag = messageTag,
-                Object = message
+                Tag = messageTag, Object = message
             }).ConfigureAwait(false);
         }
         catch (Exception ex)
@@ -642,9 +637,7 @@ public abstract class RustPlusFcmSocket(
         Logger.LogRespondingToPing(ping.StreamId, ping.LastStreamIdReceived, ping.Status);
         var pingResponse = new HeartbeatAck
         {
-            StreamId = (ping.StreamId ?? 0) + 1,
-            LastStreamIdReceived = ping.StreamId,
-            Status = ping.Status
+            StreamId = (ping.StreamId ?? 0) + 1, LastStreamIdReceived = ping.StreamId, Status = ping.Status
         };
 
         await SendPacketAsync(pingResponse).ConfigureAwait(false);

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -170,13 +170,24 @@ public abstract class RustPlusFcmSocket(
                 AuthToken = credentials.Gcm.SecurityToken.ToString(CultureInfo.InvariantCulture),
                 Id = "chrome-63.0.3234.0",
                 Domain = "mcs.android.com",
-                DeviceId = $"android-{BigInteger.Parse(credentials.Gcm.AndroidId.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture):X}",
+                DeviceId =
+                    $"android-{BigInteger.Parse(credentials.Gcm.AndroidId.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture):X}",
                 NetworkType = 1,
                 Resource = credentials.Gcm.AndroidId.ToString(CultureInfo.InvariantCulture),
                 User = credentials.Gcm.AndroidId.ToString(CultureInfo.InvariantCulture),
                 UseRmq2 = true,
-                Settings = { new Setting { Name = "new_vc", Value = "1" } },
-                ClientEvents = { new ClientEvent() },
+                Settings =
+                {
+                    new Setting
+                    {
+                        Name = "new_vc",
+                        Value = "1"
+                    }
+                },
+                ClientEvents =
+                {
+                    new ClientEvent()
+                },
             };
 
             if (persistentIds != null)
@@ -314,7 +325,10 @@ public abstract class RustPlusFcmSocket(
     /// </summary>
     private async Task WaitForReceiveLoopAsync()
     {
-        var loops = new[] { _receiveLoop, _heartbeatLoop }
+        var loops = new[]
+            {
+                _receiveLoop, _heartbeatLoop
+            }
             .Where(static t => t is not null)
             .Cast<Task>()
             .ToArray();
@@ -433,7 +447,8 @@ public abstract class RustPlusFcmSocket(
 
             if (type != typeof(LoginResponse))
             {
-                throw new InvalidOperationException($"Got wrong login response. Expected {nameof(LoginResponse)}, got {type.Name}");
+                throw new InvalidOperationException(
+                    $"Got wrong login response. Expected {nameof(LoginResponse)}, got {type.Name}");
             }
 
             await OnGotMessageBytesAsync(payload, type).ConfigureAwait(false);
@@ -481,7 +496,11 @@ public abstract class RustPlusFcmSocket(
 
             if (data.Length == 0)
             {
-                await OnMessageAsync(new MessageEventArgs { Tag = messageTag, Object = Activator.CreateInstance(type) }).ConfigureAwait(false);
+                await OnMessageAsync(new MessageEventArgs
+                {
+                    Tag = messageTag,
+                    Object = Activator.CreateInstance(type)
+                }).ConfigureAwait(false);
                 return;
             }
 
@@ -490,7 +509,11 @@ public abstract class RustPlusFcmSocket(
 #pragma warning restore RCS1261
             var message = Serializer.NonGeneric.Deserialize(type, stream);
 
-            await OnMessageAsync(new MessageEventArgs { Tag = messageTag, Object = message }).ConfigureAwait(false);
+            await OnMessageAsync(new MessageEventArgs
+            {
+                Tag = messageTag,
+                Object = message
+            }).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -512,7 +535,8 @@ public abstract class RustPlusFcmSocket(
         {
             // byte[] overload is intentional: the Memory<byte> overload (preferred by CA1835) is unavailable on netstandard2.0.
 #pragma warning disable CA1835
-            var read = await _transport!.ReadAsync(buffer, bytesRead, size - bytesRead, CancellationToken).ConfigureAwait(false);
+            var read = await _transport!.ReadAsync(buffer, bytesRead, size - bytesRead, CancellationToken)
+                .ConfigureAwait(false);
 #pragma warning restore CA1835
             if (read == 0)
             {
@@ -521,6 +545,7 @@ public abstract class RustPlusFcmSocket(
 
             bytesRead += read;
         }
+
         return buffer;
     }
 
@@ -564,6 +589,7 @@ public abstract class RustPlusFcmSocket(
 
             shift += 7;
         }
+
         return result;
     }
 
@@ -575,7 +601,10 @@ public abstract class RustPlusFcmSocket(
     private async Task SendPacketAsync(object packet)
     {
         var tagEnum = GetTagFromProtobufType(packet.GetType());
-        var header = new byte[] { KMcsVersion, (byte)(int)tagEnum };
+        var header = new byte[]
+        {
+            KMcsVersion, (byte)(int)tagEnum
+        };
 
 #pragma warning disable RCS1261 // MemoryStream.DisposeAsync is a no-op; await using not available in netstandard2.0
         using var ms = new MemoryStream();
@@ -645,7 +674,7 @@ public abstract class RustPlusFcmSocket(
                 Disconnect();
                 break;
             case McsProtoTag.KIqStanzaTag:
-                break;  // To investigate further, if needed
+                break; // To investigate further, if needed
             default:
                 Logger.LogUnrecognizedTag(e.Tag);
                 break;

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocketLog.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocketLog.cs
@@ -14,7 +14,8 @@ internal static partial class RustPlusFcmSocketLog
     [LoggerMessage(Level = LogLevel.Warning, Message = "Background loop faulted during teardown (expected).")]
     public static partial void LogTeardownLoopFaulted(this ILogger logger, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Trace, Message = "Responding to ping: StreamId={StreamId}, Last={Last}, Status={Status}")]
+    [LoggerMessage(Level = LogLevel.Trace,
+        Message = "Responding to ping: StreamId={StreamId}, Last={Last}, Status={Status}")]
     public static partial void LogRespondingToPing(this ILogger logger, int? streamId, int? last, long? status);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Ignoring unrecognized tag: {Tag}")]

--- a/src/RustPlusApi.Fcm/Utils/McsUtils.cs
+++ b/src/RustPlusApi.Fcm/Utils/McsUtils.cs
@@ -13,7 +13,8 @@ public static class McsUtils
     {
         if (value < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(value), value, "MCS varints encode non-negative lengths only.");
+            throw new ArgumentOutOfRangeException(nameof(value), value,
+                "MCS varints encode non-negative lengths only.");
         }
 
         List<byte> result = [];
@@ -30,6 +31,7 @@ public static class McsUtils
 
             result.Add(b);
         } while (value != 0);
+
         return [.. result];
     }
 

--- a/src/RustPlusApi/Data/Cameras/CameraButtons.cs
+++ b/src/RustPlusApi/Data/Cameras/CameraButtons.cs
@@ -9,28 +9,40 @@ public enum CameraButtons
 {
     /// <summary>No button pressed.</summary>
     None = 0,
+
     /// <summary>Move forward.</summary>
     Forward = 1 << 1,
+
     /// <summary>Move backward.</summary>
     Backward = 1 << 2,
+
     /// <summary>Strafe left.</summary>
     Left = 1 << 3,
+
     /// <summary>Strafe right.</summary>
     Right = 1 << 4,
+
     /// <summary>Jump.</summary>
     Jump = 1 << 5,
+
     /// <summary>Crouch / duck.</summary>
     Duck = 1 << 6,
+
     /// <summary>Sprint.</summary>
     Sprint = 1 << 7,
+
     /// <summary>Use / interact.</summary>
     Use = 1 << 8,
+
     /// <summary>Fire primary weapon.</summary>
     FirePrimary = 1 << 10,
+
     /// <summary>Fire secondary (aim down sights / alt-fire).</summary>
     FireSecondary = 1 << 11,
+
     /// <summary>Reload.</summary>
     Reload = 1 << 13,
+
     /// <summary>Fire tertiary (underbarrel / melee).</summary>
     FireThird = 1 << 27,
 }

--- a/src/RustPlusApi/Data/Cameras/CameraControlFlags.cs
+++ b/src/RustPlusApi/Data/Cameras/CameraControlFlags.cs
@@ -15,16 +15,22 @@ public enum CameraControlFlags
 {
     /// <summary>No controls available.</summary>
     None = 0,
+
     /// <summary>WASD movement is supported.</summary>
     Movement = 1 << 0,
+
     /// <summary>Mouse look is supported.</summary>
     Mouse = 1 << 1,
+
     /// <summary>Sprint and duck inputs are supported.</summary>
     SprintAndDuck = 1 << 2,
+
     /// <summary>Fire inputs are supported.</summary>
     Fire = 1 << 3,
+
     /// <summary>Reload input is supported.</summary>
     Reload = 1 << 4,
+
     /// <summary>The camera renders a crosshair overlay.</summary>
     Crosshair = 1 << 5,
 }

--- a/src/RustPlusApi/Data/Cameras/CameraEntityType.cs
+++ b/src/RustPlusApi/Data/Cameras/CameraEntityType.cs
@@ -5,6 +5,7 @@ public enum CameraEntityType
 {
     /// <summary>A tree.</summary>
     Tree = 1,
+
     /// <summary>A player.</summary>
     Player = 2,
 }

--- a/src/RustPlusApi/Data/Notes/NoteColors.cs
+++ b/src/RustPlusApi/Data/Notes/NoteColors.cs
@@ -5,14 +5,19 @@ public enum NoteColors
 {
     /// <summary>Yellow note.</summary>
     Yellow = 0,
+
     /// <summary>Blue note.</summary>
     Blue = 1,
+
     /// <summary>Green note.</summary>
     Green = 2,
+
     /// <summary>Red note.</summary>
     Red = 3,
+
     /// <summary>Purple note.</summary>
     Purple = 4,
+
     /// <summary>Cyan note.</summary>
     Cyan = 5,
 }

--- a/src/RustPlusApi/Data/Notes/NoteIcons.cs
+++ b/src/RustPlusApi/Data/Notes/NoteIcons.cs
@@ -5,26 +5,37 @@ public enum NoteIcons
 {
     /// <summary>Default pin icon.</summary>
     Default = 0,
+
     /// <summary>Money / loot icon.</summary>
     Money = 1,
+
     /// <summary>Home / base icon.</summary>
     Home = 2,
+
     /// <summary>Drop / supply icon.</summary>
     Drop = 3,
+
     /// <summary>Sight / observe icon.</summary>
     Sight = 4,
+
     /// <summary>Shield / safe icon.</summary>
     Shield = 5,
+
     /// <summary>Skull / danger icon.</summary>
     Skull = 6,
+
     /// <summary>Bed / sleeping bag icon.</summary>
     Bed = 7,
+
     /// <summary>Sleep icon.</summary>
     Sleep = 8,
+
     /// <summary>Gun icon.</summary>
     Gun = 9,
+
     /// <summary>Rock / stone icon.</summary>
     Rock = 10,
+
     /// <summary>Chest / storage icon.</summary>
     Chest = 11,
 }

--- a/src/RustPlusApi/Extensions/AppCameraToModel.cs
+++ b/src/RustPlusApi/Extensions/AppCameraToModel.cs
@@ -4,6 +4,7 @@ using AppCameraInfo = RustPlusContracts.AppCameraInfo;
 using AppCameraRays = RustPlusContracts.AppCameraRays;
 using ProtoCameraEntity = RustPlusContracts.AppCameraRays.Entity;
 using ProtoVector3 = RustPlusContracts.Vector3;
+
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace RustPlusApi.Extensions;
@@ -90,6 +91,11 @@ public static class AppCameraToModel
             return new Vector3();
         }
 
-        return new Vector3 { X = vector.X, Y = vector.Y, Z = vector.Z };
+        return new Vector3
+        {
+            X = vector.X,
+            Y = vector.Y,
+            Z = vector.Z
+        };
     }
 }

--- a/src/RustPlusApi/Extensions/AppCameraToModel.cs
+++ b/src/RustPlusApi/Extensions/AppCameraToModel.cs
@@ -93,9 +93,7 @@ public static class AppCameraToModel
 
         return new Vector3
         {
-            X = vector.X,
-            Y = vector.Y,
-            Z = vector.Z
+            X = vector.X, Y = vector.Y, Z = vector.Z
         };
     }
 }

--- a/src/RustPlusApi/Extensions/AppClanChatToModel.cs
+++ b/src/RustPlusApi/Extensions/AppClanChatToModel.cs
@@ -1,7 +1,7 @@
 using RustPlusApi.Data.Clans;
 using RustPlusApi.Data.Events;
-
 using RustPlusContracts;
+
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace RustPlusApi.Extensions;

--- a/src/RustPlusApi/Extensions/AppClanInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppClanInfoToModel.cs
@@ -3,6 +3,7 @@ using RustPlusApi.Data.Events;
 using AppClanChanged = RustPlusContracts.AppClanChanged;
 using AppClanInfo = RustPlusContracts.AppClanInfo;
 using ProtoClanInfo = RustPlusContracts.ClanInfo;
+
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace RustPlusApi.Extensions;

--- a/src/RustPlusApi/Extensions/AppEntityInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppEntityInfoToModel.cs
@@ -65,9 +65,7 @@ public static class AppEntityInfoToModel
     {
         return new StorageMonitorItemInfo
         {
-            Id = item.ItemId,
-            Quantity = item.Quantity,
-            IsItemBlueprint = item.ItemIsBlueprint,
+            Id = item.ItemId, Quantity = item.Quantity, IsItemBlueprint = item.ItemIsBlueprint,
         };
     }
 

--- a/src/RustPlusApi/Extensions/AppEntityInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppEntityInfoToModel.cs
@@ -1,5 +1,6 @@
 using RustPlusApi.Data.Entities;
 using RustPlusContracts;
+
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace RustPlusApi.Extensions;
@@ -16,6 +17,7 @@ public static class AppEntityInfoToModel
         {
             throw new InvalidOperationException("Entity type is not a SmartSwitch.");
         }
+
         return new SmartSwitchInfo
         {
             IsActive = entity.Payload.Value
@@ -31,6 +33,7 @@ public static class AppEntityInfoToModel
         {
             throw new InvalidOperationException("Entity type is not an Alarm.");
         }
+
         return new AlarmInfo
         {
             IsActive = entity.Payload.Value
@@ -46,6 +49,7 @@ public static class AppEntityInfoToModel
         {
             throw new InvalidOperationException("Entity type is not a StorageMonitor.");
         }
+
         return new StorageMonitorInfo
         {
             Capacity = entity.Payload.Capacity,
@@ -69,7 +73,8 @@ public static class AppEntityInfoToModel
 
     /// <summary>Maps a sequence of protobuf storage items to <see cref="StorageMonitorItemInfo"/> instances.</summary>
     /// <param name="items">The protobuf storage items to map.</param>
-    public static IEnumerable<StorageMonitorItemInfo> ToStorageMonitorItemsInfo(this IEnumerable<AppEntityPayload.Item> items)
+    public static IEnumerable<StorageMonitorItemInfo> ToStorageMonitorItemsInfo(
+        this IEnumerable<AppEntityPayload.Item> items)
     {
         return items.Select(ToStorageMonitorItemInfo);
     }

--- a/src/RustPlusApi/Extensions/AppFlagToModel.cs
+++ b/src/RustPlusApi/Extensions/AppFlagToModel.cs
@@ -1,5 +1,4 @@
 using RustPlusApi.Data;
-
 using RustPlusContracts;
 
 namespace RustPlusApi.Extensions;

--- a/src/RustPlusApi/Extensions/AppInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppInfoToModel.cs
@@ -1,5 +1,4 @@
 using RustPlusApi.Data;
-
 using RustPlusContracts;
 
 namespace RustPlusApi.Extensions;

--- a/src/RustPlusApi/Extensions/AppMapToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMapToModel.cs
@@ -33,9 +33,7 @@ public static class AppMapToModel
         return new ServerMapMonument
         {
             // Server field is `token` (a localization key, e.g. "lighthouse"); exposed as Name.
-            Name = appMapMonument.Token,
-            X = appMapMonument.X,
-            Y = appMapMonument.Y
+            Name = appMapMonument.Token, X = appMapMonument.X, Y = appMapMonument.Y
         };
     }
 

--- a/src/RustPlusApi/Extensions/AppMapToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMapToModel.cs
@@ -3,6 +3,7 @@ using RustPlusApi.Utils;
 using RustPlusContracts;
 using System.Drawing;
 using static RustPlusContracts.AppMap;
+
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace RustPlusApi.Extensions;

--- a/src/RustPlusApi/Extensions/AppMarkerToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMarkerToModel.cs
@@ -1,9 +1,8 @@
 using RustPlusApi.Data;
 using RustPlusApi.Data.Markers;
-
 using RustPlusContracts;
-
 using static RustPlusContracts.AppMarker;
+
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace RustPlusApi.Extensions;

--- a/src/RustPlusApi/Extensions/AppMarkerToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMarkerToModel.cs
@@ -16,9 +16,7 @@ public static class AppMarkerToModel
     {
         return new UnknownMarker
         {
-            Id = marker.Id,
-            X = marker.X,
-            Y = marker.Y
+            Id = marker.Id, X = marker.X, Y = marker.Y
         };
     }
 
@@ -83,9 +81,7 @@ public static class AppMarkerToModel
     {
         return new Ch47Marker
         {
-            Id = marker.Id,
-            X = marker.X,
-            Y = marker.Y
+            Id = marker.Id, X = marker.X, Y = marker.Y
         };
     }
 
@@ -95,9 +91,7 @@ public static class AppMarkerToModel
     {
         return new CargoShipMarker
         {
-            Id = marker.Id,
-            X = marker.X,
-            Y = marker.Y
+            Id = marker.Id, X = marker.X, Y = marker.Y
         };
     }
 
@@ -107,9 +101,7 @@ public static class AppMarkerToModel
     {
         return new PatrolHelicopterMarker
         {
-            Id = marker.Id,
-            X = marker.X,
-            Y = marker.Y
+            Id = marker.Id, X = marker.X, Y = marker.Y
         };
     }
 
@@ -119,9 +111,7 @@ public static class AppMarkerToModel
     {
         return new TravellingVendorMarker
         {
-            Id = marker.Id,
-            X = marker.X,
-            Y = marker.Y
+            Id = marker.Id, X = marker.X, Y = marker.Y
         };
     }
 }

--- a/src/RustPlusApi/Extensions/AppNexusAuthToModel.cs
+++ b/src/RustPlusApi/Extensions/AppNexusAuthToModel.cs
@@ -12,8 +12,7 @@ public static class AppNexusAuthToModel
     {
         return new NexusAuth
         {
-            ServerId = appNexusAuth.ServerId,
-            PlayerToken = appNexusAuth.PlayerToken
+            ServerId = appNexusAuth.ServerId, PlayerToken = appNexusAuth.PlayerToken
         };
     }
 }

--- a/src/RustPlusApi/Extensions/AppNexusAuthToModel.cs
+++ b/src/RustPlusApi/Extensions/AppNexusAuthToModel.cs
@@ -1,5 +1,4 @@
 using RustPlusApi.Data;
-
 using RustPlusContracts;
 
 namespace RustPlusApi.Extensions;

--- a/src/RustPlusApi/Extensions/AppTeamChatToModel.cs
+++ b/src/RustPlusApi/Extensions/AppTeamChatToModel.cs
@@ -3,6 +3,7 @@ using RustPlusApi.Data.Events;
 using RustPlusApi.Utils;
 using RustPlusContracts;
 using System.Drawing;
+
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace RustPlusApi.Extensions;

--- a/src/RustPlusApi/Extensions/AppTeamInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppTeamInfoToModel.cs
@@ -1,9 +1,8 @@
 using RustPlusApi.Data;
 using RustPlusApi.Data.Notes;
-
 using RustPlusContracts;
-
 using static RustPlusContracts.AppTeamInfo;
+
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace RustPlusApi.Extensions;

--- a/src/RustPlusApi/Extensions/AppTeamInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppTeamInfoToModel.cs
@@ -73,8 +73,7 @@ public static class AppTeamInfoToModel
     {
         return new DeathNote
         {
-            X = note.X,
-            Y = note.Y,
+            X = note.X, Y = note.Y,
         };
     }
 

--- a/src/RustPlusApi/Extensions/AppTimeToModel.cs
+++ b/src/RustPlusApi/Extensions/AppTimeToModel.cs
@@ -1,5 +1,4 @@
 using RustPlusApi.Data;
-
 using RustPlusContracts;
 
 namespace RustPlusApi.Extensions;

--- a/src/RustPlusApi/Extensions/EntityChangedToModel.cs
+++ b/src/RustPlusApi/Extensions/EntityChangedToModel.cs
@@ -12,8 +12,7 @@ public static class EntityChangedToModel
     {
         return new SmartSwitchEventArg
         {
-            Id = entityChanged.EntityId,
-            IsActive = entityChanged.Payload.Value
+            Id = entityChanged.EntityId, IsActive = entityChanged.Payload.Value
         };
     }
 

--- a/src/RustPlusApi/Extensions/EntityChangedToModel.cs
+++ b/src/RustPlusApi/Extensions/EntityChangedToModel.cs
@@ -1,5 +1,4 @@
 using RustPlusApi.Data.Events;
-
 using RustPlusContracts;
 
 namespace RustPlusApi.Extensions;

--- a/src/RustPlusApi/Interfaces/IRustPlus.cs
+++ b/src/RustPlusApi/Interfaces/IRustPlus.cs
@@ -71,7 +71,9 @@ public interface IRustPlus : IRustPlusSocket
     /// <param name="mouseDeltaX">Horizontal mouse delta.</param>
     /// <param name="mouseDeltaY">Vertical mouse delta.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    Task<Response> SendCameraInputAsync(CameraButtons buttons, float mouseDeltaX = 0, float mouseDeltaY = 0,
+    Task<Response> SendCameraInputAsync(CameraButtons buttons,
+        float mouseDeltaX = 0,
+        float mouseDeltaY = 0,
         CancellationToken cancellationToken = default);
 
     /// <summary>Unsubscribes from the currently subscribed camera.</summary>
@@ -128,14 +130,16 @@ public interface IRustPlus : IRustPlusSocket
     /// <param name="smartSwitchId">Entity ID of the smart switch.</param>
     /// <param name="smartSwitchValue"><see langword="true"/> to turn on, <see langword="false"/> to turn off.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    Task<Response<SmartSwitchInfo?>> SetSmartSwitchValueAsync(ulong smartSwitchId, bool smartSwitchValue,
+    Task<Response<SmartSwitchInfo?>> SetSmartSwitchValueAsync(ulong smartSwitchId,
+        bool smartSwitchValue,
         CancellationToken cancellationToken = default);
 
     /// <summary>Subscribes or unsubscribes from push notifications for a smart alarm.</summary>
     /// <param name="entityId">Entity ID of the alarm.</param>
     /// <param name="doSubscribe"><see langword="true"/> to subscribe, <see langword="false"/> to unsubscribe.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    Task<Response> SetSubscriptionAsync(ulong entityId, bool doSubscribe = true,
+    Task<Response> SetSubscriptionAsync(ulong entityId,
+        bool doSubscribe = true,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -146,8 +150,10 @@ public interface IRustPlus : IRustPlusSocket
     /// <param name="timeoutMilliseconds">Duration to hold the initial state before reverting, in milliseconds.</param>
     /// <param name="value">Initial state to pulse the switch to.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    Task<Response<SmartSwitchInfo?>> StrobeSmartSwitchAsync(ulong entityId, int timeoutMilliseconds = 1000,
-        bool value = true, CancellationToken cancellationToken = default);
+    Task<Response<SmartSwitchInfo?>> StrobeSmartSwitchAsync(ulong entityId,
+        int timeoutMilliseconds = 1000,
+        bool value = true,
+        CancellationToken cancellationToken = default);
 
     /// <summary>Toggles a smart switch — turns it on if off, or off if on.</summary>
     /// <param name="entityId">Entity ID of the smart switch.</param>

--- a/src/RustPlusApi/Interfaces/IRustPlus.cs
+++ b/src/RustPlusApi/Interfaces/IRustPlus.cs
@@ -30,86 +30,114 @@ public interface IRustPlus : IRustPlusSocket
     /// <summary>Checks whether the player is subscribed to push notifications from a smart alarm.</summary>
     /// <param name="alarmId">Entity ID of the smart alarm.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    Task<Response<SubscriptionInfo?>> CheckSubscriptionAsync(ulong alarmId, CancellationToken cancellationToken = default);
+    Task<Response<SubscriptionInfo?>> CheckSubscriptionAsync(ulong alarmId,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Returns the current state of a smart alarm entity.</summary>
     /// <param name="entityId">Entity ID of the alarm.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<AlarmInfo?>> GetAlarmInfoAsync(ulong entityId, CancellationToken cancellationToken = default);
+
     /// <summary>Returns the full clan snapshot for the authenticated player's clan.</summary>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<ClanInfo?>> GetClanInfoAsync(CancellationToken cancellationToken = default);
+
     /// <summary>Sets the clan's message of the day.</summary>
     /// <param name="message">The new MOTD text.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response> SetClanMotdAsync(string message, CancellationToken cancellationToken = default);
+
     /// <summary>Returns recent clan chat messages.</summary>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<ClanChatInfo?>> GetClanChatAsync(CancellationToken cancellationToken = default);
+
     /// <summary>Posts a message to the clan chat.</summary>
     /// <param name="message">The message text to send.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response> SendClanMessageAsync(string message, CancellationToken cancellationToken = default);
+
     /// <summary>Obtains a Nexus cross-server authentication token.</summary>
     /// <param name="appKey">The application key identifying the target Nexus server.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<NexusAuth?>> GetNexusAuthAsync(string appKey, CancellationToken cancellationToken = default);
+
     /// <summary>Subscribes to a camera's ray stream and returns its info.</summary>
     /// <param name="cameraId">In-game identifier of the camera entity.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<CameraInfo?>> SubscribeToCameraAsync(string cameraId, CancellationToken cancellationToken = default);
+
     /// <summary>Sends movement / action input to the currently subscribed camera.</summary>
     /// <param name="buttons">Bitmask of buttons to press.</param>
     /// <param name="mouseDeltaX">Horizontal mouse delta.</param>
     /// <param name="mouseDeltaY">Vertical mouse delta.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    Task<Response> SendCameraInputAsync(CameraButtons buttons, float mouseDeltaX = 0, float mouseDeltaY = 0, CancellationToken cancellationToken = default);
+    Task<Response> SendCameraInputAsync(CameraButtons buttons, float mouseDeltaX = 0, float mouseDeltaY = 0,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Unsubscribes from the currently subscribed camera.</summary>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response> UnsubscribeFromCameraAsync(CancellationToken cancellationToken = default);
+
     /// <summary>Returns server metadata (name, map, player counts, etc.).</summary>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<ServerInfo?>> GetInfoAsync(CancellationToken cancellationToken = default);
+
     /// <summary>Returns the server map image and monument list.</summary>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<ServerMap?>> GetMapAsync(CancellationToken cancellationToken = default);
+
     /// <summary>Returns all current map markers (players, cargo ship, vending machines, etc.).</summary>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<MapMarkers?>> GetMapMarkersAsync(CancellationToken cancellationToken = default);
+
     /// <summary>Returns the current state of a smart switch entity.</summary>
     /// <param name="entityId">Entity ID of the smart switch.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    Task<Response<SmartSwitchInfo?>> GetSmartSwitchInfoAsync(ulong entityId, CancellationToken cancellationToken = default);
+    Task<Response<SmartSwitchInfo?>> GetSmartSwitchInfoAsync(ulong entityId,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Returns the current contents and protection state of a storage monitor.</summary>
     /// <param name="entityId">Entity ID of the storage monitor.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    Task<Response<StorageMonitorInfo?>> GetStorageMonitorInfoAsync(ulong entityId, CancellationToken cancellationToken = default);
+    Task<Response<StorageMonitorInfo?>> GetStorageMonitorInfoAsync(ulong entityId,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Returns recent team chat messages.</summary>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<TeamChatInfo?>> GetTeamChatAsync(CancellationToken cancellationToken = default);
+
     /// <summary>Returns the full team snapshot including all member statuses and map notes.</summary>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<TeamInfo?>> GetTeamInfoAsync(CancellationToken cancellationToken = default);
+
     /// <summary>Returns the current in-game time and day/night cycle parameters.</summary>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<TimeInfo?>> GetTimeAsync(CancellationToken cancellationToken = default);
+
     /// <summary>Promotes a team member to team leader.</summary>
     /// <param name="steamId">Steam64 ID of the member to promote.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response> PromoteToLeaderAsync(ulong steamId, CancellationToken cancellationToken = default);
+
     /// <summary>Posts a message to the team chat.</summary>
     /// <param name="message">The message text to send.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<TeamMessage?>> SendTeamMessageAsync(string message, CancellationToken cancellationToken = default);
+
     /// <summary>Sets a smart switch to a specific on/off state.</summary>
     /// <param name="smartSwitchId">Entity ID of the smart switch.</param>
     /// <param name="smartSwitchValue"><see langword="true"/> to turn on, <see langword="false"/> to turn off.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    Task<Response<SmartSwitchInfo?>> SetSmartSwitchValueAsync(ulong smartSwitchId, bool smartSwitchValue, CancellationToken cancellationToken = default);
+    Task<Response<SmartSwitchInfo?>> SetSmartSwitchValueAsync(ulong smartSwitchId, bool smartSwitchValue,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Subscribes or unsubscribes from push notifications for a smart alarm.</summary>
     /// <param name="entityId">Entity ID of the alarm.</param>
     /// <param name="doSubscribe"><see langword="true"/> to subscribe, <see langword="false"/> to unsubscribe.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    Task<Response> SetSubscriptionAsync(ulong entityId, bool doSubscribe = true, CancellationToken cancellationToken = default);
+    Task<Response> SetSubscriptionAsync(ulong entityId, bool doSubscribe = true,
+        CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Pulses a smart switch on then off (or off then on) with the specified delay, implementing a
     /// simple strobe / one-shot trigger pattern.
@@ -118,9 +146,12 @@ public interface IRustPlus : IRustPlusSocket
     /// <param name="timeoutMilliseconds">Duration to hold the initial state before reverting, in milliseconds.</param>
     /// <param name="value">Initial state to pulse the switch to.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    Task<Response<SmartSwitchInfo?>> StrobeSmartSwitchAsync(ulong entityId, int timeoutMilliseconds = 1000, bool value = true, CancellationToken cancellationToken = default);
+    Task<Response<SmartSwitchInfo?>> StrobeSmartSwitchAsync(ulong entityId, int timeoutMilliseconds = 1000,
+        bool value = true, CancellationToken cancellationToken = default);
+
     /// <summary>Toggles a smart switch — turns it on if off, or off if on.</summary>
     /// <param name="entityId">Entity ID of the smart switch.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    Task<Response<SmartSwitchInfo?>> ToggleSmartSwitchAsync(ulong entityId, CancellationToken cancellationToken = default);
+    Task<Response<SmartSwitchInfo?>> ToggleSmartSwitchAsync(ulong entityId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -168,8 +168,7 @@ public class RustPlus(
     {
         var request = new AppRequest
         {
-            EntityId = entityId,
-            GetEntityInfo = new AppEmpty()
+            EntityId = entityId, GetEntityInfo = new AppEmpty()
         };
         return await ProcessRequestAsync(request, selector, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
@@ -185,8 +184,7 @@ public class RustPlus(
     {
         var request = new AppRequest
         {
-            CheckSubscription = new AppEmpty(),
-            EntityId = alarmId
+            CheckSubscription = new AppEmpty(), EntityId = alarmId
         };
         return await ProcessRequestAsync<SubscriptionInfo?>(
             request,
@@ -334,8 +332,7 @@ public class RustPlus(
                 Buttons = (int)buttons,
                 MouseDelta = new Vector2
                 {
-                    X = mouseDeltaX,
-                    Y = mouseDeltaY
+                    X = mouseDeltaX, Y = mouseDeltaY
                 }
             }
         };

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -124,8 +124,10 @@ public class RustPlus(
     /// than <c>response.Response</c>. Unrelated broadcasts stay pure notifications.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the processed result.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    protected async Task<Response<T?>> ProcessRequestAsync<T>(AppRequest request, Func<AppMessage, T> successSelector,
-        Func<AppBroadcast, bool>? broadcastReplyMatcher = null, CancellationToken cancellationToken = default)
+    protected async Task<Response<T?>> ProcessRequestAsync<T>(AppRequest request,
+        Func<AppMessage, T> successSelector,
+        Func<AppBroadcast, bool>? broadcastReplyMatcher = null,
+        CancellationToken cancellationToken = default)
     {
         var response = await SendRequestAsync(request, broadcastReplyMatcher, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
@@ -160,7 +162,8 @@ public class RustPlus(
     /// <param name="selector">The function to select the entity information from the response.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the entity information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    protected async Task<Response<T?>> GetEntityInfoAsync<T>(ulong entityId, Func<AppMessage, T> selector,
+    protected async Task<Response<T?>> GetEntityInfoAsync<T>(ulong entityId,
+        Func<AppMessage, T> selector,
         CancellationToken cancellationToken = default)
     {
         var request = new AppRequest
@@ -319,8 +322,10 @@ public class RustPlus(
     /// <param name="mouseDeltaY">The vertical mouse delta.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a payload-free <see cref="Response"/> indicating the success of the operation.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response> SendCameraInputAsync(CameraButtons buttons, float mouseDeltaX = 0,
-        float mouseDeltaY = 0, CancellationToken cancellationToken = default)
+    public async Task<Response> SendCameraInputAsync(CameraButtons buttons,
+        float mouseDeltaX = 0,
+        float mouseDeltaY = 0,
+        CancellationToken cancellationToken = default)
     {
         var request = new AppRequest
         {
@@ -521,7 +526,8 @@ public class RustPlus(
     /// <param name="smartSwitchValue">The value to set for the smart switch.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the updated smart switch information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response<SmartSwitchInfo?>> SetSmartSwitchValueAsync(ulong smartSwitchId, bool smartSwitchValue,
+    public async Task<Response<SmartSwitchInfo?>> SetSmartSwitchValueAsync(ulong smartSwitchId,
+        bool smartSwitchValue,
         CancellationToken cancellationToken = default)
     {
         var request = new AppRequest
@@ -548,7 +554,8 @@ public class RustPlus(
     /// <param name="doSubscribe">Specifies whether to subscribe or unsubscribe.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a payload-free <see cref="Response"/> indicating the success of the operation.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response> SetSubscriptionAsync(ulong entityId, bool doSubscribe = true,
+    public async Task<Response> SetSubscriptionAsync(ulong entityId,
+        bool doSubscribe = true,
         CancellationToken cancellationToken = default)
     {
         var request = new AppRequest

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -9,6 +9,7 @@ using RustPlusApi.Interfaces;
 using RustPlusApi.Utils;
 using RustPlusContracts;
 using ClanInfo = RustPlusApi.Data.Clans.ClanInfo;
+
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace RustPlusApi;
@@ -22,7 +23,10 @@ namespace RustPlusApi;
 /// <param name="loggerFactory">Routes the client's diagnostics into your logging stack; logging is
 /// disabled (a no-op <c>NullLogger</c>) when <see langword="null"/>.</param>
 /// <seealso cref="RustPlusSocket"/>
-public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? options = null, ILoggerFactory? loggerFactory = null)
+public class RustPlus(
+    RustPlusConnection connection,
+    RustPlusSocketOptions? options = null,
+    ILoggerFactory? loggerFactory = null)
     : RustPlusSocket(connection, options, loggerFactory), IRustPlus
 {
     /// <summary>
@@ -81,26 +85,31 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
 
             return;
         }
+
         if (broadcast.TeamMessage is not null)
         {
             OnTeamChatReceived?.Invoke(this, broadcast.TeamMessage.Message.ToTeamMessageEvent());
             return;
         }
+
         if (broadcast.ClanMessage is not null)
         {
             OnClanChatReceived?.Invoke(this, broadcast.ClanMessage.ToClanMessageEvent());
             return;
         }
+
         if (broadcast.ClanChanged is not null)
         {
             OnClanChanged?.Invoke(this, broadcast.ClanChanged.ToClanChangedEvent());
             return;
         }
+
         if (broadcast.CameraRays is not null)
         {
             OnCameraRaysReceived?.Invoke(this, broadcast.CameraRays.ToCameraRaysEvent());
             return;
         }
+
         Logger.LogUnknownBroadcast(broadcast);
     }
 
@@ -115,9 +124,11 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// than <c>response.Response</c>. Unrelated broadcasts stay pure notifications.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the processed result.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    protected async Task<Response<T?>> ProcessRequestAsync<T>(AppRequest request, Func<AppMessage, T> successSelector, Func<AppBroadcast, bool>? broadcastReplyMatcher = null, CancellationToken cancellationToken = default)
+    protected async Task<Response<T?>> ProcessRequestAsync<T>(AppRequest request, Func<AppMessage, T> successSelector,
+        Func<AppBroadcast, bool>? broadcastReplyMatcher = null, CancellationToken cancellationToken = default)
     {
-        var response = await SendRequestAsync(request, broadcastReplyMatcher, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var response = await SendRequestAsync(request, broadcastReplyMatcher, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
         return IsError(response)
             ? ResponseHelper.BuildGenericOutput<T>(false, default!, GetErrorMessage(response))
@@ -131,7 +142,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// <param name="request">The request to be processed.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>A <see cref="Task{TResult}"/> whose result is a payload-free <see cref="Response"/>.</returns>
-    protected async Task<Response> ProcessAckRequestAsync(AppRequest request, CancellationToken cancellationToken = default)
+    protected async Task<Response> ProcessAckRequestAsync(AppRequest request,
+        CancellationToken cancellationToken = default)
     {
         var response = await SendRequestAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -148,7 +160,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// <param name="selector">The function to select the entity information from the response.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the entity information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    protected async Task<Response<T?>> GetEntityInfoAsync<T>(ulong entityId, Func<AppMessage, T> selector, CancellationToken cancellationToken = default)
+    protected async Task<Response<T?>> GetEntityInfoAsync<T>(ulong entityId, Func<AppMessage, T> selector,
+        CancellationToken cancellationToken = default)
     {
         var request = new AppRequest
         {
@@ -164,7 +177,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// <param name="alarmId">The ID of the alarm entity.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the subscription information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response<SubscriptionInfo?>> CheckSubscriptionAsync(ulong alarmId, CancellationToken cancellationToken = default)
+    public async Task<Response<SubscriptionInfo?>> CheckSubscriptionAsync(ulong alarmId,
+        CancellationToken cancellationToken = default)
     {
         var request = new AppRequest
         {
@@ -182,9 +196,11 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// <param name="entityId">The ID of the alarm entity.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the alarm information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response<AlarmInfo?>> GetAlarmInfoAsync(ulong entityId, CancellationToken cancellationToken = default)
+    public async Task<Response<AlarmInfo?>> GetAlarmInfoAsync(ulong entityId,
+        CancellationToken cancellationToken = default)
     {
-        return await GetEntityInfoAsync<AlarmInfo?>(entityId, r => r.Response.EntityInfo.ToAlarmInfo(), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await GetEntityInfoAsync<AlarmInfo?>(entityId, r => r.Response.EntityInfo.ToAlarmInfo(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -198,7 +214,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
         {
             GetClanInfo = new AppEmpty()
         };
-        return await ProcessRequestAsync<ClanInfo?>(request, r => r.Response.ClanInfo.ToClanInfo(), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await ProcessRequestAsync<ClanInfo?>(request, r => r.Response.ClanInfo.ToClanInfo(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -230,7 +247,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
         {
             GetClanChat = new AppEmpty()
         };
-        return await ProcessRequestAsync<ClanChatInfo?>(request, r => r.Response.ClanChat.ToClanChatInfo(), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await ProcessRequestAsync<ClanChatInfo?>(request, r => r.Response.ClanChat.ToClanChatInfo(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -257,7 +275,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// <param name="appKey">The app key for Nexus authentication.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the Nexus authentication.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response<NexusAuth?>> GetNexusAuthAsync(string appKey, CancellationToken cancellationToken = default)
+    public async Task<Response<NexusAuth?>> GetNexusAuthAsync(string appKey,
+        CancellationToken cancellationToken = default)
     {
         var request = new AppRequest
         {
@@ -266,7 +285,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
                 AppKey = appKey
             }
         };
-        return await ProcessRequestAsync<NexusAuth?>(request, r => r.Response.NexusAuth.ToNexusAuth(), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await ProcessRequestAsync<NexusAuth?>(request, r => r.Response.NexusAuth.ToNexusAuth(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -275,7 +295,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// <param name="cameraId">The identifier of the camera/CCTV entity to subscribe to.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the camera information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response<CameraInfo?>> SubscribeToCameraAsync(string cameraId, CancellationToken cancellationToken = default)
+    public async Task<Response<CameraInfo?>> SubscribeToCameraAsync(string cameraId,
+        CancellationToken cancellationToken = default)
     {
         var request = new AppRequest
         {
@@ -285,8 +306,9 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
             }
         };
         return await ProcessRequestAsync<CameraInfo?>(
-            request,
-            r => r.Response.CameraSubscribeInfo.ToCameraInfo(), cancellationToken: cancellationToken).ConfigureAwait(false);
+                request,
+                r => r.Response.CameraSubscribeInfo.ToCameraInfo(), cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -297,7 +319,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// <param name="mouseDeltaY">The vertical mouse delta.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a payload-free <see cref="Response"/> indicating the success of the operation.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response> SendCameraInputAsync(CameraButtons buttons, float mouseDeltaX = 0, float mouseDeltaY = 0, CancellationToken cancellationToken = default)
+    public async Task<Response> SendCameraInputAsync(CameraButtons buttons, float mouseDeltaX = 0,
+        float mouseDeltaY = 0, CancellationToken cancellationToken = default)
     {
         var request = new AppRequest
         {
@@ -339,7 +362,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
         {
             GetInfo = new AppEmpty()
         };
-        return await ProcessRequestAsync<ServerInfo?>(request, r => r.Response.Info.ToServerInfo(), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await ProcessRequestAsync<ServerInfo?>(request, r => r.Response.Info.ToServerInfo(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -353,7 +377,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
         {
             GetMap = new AppEmpty()
         };
-        return await ProcessRequestAsync<ServerMap?>(request, r => r.Response.Map.ToServerMap(), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await ProcessRequestAsync<ServerMap?>(request, r => r.Response.Map.ToServerMap(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -367,7 +392,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
         {
             GetMapMarkers = new AppEmpty()
         };
-        return await ProcessRequestAsync<MapMarkers?>(request, r => r.Response.MapMarkers.ToMapMarkers(), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await ProcessRequestAsync<MapMarkers?>(request, r => r.Response.MapMarkers.ToMapMarkers(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -376,7 +402,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// <param name="entityId">The ID of the smart switch entity.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the smart switch information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response<SmartSwitchInfo?>> GetSmartSwitchInfoAsync(ulong entityId, CancellationToken cancellationToken = default)
+    public async Task<Response<SmartSwitchInfo?>> GetSmartSwitchInfoAsync(ulong entityId,
+        CancellationToken cancellationToken = default)
     {
         return await GetEntityInfoAsync<SmartSwitchInfo?>(
             entityId,
@@ -389,11 +416,13 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// <param name="entityId">The ID of the storage monitor entity.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the storage monitor information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response<StorageMonitorInfo?>> GetStorageMonitorInfoAsync(ulong entityId, CancellationToken cancellationToken = default)
+    public async Task<Response<StorageMonitorInfo?>> GetStorageMonitorInfoAsync(ulong entityId,
+        CancellationToken cancellationToken = default)
     {
         return await GetEntityInfoAsync<StorageMonitorInfo?>(
-            entityId,
-            r => r.Response.EntityInfo.ToStorageMonitorInfo(), cancellationToken: cancellationToken).ConfigureAwait(false);
+                entityId,
+                r => r.Response.EntityInfo.ToStorageMonitorInfo(), cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -423,7 +452,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
         {
             GetTeamInfo = new AppEmpty()
         };
-        return await ProcessRequestAsync<TeamInfo?>(request, r => r.Response.TeamInfo.ToTeamInfo(), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await ProcessRequestAsync<TeamInfo?>(request, r => r.Response.TeamInfo.ToTeamInfo(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -437,7 +467,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
         {
             GetTime = new AppEmpty()
         };
-        return await ProcessRequestAsync<TimeInfo?>(request, r => r.Response.Time.ToTimeInfo(), cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await ProcessRequestAsync<TimeInfo?>(request, r => r.Response.Time.ToTimeInfo(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -464,7 +495,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// <param name="message">The message to send.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the team message.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response<TeamMessage?>> SendTeamMessageAsync(string message, CancellationToken cancellationToken = default)
+    public async Task<Response<TeamMessage?>> SendTeamMessageAsync(string message,
+        CancellationToken cancellationToken = default)
     {
         var request = new AppRequest
         {
@@ -489,7 +521,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// <param name="smartSwitchValue">The value to set for the smart switch.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the updated smart switch information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response<SmartSwitchInfo?>> SetSmartSwitchValueAsync(ulong smartSwitchId, bool smartSwitchValue, CancellationToken cancellationToken = default)
+    public async Task<Response<SmartSwitchInfo?>> SetSmartSwitchValueAsync(ulong smartSwitchId, bool smartSwitchValue,
+        CancellationToken cancellationToken = default)
     {
         var request = new AppRequest
         {
@@ -515,7 +548,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// <param name="doSubscribe">Specifies whether to subscribe or unsubscribe.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a payload-free <see cref="Response"/> indicating the success of the operation.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response> SetSubscriptionAsync(ulong entityId, bool doSubscribe = true, CancellationToken cancellationToken = default)
+    public async Task<Response> SetSubscriptionAsync(ulong entityId, bool doSubscribe = true,
+        CancellationToken cancellationToken = default)
     {
         var request = new AppRequest
         {
@@ -542,7 +576,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
         bool value = true,
         CancellationToken cancellationToken = default)
     {
-        var response = await SetSmartSwitchValueAsync(entityId, value, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var response = await SetSmartSwitchValueAsync(entityId, value, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
         if (!response.IsSuccess)
         {
@@ -550,7 +585,8 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
         }
 
         await Task.Delay(timeoutMilliseconds, cancellationToken: cancellationToken).ConfigureAwait(false);
-        return await SetSmartSwitchValueAsync(entityId, !value, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await SetSmartSwitchValueAsync(entityId, !value, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -559,9 +595,11 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
     /// <param name="entityId">The ID of the smart switch entity.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the updated smart switch information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
-    public async Task<Response<SmartSwitchInfo?>> ToggleSmartSwitchAsync(ulong entityId, CancellationToken cancellationToken = default)
+    public async Task<Response<SmartSwitchInfo?>> ToggleSmartSwitchAsync(ulong entityId,
+        CancellationToken cancellationToken = default)
     {
-        var entityInfo = await GetSmartSwitchInfoAsync(entityId, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var entityInfo = await GetSmartSwitchInfoAsync(entityId, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
         if (!entityInfo.IsSuccess)
         {
@@ -569,6 +607,7 @@ public class RustPlus(RustPlusConnection connection, RustPlusSocketOptions? opti
         }
 
         var value = entityInfo.Data!.IsActive;
-        return await SetSmartSwitchValueAsync(entityId, !value, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await SetSmartSwitchValueAsync(entityId, !value, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using System.Threading.Channels;
 using static System.GC;
+
 // ReSharper disable MemberCanBeProtected.Global
 // ReSharper disable MemberCanBePrivate.Global
 
@@ -44,6 +45,7 @@ public abstract class RustPlusSocket(
 
     /// <summary>Backoff applied after a non-fatal receive error so the loop cannot busy-spin on it.</summary>
     private static readonly TimeSpan ReceiveErrorBackoff = TimeSpan.FromMilliseconds(100);
+
     /// <summary>
     /// Occurs when the client is about to connect to the Rust+ server.
     /// </summary>
@@ -111,7 +113,10 @@ public abstract class RustPlusSocket(
 
     /// <summary>Outgoing requests are handed to the send loop via a channel — no polling, no per-send latency.</summary>
     private readonly Channel<AppRequest> _sendChannel = Channel.CreateUnbounded<AppRequest>(
-        new UnboundedChannelOptions { SingleReader = true });
+        new UnboundedChannelOptions
+        {
+            SingleReader = true
+        });
 
     /// <summary>Requests answered by a seq-bearing <see cref="AppResponse"/>, keyed by <see cref="AppRequest.Seq"/>
     /// so each response resolves the request it actually answers; unsolicited broadcasts never touch this map.</summary>
@@ -121,7 +126,8 @@ public abstract class RustPlusSocket(
     /// TeamMessage). Broadcasts carry no seq, so each waiter supplies a matcher describing the broadcast it
     /// expects (entity ID, own Steam ID, …); a broadcast that matches no waiter is a pure notification.
     /// Guarded by <see cref="_broadcastRepliesLock"/>.</summary>
-    private readonly List<(Func<AppBroadcast, bool> Matches, TaskCompletionSource<AppMessage> Tcs)> _pendingBroadcastReplies = [];
+    private readonly List<(Func<AppBroadcast, bool> Matches, TaskCompletionSource<AppMessage> Tcs)>
+        _pendingBroadcastReplies = [];
 
     private readonly object _broadcastRepliesLock = new();
 
@@ -268,7 +274,8 @@ public abstract class RustPlusSocket(
     /// <param name="cancellationToken">A token to cancel waiting for the response.</param>
     /// <returns>A task that represents the asynchronous operation and contains the <see cref="AppMessage"/> response.</returns>
     /// <exception cref="TimeoutException">Thrown when no response arrives within the request timeout.</exception>
-    public async Task<AppMessage> SendRequestAsync(AppRequest request, Func<AppBroadcast, bool>? broadcastReplyMatcher = null, CancellationToken cancellationToken = default)
+    public async Task<AppMessage> SendRequestAsync(AppRequest request,
+        Func<AppBroadcast, bool>? broadcastReplyMatcher = null, CancellationToken cancellationToken = default)
     {
         // RunContinuationsAsynchronously keeps the receive loop from running awaiters inline when it resolves the TCS.
         var tcs = new TaskCompletionSource<AppMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -296,12 +303,14 @@ public abstract class RustPlusSocket(
         RequestSent?.Invoke(this, request);
 
         using var timeoutCts = new CancellationTokenSource(_options.RequestTimeout);
-        using var linked = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, cancellationToken, timeoutCts.Token);
+        using var linked =
+            CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, cancellationToken, timeoutCts.Token);
 
         try
         {
             // Cancel the wait if the caller cancels, the client is disposed, or the request times out.
-            using (linked.Token.Register(static state => ((TaskCompletionSource<AppMessage>)state!).TrySetCanceled(), tcs))
+            using (linked.Token.Register(static state => ((TaskCompletionSource<AppMessage>)state!).TrySetCanceled(),
+                       tcs))
             {
                 return await tcs.Task.ConfigureAwait(false);
             }
@@ -310,7 +319,8 @@ public abstract class RustPlusSocket(
                                                  && !cancellationToken.IsCancellationRequested
                                                  && !CancellationToken.IsCancellationRequested)
         {
-            throw new TimeoutException($"The Rust+ request (Seq {seq}) timed out after {_options.RequestTimeout.TotalSeconds:0.#}s.");
+            throw new TimeoutException(
+                $"The Rust+ request (Seq {seq}) timed out after {_options.RequestTimeout.TotalSeconds:0.#}s.");
         }
         finally
         {
@@ -351,7 +361,8 @@ public abstract class RustPlusSocket(
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, closeTimeout.Token);
         try
         {
-            await _webSocket!.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, linked.Token).ConfigureAwait(false);
+            await _webSocket!.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, linked.Token)
+                .ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -438,7 +449,10 @@ public abstract class RustPlusSocket(
     /// </summary>
     private async Task WaitForLoopsAsync()
     {
-        var loops = new[] { ReceiveLoopForTests, SendLoopForTests }
+        var loops = new[]
+            {
+                ReceiveLoopForTests, SendLoopForTests
+            }
             .Where(static t => t is not null)
             .Cast<Task>()
             .ToArray();
@@ -545,7 +559,8 @@ public abstract class RustPlusSocket(
 #pragma warning restore RCS1261
                     Serializer.Serialize(ms, request);
                     var buffer = ms.ToArray();
-                    await _webSocket!.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Binary, true, CancellationToken).ConfigureAwait(false);
+                    await _webSocket!.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Binary, true,
+                        CancellationToken).ConfigureAwait(false);
                 }
             }
         }
@@ -621,6 +636,7 @@ public abstract class RustPlusSocket(
                 }
             }
         }
+
         Logger.LogReceiveLoopExited();
 
         // The loop also exits without an exception (server close frame, graceful disconnect). No
@@ -649,7 +665,8 @@ public abstract class RustPlusSocket(
 
         do
         {
-            result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken).ConfigureAwait(false);
+            result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken)
+                .ConfigureAwait(false);
 #pragma warning disable CA1849, VSTHRD103, S6966 // MemoryStream.Write is in-memory and never blocks; WriteAsync would only add overhead
             messageStream.Write(buffer, 0, result.Count);
 #pragma warning restore CA1849, VSTHRD103, S6966

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -275,7 +275,8 @@ public abstract class RustPlusSocket(
     /// <returns>A task that represents the asynchronous operation and contains the <see cref="AppMessage"/> response.</returns>
     /// <exception cref="TimeoutException">Thrown when no response arrives within the request timeout.</exception>
     public async Task<AppMessage> SendRequestAsync(AppRequest request,
-        Func<AppBroadcast, bool>? broadcastReplyMatcher = null, CancellationToken cancellationToken = default)
+        Func<AppBroadcast, bool>? broadcastReplyMatcher = null,
+        CancellationToken cancellationToken = default)
     {
         // RunContinuationsAsynchronously keeps the receive loop from running awaiters inline when it resolves the TCS.
         var tcs = new TaskCompletionSource<AppMessage>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/RustPlusApi/RustPlusSocketLog.cs
+++ b/src/RustPlusApi/RustPlusSocketLog.cs
@@ -43,7 +43,8 @@ internal static partial class RustPlusSocketLog
     [LoggerMessage(Level = LogLevel.Error, Message = "Disconnected from the Rust+ socket due to a WebSocketException.")]
     public static partial void LogReceiveWebSocketFault(this ILogger logger, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Receive loop encountered a non-fatal exception; backing off before retrying.")]
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Receive loop encountered a non-fatal exception; backing off before retrying.")]
     public static partial void LogReceiveFault(this ILogger logger, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Broadcast-reply matcher threw; treating as no match.")]

--- a/src/RustPlusApi/Utils/ResponseHelper.cs
+++ b/src/RustPlusApi/Utils/ResponseHelper.cs
@@ -18,7 +18,12 @@ public static class ResponseHelper
         return new Response<T?>
         {
             IsSuccess = isSuccess,
-            Error = message is null ? null : new ErrorMessage { Message = message },
+            Error = message is null
+                ? null
+                : new ErrorMessage
+                {
+                    Message = message
+                },
             Data = data
         };
     }
@@ -34,7 +39,12 @@ public static class ResponseHelper
         return new Response
         {
             IsSuccess = isSuccess,
-            Error = message is null ? null : new ErrorMessage { Message = message }
+            Error = message is null
+                ? null
+                : new ErrorMessage
+                {
+                    Message = message
+                }
         };
     }
 }

--- a/tests/RustPlusApi.Camera.UnitTests/CameraRendererTests.cs
+++ b/tests/RustPlusApi.Camera.UnitTests/CameraRendererTests.cs
@@ -83,8 +83,7 @@ public class CameraRendererTests
         // One full ray: t=512, r=63 (alignment=1.0), material=2
         renderer.AddRays(new CameraFrame
         {
-            RayData = FullRay(128, 63, 2),
-            SampleOffset = 0
+            RayData = FullRay(128, 63, 2), SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -99,8 +98,7 @@ public class CameraRendererTests
         var renderer = new CameraRenderer(4, 4);
         renderer.AddRays(new CameraFrame
         {
-            RayData = FullRay(128, 63, 2),
-            SampleOffset = 0
+            RayData = FullRay(128, 63, 2), SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -131,8 +129,7 @@ public class CameraRendererTests
         var renderer = new CameraRenderer(16, 16);
         renderer.AddRays(new CameraFrame
         {
-            RayData = FullRay(255, 192, 0),
-            SampleOffset = 0
+            RayData = FullRay(255, 192, 0), SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -154,8 +151,7 @@ public class CameraRendererTests
 
         renderer.AddRays(new CameraFrame
         {
-            RayData = [.. rays],
-            SampleOffset = 0
+            RayData = [.. rays], SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -168,8 +164,7 @@ public class CameraRendererTests
         var renderer = new CameraRenderer(16, 16);
         renderer.AddRays(new CameraFrame
         {
-            RayData = FullRay(255, 192, 0),
-            SampleOffset = 0
+            RayData = FullRay(255, 192, 0), SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -199,8 +194,7 @@ public class CameraRendererTests
         var renderer = new CameraRenderer(4, 4);
         renderer.AddRays(new CameraFrame
         {
-            RayData = FullRay(128, 63, (byte)material),
-            SampleOffset = 0
+            RayData = FullRay(128, 63, (byte)material), SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -221,8 +215,7 @@ public class CameraRendererTests
 
         renderer.AddRays(new CameraFrame
         {
-            RayData = [.. rays],
-            SampleOffset = 0
+            RayData = [.. rays], SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -247,8 +240,7 @@ public class CameraRendererTests
         renderer.AddRays(new CameraFrame
         {
             // b1=1 → t=4; b2=32 → r=32; material as given
-            RayData = FullRay(1, 32, (byte)material),
-            SampleOffset = 0
+            RayData = FullRay(1, 32, (byte)material), SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -284,8 +276,7 @@ public class CameraRendererTests
         var renderer = new CameraRenderer(4, 4);
         renderer.AddRays(new CameraFrame
         {
-            RayData = [255, 0, 63, 6, 0x79, 0xFF],
-            SampleOffset = 0
+            RayData = [255, 0, 63, 6, 0x79, 0xFF], SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -300,17 +291,13 @@ public class CameraRendererTests
         var renderer = new CameraRenderer(16, 16);
         var rays = new List<byte>
         {
-            255,
-            0,
-            63,
-            6
+            255, 0, 63, 6
         };
         rays.AddRange([0x79, 0xFF]);
 
         renderer.AddRays(new CameraFrame
         {
-            RayData = [.. rays],
-            SampleOffset = 0
+            RayData = [.. rays], SampleOffset = 0
         });
         var png = renderer.Render();
 
@@ -334,8 +321,7 @@ public class CameraRendererTests
         var renderer = new CameraRenderer(4, 4);
         renderer.AddRays(new CameraFrame
         {
-            RayData = [255, 0, 0, 0, 0b0100_0000, 0x00],
-            SampleOffset = 0
+            RayData = [255, 0, 0, 0, 0b0100_0000, 0x00], SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -355,8 +341,7 @@ public class CameraRendererTests
 
         renderer.AddRays(new CameraFrame
         {
-            RayData = [.. rays],
-            SampleOffset = 0
+            RayData = [.. rays], SampleOffset = 0
         });
         var png = renderer.Render();
 
@@ -414,8 +399,7 @@ public class CameraRendererTests
         var renderer = new CameraRenderer(4, 4);
         renderer.AddRays(new CameraFrame
         {
-            RayData = rayData,
-            SampleOffset = 0
+            RayData = rayData, SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -440,8 +424,7 @@ public class CameraRendererTests
 
         renderer.AddRays(new CameraFrame
         {
-            RayData = [.. rays],
-            SampleOffset = 0
+            RayData = [.. rays], SampleOffset = 0
         });
         var png = renderer.Render();
 
@@ -469,8 +452,7 @@ public class CameraRendererTests
         {
             // Full ray + repeat referencing slot 57; trailing 0 ensures the loop's
             // "p < rayData.Length - 1" guard still includes the repeat byte.
-            RayData = [255, 128, 32, 5, 57, 0],
-            SampleOffset = 0
+            RayData = [255, 128, 32, 5, 57, 0], SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -513,15 +495,13 @@ public class CameraRendererTests
         var renderer1 = new CameraRenderer(4, 4);
         renderer1.AddRays(new CameraFrame
         {
-            RayData = FullRay(128, 63, 2),
-            SampleOffset = 0
+            RayData = FullRay(128, 63, 2), SampleOffset = 0
         });
 
         var renderer2 = new CameraRenderer(4, 4);
         renderer2.AddRays(new CameraFrame
         {
-            RayData = FullRay(128, 63, 2),
-            SampleOffset = 32
+            RayData = FullRay(128, 63, 2), SampleOffset = 32
         });
 
         using var img1 = Decode(renderer1.Render());
@@ -542,14 +522,12 @@ public class CameraRendererTests
         // Frame 1: paint image(2,2) with mat2 (76,178,255)
         renderer.AddRays(new CameraFrame
         {
-            RayData = FullRay(128, 63, 2),
-            SampleOffset = 0
+            RayData = FullRay(128, 63, 2), SampleOffset = 0
         });
         // Frame 2: repaint image(2,2) with mat0 (127,127,127)
         renderer.AddRays(new CameraFrame
         {
-            RayData = FullRay(128, 63, 0),
-            SampleOffset = 0
+            RayData = FullRay(128, 63, 0), SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -591,15 +569,13 @@ public class CameraRendererTests
         var r1 = new CameraRenderer(4, 4);
         r1.AddRays(new CameraFrame
         {
-            RayData = FullRay(128, 63, 2),
-            SampleOffset = 0
+            RayData = FullRay(128, 63, 2), SampleOffset = 0
         });
 
         var r2 = new CameraRenderer(4, 4);
         r2.AddRays(new CameraFrame
         {
-            RayData = FullRay(128, 63, 10),
-            SampleOffset = 0
+            RayData = FullRay(128, 63, 10), SampleOffset = 0
         });
 
         using var img1 = Decode(r1.Render());
@@ -631,8 +607,7 @@ public class CameraRendererTests
         {
             // Full ray that stores lookback[41], followed by repeat byte 41
             // which should NOT be consumed under the correct loop bound.
-            RayData = [255, 128, 63, 2, 41],
-            SampleOffset = 0
+            RayData = [255, 128, 63, 2, 41], SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -667,8 +642,7 @@ public class CameraRendererTests
         var renderer = new CameraRenderer(4, 4);
         renderer.AddRays(new CameraFrame
         {
-            RayData = [194, 0x80, 0xFF, 41, 0, 0],
-            SampleOffset = 0
+            RayData = [194, 0x80, 0xFF, 41, 0, 0], SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -698,8 +672,7 @@ public class CameraRendererTests
         var renderer = new CameraRenderer(4, 4);
         renderer.AddRays(new CameraFrame
         {
-            RayData = [255, 255, 128, 0, 85, 131, 0],
-            SampleOffset = 0
+            RayData = [255, 255, 128, 0, 85, 131, 0], SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -727,8 +700,7 @@ public class CameraRendererTests
         var renderer = new CameraRenderer(4, 4);
         renderer.AddRays(new CameraFrame
         {
-            RayData = [255, 223, 192, 0, 146, 255, 0],
-            SampleOffset = 0
+            RayData = [255, 223, 192, 0, 146, 255, 0], SampleOffset = 0
         });
 
         using var image = Decode(renderer.Render());
@@ -761,8 +733,7 @@ public class CameraRendererTests
         var exception = Record.Exception(() =>
             renderer.AddRays(new CameraFrame
             {
-                RayData = [.. rays],
-                SampleOffset = 1
+                RayData = [.. rays], SampleOffset = 1
             }));
 
         Assert.Null(exception);

--- a/tests/RustPlusApi.Camera.UnitTests/CameraRendererTests.cs
+++ b/tests/RustPlusApi.Camera.UnitTests/CameraRendererTests.cs
@@ -1,9 +1,7 @@
 using RustPlusApi.Camera;
 using RustPlusApi.Data.Cameras;
-
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-
 using Xunit;
 
 namespace RustPlusApi.Camera.UnitTests;
@@ -154,7 +152,11 @@ public class CameraRendererTests
             rays.AddRange(FullRay(255, 192, 0));
         }
 
-        renderer.AddRays(new CameraFrame { RayData = [.. rays], SampleOffset = 0 });
+        renderer.AddRays(new CameraFrame
+        {
+            RayData = [.. rays],
+            SampleOffset = 0
+        });
 
         using var image = Decode(renderer.Render());
         Assert.True(HasPixel(image, new Rgba32(208, 230, 252)));
@@ -183,14 +185,14 @@ public class CameraRendererTests
     // ──────────────────────────────────────────────────────────────────────────
 
     [Theory]
-    [InlineData(0, 127, 127, 127)]   // [0.5, 0.5, 0.5]
-    [InlineData(1, 204, 178, 178)]   // [0.8, 0.7, 0.7]
-    [InlineData(2, 76, 178, 255)]   // [0.3, 0.7, 1.0]
-    [InlineData(3, 153, 153, 153)]   // [0.6, 0.6, 0.6]
-    [InlineData(4, 178, 178, 178)]   // [0.7, 0.7, 0.7]
-    [InlineData(5, 204, 153, 102)]   // [0.8, 0.6, 0.4]
-    [InlineData(6, 255, 102, 102)]   // [1.0, 0.4, 0.4]
-    [InlineData(7, 255, 25, 25)]   // [1.0, 0.1, 0.1]
+    [InlineData(0, 127, 127, 127)] // [0.5, 0.5, 0.5]
+    [InlineData(1, 204, 178, 178)] // [0.8, 0.7, 0.7]
+    [InlineData(2, 76, 178, 255)] // [0.3, 0.7, 1.0]
+    [InlineData(3, 153, 153, 153)] // [0.6, 0.6, 0.6]
+    [InlineData(4, 178, 178, 178)] // [0.7, 0.7, 0.7]
+    [InlineData(5, 204, 153, 102)] // [0.8, 0.6, 0.4]
+    [InlineData(6, 255, 102, 102)] // [1.0, 0.4, 0.4]
+    [InlineData(7, 255, 25, 25)] // [1.0, 0.1, 0.1]
     public void Material_FullAlignment_ExactPixelColour(int material, byte r, byte g, byte b)
     {
         // b2=63 → alignment=63, t=(128<<2)|(63>>6)=512 (non-sky)
@@ -217,7 +219,11 @@ public class CameraRendererTests
             rays.AddRange(FullRay(128, 63, 2));
         }
 
-        renderer.AddRays(new CameraFrame { RayData = [.. rays], SampleOffset = 0 });
+        renderer.AddRays(new CameraFrame
+        {
+            RayData = [.. rays],
+            SampleOffset = 0
+        });
 
         using var image = Decode(renderer.Render());
         Assert.True(HasPixel(image, new Rgba32(76, 178, 255)));
@@ -228,11 +234,11 @@ public class CameraRendererTests
     // ──────────────────────────────────────────────────────────────────────────
 
     [Theory]
-    [InlineData(0, 64, 64, 64)]  // [0.5,0.5,0.5] * 32/63
-    [InlineData(1, 103, 90, 90)]  // [0.8,0.7,0.7] * 32/63
-    [InlineData(2, 38, 90, 129)]  // [0.3,0.7,1.0] * 32/63
-    [InlineData(5, 103, 77, 51)]  // [0.8,0.6,0.4] * 32/63
-    [InlineData(7, 129, 12, 12)]  // [1.0,0.1,0.1] * 32/63
+    [InlineData(0, 64, 64, 64)] // [0.5,0.5,0.5] * 32/63
+    [InlineData(1, 103, 90, 90)] // [0.8,0.7,0.7] * 32/63
+    [InlineData(2, 38, 90, 129)] // [0.3,0.7,1.0] * 32/63
+    [InlineData(5, 103, 77, 51)] // [0.8,0.6,0.4] * 32/63
+    [InlineData(7, 129, 12, 12)] // [1.0,0.1,0.1] * 32/63
     public void Material_MidAlignment_ExactPixelColour(int material, byte r, byte g, byte b)
     {
         // b2=32 → alignment=32, t=(0<<2)|(32>>6)=0 → not sky (t≠1023)
@@ -292,10 +298,20 @@ public class CameraRendererTests
     {
         // Drive ToByte's > 255 clamp arm: produce alignmentRaw > 63 via small-delta.
         var renderer = new CameraRenderer(16, 16);
-        var rays = new List<byte> { 255, 0, 63, 6 };
+        var rays = new List<byte>
+        {
+            255,
+            0,
+            63,
+            6
+        };
         rays.AddRange([0x79, 0xFF]);
 
-        renderer.AddRays(new CameraFrame { RayData = [.. rays], SampleOffset = 0 });
+        renderer.AddRays(new CameraFrame
+        {
+            RayData = [.. rays],
+            SampleOffset = 0
+        });
         var png = renderer.Render();
 
         Assert.NotEmpty(png);
@@ -337,7 +353,11 @@ public class CameraRendererTests
         rays.AddRange([255, 0, 0, 0]);
         rays.AddRange("@\0"u8.ToArray());
 
-        renderer.AddRays(new CameraFrame { RayData = [.. rays], SampleOffset = 0 });
+        renderer.AddRays(new CameraFrame
+        {
+            RayData = [.. rays],
+            SampleOffset = 0
+        });
         var png = renderer.Render();
 
         Assert.NotEmpty(png);
@@ -384,15 +404,19 @@ public class CameraRendererTests
 
         var rayData = new byte[]
         {
-            255, 128, 63, 2,           // ray 0: full ray
-            41,                         // ray 1: repeat lookback[41]
-            105, 0x80,                  // ray 2: small-delta on lookback[41], g=0x80
-            169, 128,                   // ray 3: medium-delta on lookback[41], g=128
-            0b1100_0001, 0x40, 0x00,   // ray 4: default arm
+            255, 128, 63, 2, // ray 0: full ray
+            41, // ray 1: repeat lookback[41]
+            105, 0x80, // ray 2: small-delta on lookback[41], g=0x80
+            169, 128, // ray 3: medium-delta on lookback[41], g=128
+            0b1100_0001, 0x40, 0x00, // ray 4: default arm
         };
 
         var renderer = new CameraRenderer(4, 4);
-        renderer.AddRays(new CameraFrame { RayData = rayData, SampleOffset = 0 });
+        renderer.AddRays(new CameraFrame
+        {
+            RayData = rayData,
+            SampleOffset = 0
+        });
 
         using var image = Decode(renderer.Render());
 
@@ -414,7 +438,11 @@ public class CameraRendererTests
         rays.AddRange([0b1000_0000, 0x80]);
         rays.AddRange([0b1100_0001, 0x40, 0x00]);
 
-        renderer.AddRays(new CameraFrame { RayData = [.. rays], SampleOffset = 0 });
+        renderer.AddRays(new CameraFrame
+        {
+            RayData = [.. rays],
+            SampleOffset = 0
+        });
         var png = renderer.Render();
 
         Assert.NotEmpty(png);
@@ -464,7 +492,7 @@ public class CameraRendererTests
         var renderer = new CameraRenderer(4, 4);
         renderer.AddRays(new CameraFrame
         {
-            RayData = FullRay(128, 63, 0),  // mat0, r=63 → (127,127,127)
+            RayData = FullRay(128, 63, 0), // mat0, r=63 → (127,127,127)
             SampleOffset = 2
         });
 
@@ -483,10 +511,18 @@ public class CameraRendererTests
     {
         // 4×4: 2*width*height = 32. sampleOffset=32 wraps to 0 → same as sampleOffset=0.
         var renderer1 = new CameraRenderer(4, 4);
-        renderer1.AddRays(new CameraFrame { RayData = FullRay(128, 63, 2), SampleOffset = 0 });
+        renderer1.AddRays(new CameraFrame
+        {
+            RayData = FullRay(128, 63, 2),
+            SampleOffset = 0
+        });
 
         var renderer2 = new CameraRenderer(4, 4);
-        renderer2.AddRays(new CameraFrame { RayData = FullRay(128, 63, 2), SampleOffset = 32 });
+        renderer2.AddRays(new CameraFrame
+        {
+            RayData = FullRay(128, 63, 2),
+            SampleOffset = 32
+        });
 
         using var img1 = Decode(renderer1.Render());
         using var img2 = Decode(renderer2.Render());
@@ -504,9 +540,17 @@ public class CameraRendererTests
     {
         var renderer = new CameraRenderer(4, 4);
         // Frame 1: paint image(2,2) with mat2 (76,178,255)
-        renderer.AddRays(new CameraFrame { RayData = FullRay(128, 63, 2), SampleOffset = 0 });
+        renderer.AddRays(new CameraFrame
+        {
+            RayData = FullRay(128, 63, 2),
+            SampleOffset = 0
+        });
         // Frame 2: repaint image(2,2) with mat0 (127,127,127)
-        renderer.AddRays(new CameraFrame { RayData = FullRay(128, 63, 0), SampleOffset = 0 });
+        renderer.AddRays(new CameraFrame
+        {
+            RayData = FullRay(128, 63, 0),
+            SampleOffset = 0
+        });
 
         using var image = Decode(renderer.Render());
 
@@ -526,7 +570,7 @@ public class CameraRendererTests
         // Need to use sampleOffset=6 so the ray hits sample[3]
         renderer.AddRays(new CameraFrame
         {
-            RayData = FullRay(128, 63, 3),  // mat3, r=63 → (153,153,153)
+            RayData = FullRay(128, 63, 3), // mat3, r=63 → (153,153,153)
             SampleOffset = 6
         });
 
@@ -545,10 +589,18 @@ public class CameraRendererTests
     {
         // mat=10 should map to same palette as mat=2 (10%8=2)
         var r1 = new CameraRenderer(4, 4);
-        r1.AddRays(new CameraFrame { RayData = FullRay(128, 63, 2), SampleOffset = 0 });
+        r1.AddRays(new CameraFrame
+        {
+            RayData = FullRay(128, 63, 2),
+            SampleOffset = 0
+        });
 
         var r2 = new CameraRenderer(4, 4);
-        r2.AddRays(new CameraFrame { RayData = FullRay(128, 63, 10), SampleOffset = 0 });
+        r2.AddRays(new CameraFrame
+        {
+            RayData = FullRay(128, 63, 10),
+            SampleOffset = 0
+        });
 
         using var img1 = Decode(r1.Render());
         using var img2 = Decode(r2.Render());
@@ -586,7 +638,7 @@ public class CameraRendererTests
         using var image = Decode(renderer.Render());
 
         Assert.Equal(new Rgba32(76, 178, 255), image[2, 2]); // full ray always paints this
-        Assert.Equal(new Rgba32(0, 0, 0, 0), image[3, 0]);   // repeat NOT consumed → transparent
+        Assert.Equal(new Rgba32(0, 0, 0, 0), image[3, 0]); // repeat NOT consumed → transparent
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -707,7 +759,11 @@ public class CameraRendererTests
         }
 
         var exception = Record.Exception(() =>
-            renderer.AddRays(new CameraFrame { RayData = [.. rays], SampleOffset = 1 }));
+            renderer.AddRays(new CameraFrame
+            {
+                RayData = [.. rays],
+                SampleOffset = 1
+            }));
 
         Assert.Null(exception);
         using var image = Decode(renderer.Render());

--- a/tests/RustPlusApi.Camera.UnitTests/IndexGeneratorTests.cs
+++ b/tests/RustPlusApi.Camera.UnitTests/IndexGeneratorTests.cs
@@ -132,7 +132,10 @@ public class IndexGeneratorTests
     {
         // Captures the exact 0/1 stream for seed 1337, killing the divisor mutation.
         var g = new IndexGenerator(1337);
-        foreach (var exp in new int[] { 0, 1, 1, 0, 1, 1, 0, 0, 1, 0 })
+        foreach (var exp in new int[]
+                 {
+                     0, 1, 1, 0, 1, 1, 0, 0, 1, 0
+                 })
         {
             Assert.Equal(exp, g.NextInt(2));
         }

--- a/tests/RustPlusApi.Extensions.DependencyInjection.UnitTests/RustPlusServiceCollectionExtensionsTests.cs
+++ b/tests/RustPlusApi.Extensions.DependencyInjection.UnitTests/RustPlusServiceCollectionExtensionsTests.cs
@@ -126,7 +126,10 @@ public class RustPlusServiceCollectionExtensionsTests
     public async Task AddRustPlus_WithPartialConfigurationSection_ThrowsOnResolve()
     {
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?> { ["Rust:Server"] = "1.2.3.4" })
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Rust:Server"] = "1.2.3.4"
+            })
             .Build();
         var services = new ServiceCollection();
         services.AddRustPlus(config.GetSection("Rust"));
@@ -168,6 +171,7 @@ public class RustPlusServiceCollectionExtensionsTests
         Assert.Throws<ArgumentNullException>(() => ((IServiceCollection)null!).AddRustPlus(AnyConnection()));
         Assert.Throws<ArgumentNullException>(() => services.AddRustPlus((RustPlusConnection)null!));
         Assert.Throws<ArgumentNullException>(() => services.AddRustPlus((IConfiguration)null!));
-        Assert.Throws<ArgumentNullException>(() => services.AddRustPlus((Func<IServiceProvider, RustPlusConnection>)null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            services.AddRustPlus((Func<IServiceProvider, RustPlusConnection>)null!));
     }
 }

--- a/tests/RustPlusApi.Fcm.Extensions.DependencyInjection.UnitTests/RustPlusFcmServiceCollectionExtensionsTests.cs
+++ b/tests/RustPlusApi.Fcm.Extensions.DependencyInjection.UnitTests/RustPlusFcmServiceCollectionExtensionsTests.cs
@@ -13,8 +13,7 @@ public class RustPlusFcmServiceCollectionExtensionsTests
     {
         Gcm = new Gcm
         {
-            AndroidId = 1,
-            SecurityToken = 1
+            AndroidId = 1, SecurityToken = 1
         }
     };
 

--- a/tests/RustPlusApi.Fcm.Extensions.DependencyInjection.UnitTests/RustPlusFcmServiceCollectionExtensionsTests.cs
+++ b/tests/RustPlusApi.Fcm.Extensions.DependencyInjection.UnitTests/RustPlusFcmServiceCollectionExtensionsTests.cs
@@ -9,7 +9,14 @@ namespace RustPlusApi.Fcm.Extensions.DependencyInjection.UnitTests;
 
 public class RustPlusFcmServiceCollectionExtensionsTests
 {
-    private static Credentials AnyCredentials() => new() { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 } };
+    private static Credentials AnyCredentials() => new()
+    {
+        Gcm = new Gcm
+        {
+            AndroidId = 1,
+            SecurityToken = 1
+        }
+    };
 
     [Fact]
     public void AddRustPlusFcm_WithCredentials_RegistersIRustPlusFcmAsSingleton()

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/AndroidFcmRegisterTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/AndroidFcmRegisterTests.cs
@@ -35,7 +35,7 @@ public class AndroidFcmRegisterTests
         return text.Split('&', StringSplitOptions.RemoveEmptyEntries)
             .Select(pair => pair.Split('=', 2))
             .ToDictionary(parts => Decode(parts[0]),
-                          parts => parts.Length > 1 ? Decode(parts[1]) : string.Empty);
+                parts => parts.Length > 1 ? Decode(parts[1]) : string.Empty);
     }
 
     /// <summary>Asserts the request carries exactly one value for <paramref name="name"/> and returns it.</summary>
@@ -120,7 +120,11 @@ public class AndroidFcmRegisterTests
         var register = new AndroidFcmRegister(handler.CreateClient());
 
         var token = await register.RegisterFcmAsync(
-            new RustPlusApi.Fcm.Data.Gcm { AndroidId = 42, SecurityToken = 99 }, "fis-auth-token");
+            new RustPlusApi.Fcm.Data.Gcm
+            {
+                AndroidId = 42,
+                SecurityToken = 99
+            }, "fis-auth-token");
 
         Assert.Equal("the-fcm-token", token);
 
@@ -146,7 +150,8 @@ public class AndroidFcmRegisterTests
         Assert.Equal("*", form["X-scope"]);
         Assert.Equal("fis-auth-token", form["X-Goog-Firebase-Installations-Auth"]);
         Assert.Equal(RegistrationConstants.GmsAppId, form["X-gms_app_id"]);
-        Assert.Equal("fire-abt/21.1.1 fire-installations/17.0.0 fire-android/ fire-core/20.3.1", form["X-Firebase-Client"]);
+        Assert.Equal("fire-abt/21.1.1 fire-installations/17.0.0 fire-android/ fire-core/20.3.1",
+            form["X-Firebase-Client"]);
         Assert.Equal("R1dAH9Ui7M-ynoznwBdw01tLxhI", form["X-firebase-app-name-hash"]);
         Assert.Equal("FIS_v2", form["X-Goog-Firebase-Installations-Auth-Version"]);
         Assert.Equal(RegistrationConstants.GcmSenderId, form["sender"]);
@@ -161,7 +166,11 @@ public class AndroidFcmRegisterTests
         var register = new AndroidFcmRegister(handler.CreateClient());
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            register.RegisterFcmAsync(new RustPlusApi.Fcm.Data.Gcm { AndroidId = 1, SecurityToken = 2 }, "fis"));
+            register.RegisterFcmAsync(new RustPlusApi.Fcm.Data.Gcm
+            {
+                AndroidId = 1,
+                SecurityToken = 2
+            }, "fis"));
         Assert.Equal(5, handler.Requests.Count); // five attempts
     }
 
@@ -175,7 +184,11 @@ public class AndroidFcmRegisterTests
         });
         var register = new AndroidFcmRegister(handler.CreateClient());
 
-        var token = await register.RegisterFcmAsync(new RustPlusApi.Fcm.Data.Gcm { AndroidId = 1, SecurityToken = 2 }, "fis");
+        var token = await register.RegisterFcmAsync(new RustPlusApi.Fcm.Data.Gcm
+        {
+            AndroidId = 1,
+            SecurityToken = 2
+        }, "fis");
 
         Assert.Equal("ok", token);
         Assert.Equal(3, handler.Requests.Count);
@@ -189,15 +202,24 @@ public class AndroidFcmRegisterTests
             var url = req.RequestUri!.ToString();
             if (url.Contains("checkin", StringComparison.Ordinal))
             {
-                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(CheckinResponseBytes(5, 6)) };
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(CheckinResponseBytes(5, 6))
+                };
             }
 
             if (url.Contains("installations", StringComparison.Ordinal))
             {
-                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("""{ "authToken": { "token": "fis" } }""") };
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""{ "authToken": { "token": "fis" } }""")
+                };
             }
 
-            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("token=final") };
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("token=final")
+            };
         });
         var register = new AndroidFcmRegister(handler.CreateClient());
 
@@ -301,7 +323,11 @@ public class AndroidFcmRegisterTests
         var handler = StubHttpMessageHandler.Always(HttpStatusCode.OK, "Error=PHONE_REGISTRATION_ERROR");
         var register = new AndroidFcmRegister(handler.CreateClient());
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            register.RegisterFcmAsync(new RustPlusApi.Fcm.Data.Gcm { AndroidId = 1, SecurityToken = 2 }, "fis"));
+            register.RegisterFcmAsync(new RustPlusApi.Fcm.Data.Gcm
+            {
+                AndroidId = 1,
+                SecurityToken = 2
+            }, "fis"));
         Assert.False(string.IsNullOrEmpty(ex.Message));
         Assert.Contains("attempts", ex.Message, StringComparison.OrdinalIgnoreCase);
     }

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/AndroidFcmRegisterTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/AndroidFcmRegisterTests.cs
@@ -17,9 +17,7 @@ public class AndroidFcmRegisterTests
         using var ms = new MemoryStream();
         Serializer.Serialize(ms, new AndroidCheckinResponse
         {
-            StatsOk = true,
-            AndroidId = androidId,
-            SecurityToken = securityToken
+            StatsOk = true, AndroidId = androidId, SecurityToken = securityToken
         });
         return ms.ToArray();
     }
@@ -122,8 +120,7 @@ public class AndroidFcmRegisterTests
         var token = await register.RegisterFcmAsync(
             new RustPlusApi.Fcm.Data.Gcm
             {
-                AndroidId = 42,
-                SecurityToken = 99
+                AndroidId = 42, SecurityToken = 99
             }, "fis-auth-token");
 
         Assert.Equal("the-fcm-token", token);
@@ -168,8 +165,7 @@ public class AndroidFcmRegisterTests
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             register.RegisterFcmAsync(new RustPlusApi.Fcm.Data.Gcm
             {
-                AndroidId = 1,
-                SecurityToken = 2
+                AndroidId = 1, SecurityToken = 2
             }, "fis"));
         Assert.Equal(5, handler.Requests.Count); // five attempts
     }
@@ -186,8 +182,7 @@ public class AndroidFcmRegisterTests
 
         var token = await register.RegisterFcmAsync(new RustPlusApi.Fcm.Data.Gcm
         {
-            AndroidId = 1,
-            SecurityToken = 2
+            AndroidId = 1, SecurityToken = 2
         }, "fis");
 
         Assert.Equal("ok", token);
@@ -325,8 +320,7 @@ public class AndroidFcmRegisterTests
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             register.RegisterFcmAsync(new RustPlusApi.Fcm.Data.Gcm
             {
-                AndroidId = 1,
-                SecurityToken = 2
+                AndroidId = 1, SecurityToken = 2
             }, "fis"));
         Assert.False(string.IsNullOrEmpty(ex.Message));
         Assert.Contains("attempts", ex.Message, StringComparison.OrdinalIgnoreCase);

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/CredentialsStoreFileTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/CredentialsStoreFileTests.cs
@@ -15,8 +15,15 @@ public class CredentialsStoreFileTests
         {
             var credentials = new Credentials
             {
-                Gcm = new Gcm { AndroidId = 1, SecurityToken = 2 },
-                Fcm = new FcmToken { Token = "t" },
+                Gcm = new Gcm
+                {
+                    AndroidId = 1,
+                    SecurityToken = 2
+                },
+                Fcm = new FcmToken
+                {
+                    Token = "t"
+                },
                 ExpoPushToken = "ExponentPushToken[a]"
             };
             CredentialsStore.Save(path, credentials);
@@ -44,7 +51,14 @@ public class CredentialsStoreFileTests
     [Fact]
     public void Serialize_ProducesIndentedJson()
     {
-        var credentials = new Credentials { Gcm = new Gcm { AndroidId = 7, SecurityToken = 3 } };
+        var credentials = new Credentials
+        {
+            Gcm = new Gcm
+            {
+                AndroidId = 7,
+                SecurityToken = 3
+            }
+        };
 
         var json = CredentialsStore.Serialize(credentials);
 

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/CredentialsStoreFileTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/CredentialsStoreFileTests.cs
@@ -17,8 +17,7 @@ public class CredentialsStoreFileTests
             {
                 Gcm = new Gcm
                 {
-                    AndroidId = 1,
-                    SecurityToken = 2
+                    AndroidId = 1, SecurityToken = 2
                 },
                 Fcm = new FcmToken
                 {
@@ -55,8 +54,7 @@ public class CredentialsStoreFileTests
         {
             Gcm = new Gcm
             {
-                AndroidId = 7,
-                SecurityToken = 3
+                AndroidId = 7, SecurityToken = 3
             }
         };
 

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/FcmRegistrationTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/FcmRegistrationTests.cs
@@ -25,9 +25,7 @@ public class FcmRegistrationTests
                 using var ms = new MemoryStream();
                 Serializer.Serialize(ms, new AndroidCheckinResponse
                 {
-                    StatsOk = true,
-                    AndroidId = 9,
-                    SecurityToken = 8
+                    StatsOk = true, AndroidId = 9, SecurityToken = 8
                 });
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
@@ -86,8 +84,7 @@ public class FcmRegistrationTests
         {
             Gcm = new Gcm
             {
-                AndroidId = 1,
-                SecurityToken = 1
+                AndroidId = 1, SecurityToken = 1
             },
             ExpoPushToken = null
         };

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/FcmRegistrationTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/FcmRegistrationTests.cs
@@ -23,21 +23,39 @@ public class FcmRegistrationTests
             if (url.Contains("checkin", StringComparison.Ordinal))
             {
                 using var ms = new MemoryStream();
-                Serializer.Serialize(ms, new AndroidCheckinResponse { StatsOk = true, AndroidId = 9, SecurityToken = 8 });
-                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(ms.ToArray()) };
+                Serializer.Serialize(ms, new AndroidCheckinResponse
+                {
+                    StatsOk = true,
+                    AndroidId = 9,
+                    SecurityToken = 8
+                });
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(ms.ToArray())
+                };
             }
+
             if (url.Contains("installations", StringComparison.Ordinal))
             {
-                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("""{ "authToken": { "token": "fis" } }""") };
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""{ "authToken": { "token": "fis" } }""")
+                };
             }
 
             if (url.Contains("register", StringComparison.Ordinal)) // FCM c2dm register
             {
-                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("token=fcm") };
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("token=fcm")
+                };
             }
 
             // Expo
-            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("""{ "data": { "expoPushToken": "ExponentPushToken[e]" } }""") };
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{ "data": { "expoPushToken": "ExponentPushToken[e]" } }""")
+            };
         });
         var registration = new FcmRegistration(handler.CreateClient());
 
@@ -64,7 +82,15 @@ public class FcmRegistrationTests
     public async Task RegisterWithRustPlusAsync_MissingExpoToken_Throws()
     {
         var registration = new FcmRegistration();
-        var credentials = new Credentials { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 }, ExpoPushToken = null };
+        var credentials = new Credentials
+        {
+            Gcm = new Gcm
+            {
+                AndroidId = 1,
+                SecurityToken = 1
+            },
+            ExpoPushToken = null
+        };
         await Assert.ThrowsAsync<InvalidOperationException>(() => registration.RegisterWithRustPlusAsync(credentials));
     }
 }

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/RegistrationTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/RegistrationTests.cs
@@ -50,9 +50,7 @@ public class RegistrationTests
     {
         var response = new AndroidCheckinResponse
         {
-            StatsOk = true,
-            AndroidId = 1234567890123UL,
-            SecurityToken = 9876543210987UL
+            StatsOk = true, AndroidId = 1234567890123UL, SecurityToken = 9876543210987UL
         };
 
         using var stream = new MemoryStream();
@@ -86,8 +84,7 @@ public class RegistrationTests
         {
             Gcm = new Gcm
             {
-                AndroidId = 42,
-                SecurityToken = 7
+                AndroidId = 42, SecurityToken = 7
             },
             Fcm = new FcmToken
             {
@@ -112,9 +109,7 @@ public class RegistrationTests
             PlayerToken = 123456789,
             Data = new ServerEvent
             {
-                Ip = "1.2.3.4",
-                Port = 28083,
-                Name = "My Server"
+                Ip = "1.2.3.4", Port = 28083, Name = "My Server"
             }
         };
 
@@ -162,8 +157,7 @@ public class RegistrationTests
         {
             Gcm = new Gcm
             {
-                AndroidId = 1,
-                SecurityToken = 1
+                AndroidId = 1, SecurityToken = 1
             }
         };
 

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/RegistrationTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/RegistrationTests.cs
@@ -84,8 +84,15 @@ public class RegistrationTests
     {
         var credentials = new Credentials
         {
-            Gcm = new Gcm { AndroidId = 42, SecurityToken = 7 },
-            Fcm = new FcmToken { Token = "fcm-token" },
+            Gcm = new Gcm
+            {
+                AndroidId = 42,
+                SecurityToken = 7
+            },
+            Fcm = new FcmToken
+            {
+                Token = "fcm-token"
+            },
             ExpoPushToken = "ExponentPushToken[abc]"
         };
 
@@ -103,7 +110,12 @@ public class RegistrationTests
         {
             PlayerId = 76561198000000000,
             PlayerToken = 123456789,
-            Data = new ServerEvent { Ip = "1.2.3.4", Port = 28083, Name = "My Server" }
+            Data = new ServerEvent
+            {
+                Ip = "1.2.3.4",
+                Port = 28083,
+                Name = "My Server"
+            }
         };
 
         var pairing = PairingListener.ToServerPairing(notification);
@@ -126,7 +138,7 @@ public class RegistrationTests
         {
             PlayerId = 76561198000000000,
             PlayerToken = 999,
-            Data = null  // server is null → all server?.Xxx produce null → ?? fallbacks used
+            Data = null // server is null → all server?.Xxx produce null → ?? fallbacks used
         };
 
         var pairing = PairingListener.ToServerPairing(notification);
@@ -146,14 +158,21 @@ public class RegistrationTests
     [Fact]
     public void PairingListener_ConstructAndDispose_DoesNotThrow()
     {
-        var credentials = new Credentials { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 } };
+        var credentials = new Credentials
+        {
+            Gcm = new Gcm
+            {
+                AndroidId = 1,
+                SecurityToken = 1
+            }
+        };
 
         var listener = new PairingListener(credentials);
 
         var ex = Record.Exception(() =>
         {
             listener.Dispose();
-            listener.Dispose();  // idempotent
+            listener.Dispose(); // idempotent
         });
         Assert.Null(ex);
     }

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/TestHelpers/StubHttpMessageHandler.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/TestHelpers/StubHttpMessageHandler.cs
@@ -39,7 +39,8 @@ public sealed class StubHttpMessageHandler(
 
     /// <inheritdoc/>
     protected override async Task<HttpResponseMessage> SendAsync(
-        HttpRequestMessage request, CancellationToken cancellationToken)
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
     {
         var index = _callIndex++;
         Requests.Add(request);

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/TestHelpers/StubHttpMessageHandler.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/TestHelpers/StubHttpMessageHandler.cs
@@ -23,13 +23,19 @@ public sealed class StubHttpMessageHandler(
     /// <param name="status">The HTTP status code to return for every request.</param>
     /// <param name="body">The raw byte body to include in every response.</param>
     public static StubHttpMessageHandler Always(HttpStatusCode status, byte[] body) =>
-        new((_, _) => new HttpResponseMessage(status) { Content = new ByteArrayContent(body) });
+        new((_, _) => new HttpResponseMessage(status)
+        {
+            Content = new ByteArrayContent(body)
+        });
 
     /// <summary>Convenience ctor: always return the same status + string body.</summary>
     /// <param name="status">The HTTP status code to return for every request.</param>
     /// <param name="body">The string body to include in every response.</param>
     public static StubHttpMessageHandler Always(HttpStatusCode status, string body) =>
-        new((_, _) => new HttpResponseMessage(status) { Content = new StringContent(body) });
+        new((_, _) => new HttpResponseMessage(status)
+        {
+            Content = new StringContent(body)
+        });
 
     /// <inheritdoc/>
     protected override async Task<HttpResponseMessage> SendAsync(

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
@@ -10,7 +10,12 @@ public class FcmExtensionMapperTests
     [Fact]
     public void ToEntityEvent_MapsTypeIdName()
     {
-        var body = new Body { EntityType = 1, EntityId = 42, EntityName = "Switch" };
+        var body = new Body
+        {
+            EntityType = 1,
+            EntityId = 42,
+            EntityName = "Switch"
+        };
         var ev = body.ToEntityEvent();
         Assert.Equal(1, ev.EntityType);
         Assert.Equal(42, ev.EntityId);
@@ -21,7 +26,13 @@ public class FcmExtensionMapperTests
     [Fact]
     public void ToServerEvent_NullEntityName_BecomesEmpty()
     {
-        var body = new Body { Id = Guid.Empty, Ip = "1.2.3.4", Port = 28083, EntityName = null };
+        var body = new Body
+        {
+            Id = Guid.Empty,
+            Ip = "1.2.3.4",
+            Port = 28083,
+            EntityName = null
+        };
         var ev = body.ToServerEvent();
         Assert.Equal(string.Empty, ev.Name);
         Assert.Equal("1.2.3.4", ev.Ip);
@@ -31,14 +42,23 @@ public class FcmExtensionMapperTests
     [Fact]
     public void ToServerEvent_WithEntityName_UsesIt()
     {
-        var body = new Body { EntityName = "My Server", Ip = "1.2.3.4", Port = 1 };
+        var body = new Body
+        {
+            EntityName = "My Server",
+            Ip = "1.2.3.4",
+            Port = 1
+        };
         Assert.Equal("My Server", body.ToServerEvent().Name);
     }
 
     [Fact]
     public void ToAlarmEvent_MapsTitleAndMessage()
     {
-        var data = new MessageData { Title = "Base attacked", Message = "Door opened" };
+        var data = new MessageData
+        {
+            Title = "Base attacked",
+            Message = "Door opened"
+        };
         var ev = data.ToAlarmEvent();
         Assert.Equal("Base attacked", ev.Title);
         Assert.Equal("Door opened", ev.Message);

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
@@ -12,9 +12,7 @@ public class FcmExtensionMapperTests
     {
         var body = new Body
         {
-            EntityType = 1,
-            EntityId = 42,
-            EntityName = "Switch"
+            EntityType = 1, EntityId = 42, EntityName = "Switch"
         };
         var ev = body.ToEntityEvent();
         Assert.Equal(1, ev.EntityType);
@@ -28,10 +26,7 @@ public class FcmExtensionMapperTests
     {
         var body = new Body
         {
-            Id = Guid.Empty,
-            Ip = "1.2.3.4",
-            Port = 28083,
-            EntityName = null
+            Id = Guid.Empty, Ip = "1.2.3.4", Port = 28083, EntityName = null
         };
         var ev = body.ToServerEvent();
         Assert.Equal(string.Empty, ev.Name);
@@ -44,9 +39,7 @@ public class FcmExtensionMapperTests
     {
         var body = new Body
         {
-            EntityName = "My Server",
-            Ip = "1.2.3.4",
-            Port = 1
+            EntityName = "My Server", Ip = "1.2.3.4", Port = 1
         };
         Assert.Equal("My Server", body.ToServerEvent().Name);
     }
@@ -56,8 +49,7 @@ public class FcmExtensionMapperTests
     {
         var data = new MessageData
         {
-            Title = "Base attacked",
-            Message = "Door opened"
+            Title = "Base attacked", Message = "Door opened"
         };
         var ev = data.ToAlarmEvent();
         Assert.Equal("Base attacked", ev.Title);

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmJsonTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmJsonTests.cs
@@ -12,21 +12,24 @@ namespace RustPlusApi.Fcm.UnitTests;
 public class FcmJsonTests
 {
     /// <summary>Mirrors RustPlusFcmSocket's parsing options (Rust+ sends camelCase keys).</summary>
-    private static readonly JsonSerializerOptions Options = new() { PropertyNameCaseInsensitive = true };
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
 
     private const string PairingBodyJson = """
-        {
-          "id": "11111111-1111-1111-1111-111111111111",
-          "ip": "1.2.3.4",
-          "port": "28083",
-          "name": "Mock Server",
-          "playerId": "76561198000000000",
-          "playerToken": "123456789",
-          "type": "entity",
-          "entityType": "1",
-          "entityId": "98765"
-        }
-        """;
+                                           {
+                                             "id": "11111111-1111-1111-1111-111111111111",
+                                             "ip": "1.2.3.4",
+                                             "port": "28083",
+                                             "name": "Mock Server",
+                                             "playerId": "76561198000000000",
+                                             "playerToken": "123456789",
+                                             "type": "entity",
+                                             "entityType": "1",
+                                             "entityId": "98765"
+                                           }
+                                           """;
 
     [Fact]
     public void Body_ReadsNumericFieldsEncodedAsStrings()
@@ -60,7 +63,8 @@ public class FcmJsonTests
     public void Body_AcceptsNumericJsonToo()
     {
         // Defensive: also accept real JSON numbers, not only strings.
-        const string json = """{ "ip": "1.2.3.4", "port": 28083, "playerId": 42, "name": "n", "playerToken": "t", "type": "server" }""";
+        const string json =
+            """{ "ip": "1.2.3.4", "port": 28083, "playerId": 42, "name": "n", "playerToken": "t", "type": "server" }""";
 
         var body = JsonSerializer.Deserialize<Body>(json, Options);
 

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmLoggingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmLoggingTests.cs
@@ -12,8 +12,7 @@ public class FcmLoggingTests
         {
             Gcm = new Gcm
             {
-                AndroidId = 1,
-                SecurityToken = 1
+                AndroidId = 1, SecurityToken = 1
             }
         };
 
@@ -74,8 +73,7 @@ public class FcmLoggingTests
         {
             Gcm = new Gcm
             {
-                AndroidId = 1,
-                SecurityToken = 1
+                AndroidId = 1, SecurityToken = 1
             }
         }, loggerFactory: loggerFactory)
     {

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmLoggingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmLoggingTests.cs
@@ -8,7 +8,14 @@ namespace RustPlusApi.Fcm.UnitTests;
 public class FcmLoggingTests
 {
     private static Credentials AnyCredentials() =>
-        new() { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 } };
+        new()
+        {
+            Gcm = new Gcm
+            {
+                AndroidId = 1,
+                SecurityToken = 1
+            }
+        };
 
     [Fact]
     public void Constructor_WithNoOptions_DoesNotThrow()
@@ -40,7 +47,10 @@ public class FcmLoggingTests
 
         fcm.InvokeParseNotification(new FcmMessage
         {
-            Data = new MessageData { ChannelId = "not-a-known-channel" }
+            Data = new MessageData
+            {
+                ChannelId = "not-a-known-channel"
+            }
         });
 
         Assert.Single(factory.Logger.Entries, e =>
@@ -51,13 +61,23 @@ public class FcmLoggingTests
     /// <param name="credentials">The FCM credentials.</param>
     /// <param name="options">Optional socket options.</param>
     /// <param name="loggerFactory">Optional logger factory.</param>
-    private sealed class TestSocket(Credentials credentials, RustPlusFcmSocketOptions? options = null, ILoggerFactory? loggerFactory = null)
+    private sealed class TestSocket(
+        Credentials credentials,
+        RustPlusFcmSocketOptions? options = null,
+        ILoggerFactory? loggerFactory = null)
         : RustPlusFcmSocket(credentials, options: options, loggerFactory: loggerFactory);
 
     /// <summary>Exposes the protected ParseNotification so the unknown-channel path can be driven.</summary>
     /// <param name="loggerFactory">The logger factory under test.</param>
     private sealed class TestableRustPlusFcm(ILoggerFactory loggerFactory)
-        : RustPlusFcm(new Credentials { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 } }, loggerFactory: loggerFactory)
+        : RustPlusFcm(new Credentials
+        {
+            Gcm = new Gcm
+            {
+                AndroidId = 1,
+                SecurityToken = 1
+            }
+        }, loggerFactory: loggerFactory)
     {
         public void InvokeParseNotification(FcmMessage message) => ParseNotification(message);
     }

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
@@ -28,8 +28,7 @@ public class FcmSocketFramingTests
         {
             Gcm = new Gcm
             {
-                AndroidId = 1,
-                SecurityToken = 1
+                AndroidId = 1, SecurityToken = 1
             }
         };
 
@@ -121,8 +120,7 @@ public class FcmSocketFramingTests
             NextFrame(McsProtoTag.KDataMessageStanzaTag, RustNotification()),
             NextFrame(McsProtoTag.KHeartbeatPingTag, new HeartbeatPing
             {
-                StreamId = 1,
-                Status = 0
+                StreamId = 1, Status = 0
             }),
             NextFrame(McsProtoTag.KCloseTag, new Close())));
 
@@ -204,13 +202,11 @@ public class FcmSocketFramingTests
             {
                 new AppData
                 {
-                    Key = "channelId",
-                    Value = "pairing"
+                    Key = "channelId", Value = "pairing"
                 },
                 new AppData
                 {
-                    Key = "body",
-                    Value = body
+                    Key = "body", Value = body
                 },
             }
         };
@@ -247,8 +243,7 @@ public class FcmSocketFramingTests
             FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
             NextFrame(McsProtoTag.KHeartbeatPingTag, new HeartbeatPing
             {
-                StreamId = 7,
-                Status = 0
+                StreamId = 7, Status = 0
             }),
             NextFrame(McsProtoTag.KCloseTag, new Close())));
 
@@ -334,8 +329,7 @@ public class FcmSocketFramingTests
             {
                 new AppData
                 {
-                    Key = "body",
-                    Value = "{}"
+                    Key = "body", Value = "{}"
                 }
             } // no channelId
         };
@@ -365,8 +359,7 @@ public class FcmSocketFramingTests
             {
                 new AppData
                 {
-                    Key = "channelId",
-                    Value = "pairing"
+                    Key = "channelId", Value = "pairing"
                 }
             } // no body
         };
@@ -421,13 +414,11 @@ public class FcmSocketFramingTests
             {
                 new AppData
                 {
-                    Key = "channelId",
-                    Value = "pairing"
+                    Key = "channelId", Value = "pairing"
                 },
                 new AppData
                 {
-                    Key = "body",
-                    Value = longBody
+                    Key = "body", Value = longBody
                 },
             }
         };
@@ -539,38 +530,31 @@ public class FcmSocketFramingTests
             {
                 new AppData
                 {
-                    Key = "channelId",
-                    Value = "pairing"
+                    Key = "channelId", Value = "pairing"
                 },
                 new AppData
                 {
-                    Key = "body",
-                    Value = "{}"
+                    Key = "body", Value = "{}"
                 },
                 new AppData
                 {
-                    Key = "title",
-                    Value = "Test Title"
+                    Key = "title", Value = "Test Title"
                 },
                 new AppData
                 {
-                    Key = "projectId",
-                    Value = "00000000-0000-0000-0000-000000000001"
+                    Key = "projectId", Value = "00000000-0000-0000-0000-000000000001"
                 },
                 new AppData
                 {
-                    Key = "experienceId",
-                    Value = "@scope/exp"
+                    Key = "experienceId", Value = "@scope/exp"
                 },
                 new AppData
                 {
-                    Key = "scopeKey",
-                    Value = "myScope"
+                    Key = "scopeKey", Value = "myScope"
                 },
                 new AppData
                 {
-                    Key = "message",
-                    Value = "hello world"
+                    Key = "message", Value = "hello world"
                 },
             }
         };
@@ -611,13 +595,11 @@ public class FcmSocketFramingTests
             {
                 new AppData
                 {
-                    Key = "channelId",
-                    Value = "pairing"
+                    Key = "channelId", Value = "pairing"
                 },
                 new AppData
                 {
-                    Key = "body",
-                    Value = "{}"
+                    Key = "body", Value = "{}"
                 },
             }
         };
@@ -653,13 +635,11 @@ public class FcmSocketFramingTests
             {
                 new AppData
                 {
-                    Key = "channelId",
-                    Value = "pairing"
+                    Key = "channelId", Value = "pairing"
                 },
                 new AppData
                 {
-                    Key = "body",
-                    Value = "{}"
+                    Key = "body", Value = "{}"
                 },
             }
         };
@@ -877,13 +857,11 @@ public class FcmSocketFramingTests
             {
                 new AppData
                 {
-                    Key = "channelId",
-                    Value = "pairing"
+                    Key = "channelId", Value = "pairing"
                 },
                 new AppData
                 {
-                    Key = "body",
-                    Value = lowerCaseBody
+                    Key = "body", Value = lowerCaseBody
                 },
             }
         };

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
@@ -24,7 +24,14 @@ public class FcmSocketFramingTests
         : RustPlusFcmSocket(credentials, persistentIds);
 
     private static Credentials NewCredentials() =>
-        new() { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 } };
+        new()
+        {
+            Gcm = new Gcm
+            {
+                AndroidId = 1,
+                SecurityToken = 1
+            }
+        };
 
     private static TestSocket NewSocket(ICollection<string>? persistentIds = null) =>
         new(NewCredentials(), persistentIds);
@@ -44,7 +51,12 @@ public class FcmSocketFramingTests
         public override bool CanWrite => true;
         public override bool CanSeek => false;
         public override long Length => throw new NotSupportedException();
-        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
 
         public override int Read(byte[] buffer, int offset, int count) => _reads.Read(buffer, offset, count);
         public override int ReadByte() => _reads.ReadByte();
@@ -70,11 +82,20 @@ public class FcmSocketFramingTests
         public override bool CanWrite => true;
         public override bool CanSeek => false;
         public override long Length => throw new NotSupportedException();
-        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
 
-        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException("synchronous Read is not allowed");
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException("synchronous Read is not allowed");
+
         public override int ReadByte() => throw new NotSupportedException("synchronous ReadByte is not allowed");
-        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException("synchronous Write is not allowed");
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException("synchronous Write is not allowed");
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             => _reads.ReadAsync(buffer, offset, count, cancellationToken);
@@ -98,7 +119,11 @@ public class FcmSocketFramingTests
         var stream = new AsyncOnlyStream(Build(
             FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
             NextFrame(McsProtoTag.KDataMessageStanzaTag, RustNotification()),
-            NextFrame(McsProtoTag.KHeartbeatPingTag, new HeartbeatPing { StreamId = 1, Status = 0 }),
+            NextFrame(McsProtoTag.KHeartbeatPingTag, new HeartbeatPing
+            {
+                StreamId = 1,
+                Status = 0
+            }),
             NextFrame(McsProtoTag.KCloseTag, new Close())));
 
         // Must complete using async I/O only: synchronous Read/Write on AsyncOnlyStream throw.
@@ -124,7 +149,10 @@ public class FcmSocketFramingTests
     private static IEnumerable<byte> FirstFrame(McsProtoTag tag, object message)
     {
         var payload = PayloadOf(message);
-        return new byte[] { KMcsVersion, (byte)(int)tag }
+        return new byte[]
+            {
+                KMcsVersion, (byte)(int)tag
+            }
             .Concat(EncodeVarInt32(payload.Length))
             .Concat(payload);
     }
@@ -136,7 +164,10 @@ public class FcmSocketFramingTests
     private static IEnumerable<byte> FirstFrame(int version, McsProtoTag tag, object message)
     {
         var payload = PayloadOf(message);
-        return new byte[] { (byte)version, (byte)(int)tag }
+        return new byte[]
+            {
+                (byte)version, (byte)(int)tag
+            }
             .Concat(EncodeVarInt32(payload.Length))
             .Concat(payload);
     }
@@ -147,7 +178,10 @@ public class FcmSocketFramingTests
     private static IEnumerable<byte> NextFrame(McsProtoTag tag, object message)
     {
         var payload = PayloadOf(message);
-        return new byte[] { (byte)(int)tag }
+        return new byte[]
+            {
+                (byte)(int)tag
+            }
             .Concat(EncodeVarInt32(payload.Length))
             .Concat(payload);
     }
@@ -168,8 +202,16 @@ public class FcmSocketFramingTests
             Sent = 1_700_000_000_000,
             AppDatas =
             {
-                new AppData { Key = "channelId", Value = "pairing" },
-                new AppData { Key = "body", Value = body },
+                new AppData
+                {
+                    Key = "channelId",
+                    Value = "pairing"
+                },
+                new AppData
+                {
+                    Key = "body",
+                    Value = body
+                },
             }
         };
 
@@ -203,7 +245,11 @@ public class FcmSocketFramingTests
 
         var stream = new ScriptedStream(Build(
             FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
-            NextFrame(McsProtoTag.KHeartbeatPingTag, new HeartbeatPing { StreamId = 7, Status = 0 }),
+            NextFrame(McsProtoTag.KHeartbeatPingTag, new HeartbeatPing
+            {
+                StreamId = 7,
+                Status = 0
+            }),
             NextFrame(McsProtoTag.KCloseTag, new Close())));
 
         await socket.RunReceiveLoopOverStreamAsync(stream);
@@ -226,7 +272,7 @@ public class FcmSocketFramingTests
         using var payload = new MemoryStream(written, idx, written.Length - idx);
 #pragma warning restore RCS1261
         var ack = Serializer.Deserialize<HeartbeatAck>(payload);
-        Assert.Equal(8, ack.StreamId);           // ping.StreamId (7) + 1
+        Assert.Equal(8, ack.StreamId); // ping.StreamId (7) + 1
         Assert.Equal(7, ack.LastStreamIdReceived);
     }
 
@@ -256,8 +302,8 @@ public class FcmSocketFramingTests
 
         var script = Build(FirstFrame(37, McsProtoTag.KLoginResponseTag, new LoginResponse()));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script)));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script)));
         Assert.Contains("unsupported", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -268,8 +314,8 @@ public class FcmSocketFramingTests
 
         var script = Build(FirstFrame(McsProtoTag.KDataMessageStanzaTag, RustNotification()));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script)));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script)));
         Assert.Contains(nameof(LoginResponse), ex.Message, StringComparison.Ordinal);
     }
 
@@ -284,7 +330,14 @@ public class FcmSocketFramingTests
         {
             From = "1",
             PersistentId = "p-missing",
-            AppDatas = { new AppData { Key = "body", Value = "{}" } }   // no channelId
+            AppDatas =
+            {
+                new AppData
+                {
+                    Key = "body",
+                    Value = "{}"
+                }
+            } // no channelId
         };
 
         var script = Build(
@@ -308,7 +361,14 @@ public class FcmSocketFramingTests
         {
             From = "1",
             PersistentId = "p-missing-body",
-            AppDatas = { new AppData { Key = "channelId", Value = "pairing" } }   // no body
+            AppDatas =
+            {
+                new AppData
+                {
+                    Key = "channelId",
+                    Value = "pairing"
+                }
+            } // no body
         };
 
         var script = Build(
@@ -338,7 +398,7 @@ public class FcmSocketFramingTests
 
         await socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script));
 
-        Assert.Equal(1, count);   // first delivered, duplicate skipped
+        Assert.Equal(1, count); // first delivered, duplicate skipped
     }
 
     [Fact]
@@ -359,8 +419,16 @@ public class FcmSocketFramingTests
             Sent = 1_700_000_000_000,
             AppDatas =
             {
-                new AppData { Key = "channelId", Value = "pairing" },
-                new AppData { Key = "body", Value = longBody },
+                new AppData
+                {
+                    Key = "channelId",
+                    Value = "pairing"
+                },
+                new AppData
+                {
+                    Key = "body",
+                    Value = longBody
+                },
             }
         };
 
@@ -389,11 +457,17 @@ public class FcmSocketFramingTests
         socket.ErrorOccurred += (_, ex) => error = ex;
 
         // Manually build a frame: [tag][varint(size)][corrupt-payload]
-        var corruptPayload = new byte[] { 0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9 };
+        var corruptPayload = new byte[]
+        {
+            0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9
+        };
         var corruptFrame =
-            new byte[] { (byte)(int)McsProtoTag.KDataMessageStanzaTag }
-            .Concat(EncodeVarInt32(corruptPayload.Length))
-            .Concat(corruptPayload);
+            new byte[]
+                {
+                    (byte)(int)McsProtoTag.KDataMessageStanzaTag
+                }
+                .Concat(EncodeVarInt32(corruptPayload.Length))
+                .Concat(corruptPayload);
 
         var script = Build(
             FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
@@ -463,13 +537,41 @@ public class FcmSocketFramingTests
             Sent = 1_700_000_000_000,
             AppDatas =
             {
-                new AppData { Key = "channelId", Value = "pairing" },
-                new AppData { Key = "body", Value = "{}" },
-                new AppData { Key = "title", Value = "Test Title" },
-                new AppData { Key = "projectId", Value = "00000000-0000-0000-0000-000000000001" },
-                new AppData { Key = "experienceId", Value = "@scope/exp" },
-                new AppData { Key = "scopeKey", Value = "myScope" },
-                new AppData { Key = "message", Value = "hello world" },
+                new AppData
+                {
+                    Key = "channelId",
+                    Value = "pairing"
+                },
+                new AppData
+                {
+                    Key = "body",
+                    Value = "{}"
+                },
+                new AppData
+                {
+                    Key = "title",
+                    Value = "Test Title"
+                },
+                new AppData
+                {
+                    Key = "projectId",
+                    Value = "00000000-0000-0000-0000-000000000001"
+                },
+                new AppData
+                {
+                    Key = "experienceId",
+                    Value = "@scope/exp"
+                },
+                new AppData
+                {
+                    Key = "scopeKey",
+                    Value = "myScope"
+                },
+                new AppData
+                {
+                    Key = "message",
+                    Value = "hello world"
+                },
             }
         };
 
@@ -507,8 +609,16 @@ public class FcmSocketFramingTests
             Sent = 1_700_000_000_000,
             AppDatas =
             {
-                new AppData { Key = "channelId", Value = "pairing" },
-                new AppData { Key = "body", Value = "{}" },
+                new AppData
+                {
+                    Key = "channelId",
+                    Value = "pairing"
+                },
+                new AppData
+                {
+                    Key = "body",
+                    Value = "{}"
+                },
             }
         };
 
@@ -519,8 +629,8 @@ public class FcmSocketFramingTests
 
         await socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script));
 
-        Assert.Equal(1, count);           // message was delivered
-        Assert.Empty(ids);                // nothing added to the dedupe set
+        Assert.Equal(1, count); // message was delivered
+        Assert.Empty(ids); // nothing added to the dedupe set
     }
 
     /// <summary>
@@ -541,8 +651,16 @@ public class FcmSocketFramingTests
             // Sent deliberately not set (null)
             AppDatas =
             {
-                new AppData { Key = "channelId", Value = "pairing" },
-                new AppData { Key = "body", Value = "{}" },
+                new AppData
+                {
+                    Key = "channelId",
+                    Value = "pairing"
+                },
+                new AppData
+                {
+                    Key = "body",
+                    Value = "{}"
+                },
             }
         };
 
@@ -593,8 +711,11 @@ public class FcmSocketFramingTests
         socket.NotificationReceived += (_, _) => raised = true;
 
         var emptyFrame =
-            new byte[] { (byte)(int)McsProtoTag.KHeartbeatAckTag }
-            .Concat(EncodeVarInt32(0));   // zero-length payload
+            new byte[]
+                {
+                    (byte)(int)McsProtoTag.KHeartbeatAckTag
+                }
+                .Concat(EncodeVarInt32(0)); // zero-length payload
 
         var script = Build(
             FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
@@ -604,7 +725,7 @@ public class FcmSocketFramingTests
         var ex = await Record.ExceptionAsync(() => socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script)));
 
         Assert.Null(ex);
-        Assert.False(raised);   // HeartbeatAck hits the default arm → ignored, no notification
+        Assert.False(raised); // HeartbeatAck hits the default arm → ignored, no notification
     }
 
     /// <summary>
@@ -618,11 +739,17 @@ public class FcmSocketFramingTests
         await using var socket = NewSocket();
         // ErrorOccurred intentionally NOT subscribed
 
-        var corruptPayload = new byte[] { 0xFF, 0xFE, 0xFD, 0xFC };
+        var corruptPayload = new byte[]
+        {
+            0xFF, 0xFE, 0xFD, 0xFC
+        };
         var corruptFrame =
-            new byte[] { (byte)(int)McsProtoTag.KDataMessageStanzaTag }
-            .Concat(EncodeVarInt32(corruptPayload.Length))
-            .Concat(corruptPayload);
+            new byte[]
+                {
+                    (byte)(int)McsProtoTag.KDataMessageStanzaTag
+                }
+                .Concat(EncodeVarInt32(corruptPayload.Length))
+                .Concat(corruptPayload);
 
         var script = Build(
             FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
@@ -631,7 +758,7 @@ public class FcmSocketFramingTests
 
         var ex = await Record.ExceptionAsync(() => socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script)));
 
-        Assert.Null(ex);   // catch absorbs exception; no subscriber → no rethrow
+        Assert.Null(ex); // catch absorbs exception; no subscriber → no rethrow
     }
 
     /// <summary>
@@ -651,8 +778,11 @@ public class FcmSocketFramingTests
         socket.NotificationReceived += (_, _) => raised = true;
 
         var zeroLengthDataFrame =
-            new byte[] { (byte)(int)McsProtoTag.KDataMessageStanzaTag }
-            .Concat(EncodeVarInt32(0));
+            new byte[]
+                {
+                    (byte)(int)McsProtoTag.KDataMessageStanzaTag
+                }
+                .Concat(EncodeVarInt32(0));
 
         var script = Build(
             FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
@@ -685,7 +815,7 @@ public class FcmSocketFramingTests
 
         await socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script));
 
-        Assert.Equal(2, count);   // both delivered; no deduplication without the set
+        Assert.Equal(2, count); // both delivered; no deduplication without the set
     }
 
     /// <summary>
@@ -698,7 +828,10 @@ public class FcmSocketFramingTests
     {
         // Pre-seed the set with a known ID so that, WITHOUT clearing, the second delivery
         // would be skipped by the dedup check.
-        var ids = new List<string> { "pre-existing-id" };
+        var ids = new List<string>
+        {
+            "pre-existing-id"
+        };
         await using var socket = NewSocket(ids);
         var count = 0;
         socket.NotificationReceived += (_, _) => count++;
@@ -732,8 +865,8 @@ public class FcmSocketFramingTests
         // Body JSON with lowercase keys — requires PropertyNameCaseInsensitive = true to bind
         // "ip" → Body.Ip, "port" → Body.Port, "type" → Body.Type, etc.
         const string lowerCaseBody = """
-            {"ip":"10.0.0.1","port":28082,"type":"server","playerToken":"42","playerId":"7"}
-            """;
+                                     {"ip":"10.0.0.1","port":28082,"type":"server","playerToken":"42","playerId":"7"}
+                                     """;
 
         var stanza = new DataMessageStanza
         {
@@ -742,8 +875,16 @@ public class FcmSocketFramingTests
             Sent = 1_700_000_000_000,
             AppDatas =
             {
-                new AppData { Key = "channelId", Value = "pairing" },
-                new AppData { Key = "body", Value = lowerCaseBody },
+                new AppData
+                {
+                    Key = "channelId",
+                    Value = "pairing"
+                },
+                new AppData
+                {
+                    Key = "body",
+                    Value = lowerCaseBody
+                },
             }
         };
 
@@ -774,7 +915,10 @@ public class FcmSocketFramingTests
     [Fact]
     public async Task LoginResponse_DispatchedViaOnGotMessageBytes_ClearsPersistentIds()
     {
-        var ids = new List<string> { "old-id" };
+        var ids = new List<string>
+        {
+            "old-id"
+        };
         await using var socket = NewSocket(ids);
         var count = 0;
         socket.NotificationReceived += (_, _) => count++;
@@ -809,8 +953,11 @@ public class FcmSocketFramingTests
         // HeartbeatPing with zero-length payload (Activator.CreateInstance returns default instance
         // with null StreamId).
         var emptyPingFrame =
-            new byte[] { (byte)(int)McsProtoTag.KHeartbeatPingTag }
-            .Concat(EncodeVarInt32(0));   // zero-length payload
+            new byte[]
+                {
+                    (byte)(int)McsProtoTag.KHeartbeatPingTag
+                }
+                .Concat(EncodeVarInt32(0)); // zero-length payload
 
         var stream = new ScriptedStream(Build(
             FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
@@ -832,6 +979,7 @@ public class FcmSocketFramingTests
                 ackCount++;
             }
         }
+
         Assert.Equal(1, ackCount);
     }
 
@@ -877,9 +1025,15 @@ public class FcmSocketFramingTests
         // EOF (underlying Read returns 0) and throws EndOfStreamException rather than busy-looping
         // forever; the receive loop swallows it for a clean exit.
         var truncatedFrame =
-            new byte[] { (byte)(int)McsProtoTag.KDataMessageStanzaTag }
-            .Concat(EncodeVarInt32(10))
-            .Concat(new byte[] { 1, 2, 3 });
+            new byte[]
+                {
+                    (byte)(int)McsProtoTag.KDataMessageStanzaTag
+                }
+                .Concat(EncodeVarInt32(10))
+                .Concat(new byte[]
+                {
+                    1, 2, 3
+                });
 
         var stream = new ScriptedStream(Build(
             FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketLifecycleTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketLifecycleTests.cs
@@ -31,7 +31,14 @@ public class FcmSocketLifecycleTests
     }
 
     private static TestSocket NewSocket() =>
-        new(new Credentials { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 } });
+        new(new Credentials
+        {
+            Gcm = new Gcm
+            {
+                AndroidId = 1,
+                SecurityToken = 1
+            }
+        });
 
     [Fact]
     public void Disconnect_RaisesDisconnectingThenDisconnected()
@@ -80,7 +87,12 @@ public class FcmSocketLifecycleTests
         public override bool CanWrite => true;
         public override bool CanSeek => false;
         public override long Length => throw new NotSupportedException();
-        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
 
         public override int Read(byte[] buffer, int offset, int count) => _reads.Read(buffer, offset, count);
         public override int ReadByte() => _reads.ReadByte();
@@ -145,8 +157,8 @@ public class FcmSocketLifecycleTests
         // Frame layout per packet: [version, tag, varint-size, payload]. HeartbeatPing tag = 0.
         var written = transport.ToArray();
         Assert.True(written.Length >= 3, "expected at least one heartbeat frame");
-        Assert.Equal(41, written[0]);  // KMcsVersion
-        Assert.Equal(0, written[1]);   // KHeartbeatPingTag
+        Assert.Equal(41, written[0]); // KMcsVersion
+        Assert.Equal(0, written[1]); // KHeartbeatPingTag
     }
 
     [Fact]
@@ -182,7 +194,14 @@ public class FcmSocketLifecycleTests
     /// <summary>Concrete subclass that forwards heartbeat/watchdog tuning options.</summary>
     /// <param name="options">The heartbeat/watchdog options under test.</param>
     private sealed class OptionsSocket(RustPlusFcmSocketOptions options)
-        : RustPlusFcmSocket(new Credentials { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 } }, options: options);
+        : RustPlusFcmSocket(new Credentials
+        {
+            Gcm = new Gcm
+            {
+                AndroidId = 1,
+                SecurityToken = 1
+            }
+        }, options: options);
 
     [Fact]
     public void Dispose_IsIdempotent()
@@ -214,7 +233,14 @@ public class FcmSocketLifecycleTests
     [Fact]
     public void Dispose_CallsProtectedDisposeWithTrue()
     {
-        var creds = new Credentials { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 } };
+        var creds = new Credentials
+        {
+            Gcm = new Gcm
+            {
+                AndroidId = 1,
+                SecurityToken = 1
+            }
+        };
         var spy = new SpySocket(creds);
 
         spy.Dispose();
@@ -236,7 +262,7 @@ public class FcmSocketLifecycleTests
         // Fresh socket: CancellationTokenSource is not yet cancelled.
         var socket = NewSocket();
         var ex = Record.Exception(socket.Dispose);
-        Assert.Null(ex);   // must not throw regardless of which branch the guard takes
+        Assert.Null(ex); // must not throw regardless of which branch the guard takes
     }
 
     /// <summary>
@@ -248,7 +274,7 @@ public class FcmSocketLifecycleTests
     public void Dispose_AfterDisconnect_CancellationAlreadyRequested_DoesNotThrow()
     {
         var socket = NewSocket();
-        socket.Disconnect();  // cancels the token
+        socket.Disconnect(); // cancels the token
 
         // Now Dispose: _cancellationTokenSource.IsCancellationRequested == true,
         // so the inner Cancel() should be skipped via the guard. Must not throw.
@@ -274,7 +300,7 @@ public class FcmSocketLifecycleTests
 #pragma warning restore CA1849, VSTHRD103, S6966
 
         // After Dispose() the CTS is disposed; the receive loop's CancellationToken access throws.
-        await Assert.ThrowsAsync<ObjectDisposedException>(
-            () => socket.RunReceiveLoopOverStreamAsync(new CanceledProbeStream()));
+        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            socket.RunReceiveLoopOverStreamAsync(new CanceledProbeStream()));
     }
 }

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketLifecycleTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketLifecycleTests.cs
@@ -35,8 +35,7 @@ public class FcmSocketLifecycleTests
         {
             Gcm = new Gcm
             {
-                AndroidId = 1,
-                SecurityToken = 1
+                AndroidId = 1, SecurityToken = 1
             }
         });
 
@@ -139,8 +138,7 @@ public class FcmSocketLifecycleTests
         // A healthy connection (recent traffic) must emit client-initiated HeartbeatPing frames.
         var options = new RustPlusFcmSocketOptions
         {
-            HeartbeatInterval = TimeSpan.FromMilliseconds(30),
-            InactivityTimeout = TimeSpan.FromSeconds(30)
+            HeartbeatInterval = TimeSpan.FromMilliseconds(30), InactivityTimeout = TimeSpan.FromSeconds(30)
         };
         await using var socket = new OptionsSocket(options);
         await using var transport = new SignalingMemoryStream();
@@ -168,8 +166,7 @@ public class FcmSocketLifecycleTests
         // connection dead, raise ErrorOccurred with a TimeoutException, and disconnect.
         var options = new RustPlusFcmSocketOptions
         {
-            HeartbeatInterval = TimeSpan.FromMilliseconds(30),
-            InactivityTimeout = TimeSpan.FromMilliseconds(1)
+            HeartbeatInterval = TimeSpan.FromMilliseconds(30), InactivityTimeout = TimeSpan.FromMilliseconds(1)
         };
         await using var socket = new OptionsSocket(options);
         await using var transport = new MemoryStream();
@@ -198,8 +195,7 @@ public class FcmSocketLifecycleTests
         {
             Gcm = new Gcm
             {
-                AndroidId = 1,
-                SecurityToken = 1
+                AndroidId = 1, SecurityToken = 1
             }
         }, options: options);
 
@@ -237,8 +233,7 @@ public class FcmSocketLifecycleTests
         {
             Gcm = new Gcm
             {
-                AndroidId = 1,
-                SecurityToken = 1
+                AndroidId = 1, SecurityToken = 1
             }
         };
         var spy = new SpySocket(creds);

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketTeardownTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketTeardownTests.cs
@@ -17,8 +17,7 @@ public class FcmSocketTeardownTests
         {
             Gcm = new Gcm
             {
-                AndroidId = 1,
-                SecurityToken = 1
+                AndroidId = 1, SecurityToken = 1
             }
         });
 

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketTeardownTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketTeardownTests.cs
@@ -13,7 +13,14 @@ public class FcmSocketTeardownTests
     private sealed class TestSocket(Credentials credentials) : RustPlusFcmSocket(credentials);
 
     private static TestSocket NewSocket() =>
-        new(new Credentials { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 } });
+        new(new Credentials
+        {
+            Gcm = new Gcm
+            {
+                AndroidId = 1,
+                SecurityToken = 1
+            }
+        });
 
     [Fact]
     public async Task DisposeAsync_AwaitsTrackedReceiveLoop_StopsPromptly()
@@ -51,7 +58,12 @@ public class FcmSocketTeardownTests
         public override bool CanWrite => true;
         public override bool CanSeek => false;
         public override long Length => throw new NotSupportedException();
-        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
 
         public override int ReadByte()
         {
@@ -78,6 +90,7 @@ public class FcmSocketTeardownTests
                 {
                     buffer[offset + n++] = (byte)_initial.Dequeue();
                 }
+
                 return n;
             }
 
@@ -97,6 +110,7 @@ public class FcmSocketTeardownTests
             {
                 _gate.Dispose();
             }
+
             base.Dispose(disposing);
         }
     }

--- a/tests/RustPlusApi.Fcm.UnitTests/McsRoundTripTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/McsRoundTripTests.cs
@@ -26,9 +26,7 @@ public class McsRoundTripTests
     {
         var result = RoundTrip(new HeartbeatPing
         {
-            StreamId = 5,
-            LastStreamIdReceived = 4,
-            Status = 1
+            StreamId = 5, LastStreamIdReceived = 4, Status = 1
         });
 
         Assert.Equal(5, result.StreamId);
@@ -62,14 +60,12 @@ public class McsRoundTripTests
             {
                 new Setting
                 {
-                    Name = "new_vc",
-                    Value = "1"
+                    Name = "new_vc", Value = "1"
                 }
             },
             ReceivedPersistentIds =
             {
-                "abc",
-                "def"
+                "abc", "def"
             }
         };
 
@@ -96,13 +92,11 @@ public class McsRoundTripTests
             {
                 new AppData
                 {
-                    Key = "channelId",
-                    Value = "rust"
+                    Key = "channelId", Value = "rust"
                 },
                 new AppData
                 {
-                    Key = "body",
-                    Value = "{}"
+                    Key = "body", Value = "{}"
                 }
             }
         };

--- a/tests/RustPlusApi.Fcm.UnitTests/McsRoundTripTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/McsRoundTripTests.cs
@@ -24,7 +24,12 @@ public class McsRoundTripTests
     [Fact]
     public void HeartbeatPing_RoundTrips()
     {
-        var result = RoundTrip(new HeartbeatPing { StreamId = 5, LastStreamIdReceived = 4, Status = 1 });
+        var result = RoundTrip(new HeartbeatPing
+        {
+            StreamId = 5,
+            LastStreamIdReceived = 4,
+            Status = 1
+        });
 
         Assert.Equal(5, result.StreamId);
         Assert.Equal(4, result.LastStreamIdReceived);
@@ -53,8 +58,19 @@ public class McsRoundTripTests
             AuthToken = "secret",
             auth_service = LoginRequest.AuthService.AndroidId,
             UseRmq2 = true,
-            Settings = { new Setting { Name = "new_vc", Value = "1" } },
-            ReceivedPersistentIds = { "abc", "def" }
+            Settings =
+            {
+                new Setting
+                {
+                    Name = "new_vc",
+                    Value = "1"
+                }
+            },
+            ReceivedPersistentIds =
+            {
+                "abc",
+                "def"
+            }
         };
 
         var result = RoundTrip(request);
@@ -78,8 +94,16 @@ public class McsRoundTripTests
             Sent = 1_700_000_000_000,
             AppDatas =
             {
-                new AppData { Key = "channelId", Value = "rust" },
-                new AppData { Key = "body", Value = "{}" }
+                new AppData
+                {
+                    Key = "channelId",
+                    Value = "rust"
+                },
+                new AppData
+                {
+                    Key = "body",
+                    Value = "{}"
+                }
             }
         };
 
@@ -98,9 +122,8 @@ public class McsRoundTripTests
     {
         foreach (var type in new[]
                  {
-                     typeof(HeartbeatPing), typeof(HeartbeatAck), typeof(LoginRequest),
-                     typeof(LoginResponse), typeof(Close), typeof(IqStanza),
-                     typeof(DataMessageStanza), typeof(StreamErrorStanza)
+                     typeof(HeartbeatPing), typeof(HeartbeatAck), typeof(LoginRequest), typeof(LoginResponse),
+                     typeof(Close), typeof(IqStanza), typeof(DataMessageStanza), typeof(StreamErrorStanza)
                  })
         {
             var tag = GetTagFromProtobufType(type);

--- a/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
@@ -13,8 +13,7 @@ public class RustPlusFcmDispatchTests
     {
         Gcm = new Gcm
         {
-            AndroidId = 1,
-            SecurityToken = 1
+            AndroidId = 1, SecurityToken = 1
         }
     })
     {
@@ -26,8 +25,7 @@ public class RustPlusFcmDispatchTests
         {
             Data = new MessageData
             {
-                ChannelId = "pairing",
-                Body = body
+                ChannelId = "pairing", Body = body
             }
         };
 
@@ -131,10 +129,7 @@ public class RustPlusFcmDispatchTests
         fcm.OnPairing += (_, m) => raised = m;
         var message = Pairing(new Body
         {
-            Type = "server",
-            Ip = "1.1.1.1",
-            Port = 1,
-            PlayerToken = "0"
+            Type = "server", Ip = "1.1.1.1", Port = 1, PlayerToken = "0"
         });
         fcm.Feed(message);
         // OnPairing forwards the original FcmMessage instance unchanged.
@@ -152,9 +147,7 @@ public class RustPlusFcmDispatchTests
         {
             Data = new MessageData
             {
-                ChannelId = "alarm",
-                Title = "the title",
-                Message = "the message"
+                ChannelId = "alarm", Title = "the title", Message = "the message"
             }
         });
 
@@ -193,9 +186,7 @@ public class RustPlusFcmDispatchTests
         }));
         fcm.Feed(Pairing(new Body
         {
-            Type = "entity",
-            EntityType = 99,
-            PlayerToken = "0"
+            Type = "entity", EntityType = 99, PlayerToken = "0"
         }));
         Assert.False(any);
     }
@@ -212,10 +203,7 @@ public class RustPlusFcmDispatchTests
         fcm.OnEntityPairing += (_, _) => raised = true;
         fcm.Feed(Pairing(new Body
         {
-            Type = "entity",
-            EntityType = entityType,
-            EntityId = 1,
-            PlayerToken = "0"
+            Type = "entity", EntityType = entityType, EntityId = 1, PlayerToken = "0"
         }));
         Assert.True(raised);
     }
@@ -231,9 +219,7 @@ public class RustPlusFcmDispatchTests
         {
             Data = new MessageData
             {
-                ChannelId = "alarm",
-                Title = "t",
-                Message = "m"
+                ChannelId = "alarm", Title = "t", Message = "m"
             }
         });
         Assert.False(pairingRaised);
@@ -248,10 +234,7 @@ public class RustPlusFcmDispatchTests
         // OnServerPairing not subscribed — verifies null branch of its ?.Invoke.
         fcm.Feed(Pairing(new Body
         {
-            Type = "server",
-            Ip = "1.2.3.4",
-            Port = 1,
-            PlayerToken = "0"
+            Type = "server", Ip = "1.2.3.4", Port = 1, PlayerToken = "0"
         }));
         Assert.True(pairingRaised);
     }

--- a/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
@@ -9,13 +9,27 @@ namespace RustPlusApi.Fcm.UnitTests;
 /// subclass that exposes the protected <c>ParseNotification</c> hook — no socket needed.</summary>
 public class RustPlusFcmDispatchTests
 {
-    private sealed class TestFcm() : RustPlusFcm(new Credentials { Gcm = new Gcm { AndroidId = 1, SecurityToken = 1 } })
+    private sealed class TestFcm() : RustPlusFcm(new Credentials
+    {
+        Gcm = new Gcm
+        {
+            AndroidId = 1,
+            SecurityToken = 1
+        }
+    })
     {
         public void Feed(FcmMessage message) => ParseNotification(message);
     }
 
     private static FcmMessage Pairing(Body body) =>
-        new() { Data = new MessageData { ChannelId = "pairing", Body = body } };
+        new()
+        {
+            Data = new MessageData
+            {
+                ChannelId = "pairing",
+                Body = body
+            }
+        };
 
     [Fact]
     public void Pairing_Server_RaisesOnServerPairing()
@@ -95,7 +109,10 @@ public class RustPlusFcmDispatchTests
         Assert.Equal("switch-1", entity.Data.EntityName);
 
         // Exactly one typed event fires, carrying the entity id (42) as its payload.
-        var fired = new[] { smart, alarm, storage };
+        var fired = new[]
+        {
+            smart, alarm, storage
+        };
         var raised = Assert.Single(fired, n => n is not null);
         Assert.Equal(42, raised!.Data);
         Assert.Equal(serverId, raised.ServerId);
@@ -112,7 +129,13 @@ public class RustPlusFcmDispatchTests
         using var fcm = new TestFcm();
         FcmMessage? raised = null;
         fcm.OnPairing += (_, m) => raised = m;
-        var message = Pairing(new Body { Type = "server", Ip = "1.1.1.1", Port = 1, PlayerToken = "0" });
+        var message = Pairing(new Body
+        {
+            Type = "server",
+            Ip = "1.1.1.1",
+            Port = 1,
+            PlayerToken = "0"
+        });
         fcm.Feed(message);
         // OnPairing forwards the original FcmMessage instance unchanged.
         Assert.Same(message, raised);
@@ -125,7 +148,15 @@ public class RustPlusFcmDispatchTests
         AlarmEvent? captured = null;
         fcm.OnAlarmTriggered += (_, e) => captured = e;
 
-        fcm.Feed(new FcmMessage { Data = new MessageData { ChannelId = "alarm", Title = "the title", Message = "the message" } });
+        fcm.Feed(new FcmMessage
+        {
+            Data = new MessageData
+            {
+                ChannelId = "alarm",
+                Title = "the title",
+                Message = "the message"
+            }
+        });
 
         Assert.NotNull(captured);
         Assert.Equal("the title", captured!.Title);
@@ -139,7 +170,13 @@ public class RustPlusFcmDispatchTests
         var any = false;
         fcm.OnPairing += (_, _) => any = true;
         fcm.OnAlarmTriggered += (_, _) => any = true;
-        fcm.Feed(new FcmMessage { Data = new MessageData { ChannelId = "mystery" } });
+        fcm.Feed(new FcmMessage
+        {
+            Data = new MessageData
+            {
+                ChannelId = "mystery"
+            }
+        });
         Assert.False(any);
     }
 
@@ -150,8 +187,16 @@ public class RustPlusFcmDispatchTests
         var any = false;
         fcm.OnServerPairing += (_, _) => any = true;
         fcm.OnSmartSwitchPairing += (_, _) => any = true;
-        fcm.Feed(Pairing(new Body { Type = "mystery" }));
-        fcm.Feed(Pairing(new Body { Type = "entity", EntityType = 99, PlayerToken = "0" }));
+        fcm.Feed(Pairing(new Body
+        {
+            Type = "mystery"
+        }));
+        fcm.Feed(Pairing(new Body
+        {
+            Type = "entity",
+            EntityType = 99,
+            PlayerToken = "0"
+        }));
         Assert.False(any);
     }
 
@@ -165,7 +210,13 @@ public class RustPlusFcmDispatchTests
         var raised = false;
         // Subscribe only OnEntityPairing to confirm the entity arm fires, but the typed events are null.
         fcm.OnEntityPairing += (_, _) => raised = true;
-        fcm.Feed(Pairing(new Body { Type = "entity", EntityType = entityType, EntityId = 1, PlayerToken = "0" }));
+        fcm.Feed(Pairing(new Body
+        {
+            Type = "entity",
+            EntityType = entityType,
+            EntityId = 1,
+            PlayerToken = "0"
+        }));
         Assert.True(raised);
     }
 
@@ -176,7 +227,15 @@ public class RustPlusFcmDispatchTests
         var pairingRaised = false;
         fcm.OnPairing += (_, _) => pairingRaised = true;
         // OnAlarmTriggered not subscribed — verifies null branch of ?.Invoke.
-        fcm.Feed(new FcmMessage { Data = new MessageData { ChannelId = "alarm", Title = "t", Message = "m" } });
+        fcm.Feed(new FcmMessage
+        {
+            Data = new MessageData
+            {
+                ChannelId = "alarm",
+                Title = "t",
+                Message = "m"
+            }
+        });
         Assert.False(pairingRaised);
     }
 
@@ -187,7 +246,13 @@ public class RustPlusFcmDispatchTests
         var pairingRaised = false;
         fcm.OnPairing += (_, _) => pairingRaised = true;
         // OnServerPairing not subscribed — verifies null branch of its ?.Invoke.
-        fcm.Feed(Pairing(new Body { Type = "server", Ip = "1.2.3.4", Port = 1, PlayerToken = "0" }));
+        fcm.Feed(Pairing(new Body
+        {
+            Type = "server",
+            Ip = "1.2.3.4",
+            Port = 1,
+            PlayerToken = "0"
+        }));
         Assert.True(pairingRaised);
     }
 }

--- a/tests/RustPlusApi.Fcm.UnitTests/SpyLogger.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/SpyLogger.cs
@@ -10,7 +10,10 @@ public sealed class SpyLogger : ILogger
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
     public bool IsEnabled(LogLevel logLevel) => true;
 
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+    public void Log<TState>(LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
         Func<TState, Exception?, string> formatter)
         => Entries.Add((logLevel, formatter(state, exception)));
 

--- a/tests/RustPlusApi.Fcm.UnitTests/VarIntTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/VarIntTests.cs
@@ -14,15 +14,33 @@ public class VarIntTests
     {
         var encoded = EncodeVarInt32(0);
 
-        Assert.Equal(new byte[] { 0x00 }, encoded);
+        Assert.Equal(new byte[]
+        {
+            0x00
+        }, encoded);
     }
 
     [Theory]
-    [InlineData(1, new byte[] { 0x01 })]
-    [InlineData(127, new byte[] { 0x7F })]
-    [InlineData(128, new byte[] { 0x80, 0x01 })]
-    [InlineData(300, new byte[] { 0xAC, 0x02 })]
-    [InlineData(16384, new byte[] { 0x80, 0x80, 0x01 })]
+    [InlineData(1, new byte[]
+    {
+        0x01
+    })]
+    [InlineData(127, new byte[]
+    {
+        0x7F
+    })]
+    [InlineData(128, new byte[]
+    {
+        0x80, 0x01
+    })]
+    [InlineData(300, new byte[]
+    {
+        0xAC, 0x02
+    })]
+    [InlineData(16384, new byte[]
+    {
+        0x80, 0x80, 0x01
+    })]
     public void EncodeVarInt32_KnownValues_MatchProtobufEncoding(int value, byte[] expected)
     {
         var encoded = EncodeVarInt32(value);
@@ -33,7 +51,10 @@ public class VarIntTests
     [Fact]
     public void EncodeVarInt32_RoundTrips_ThroughManualDecode()
     {
-        foreach (var value in new[] { 0, 1, 5, 127, 128, 255, 300, 65_535, 1_000_000 })
+        foreach (var value in new[]
+                 {
+                     0, 1, 5, 127, 128, 255, 300, 65_535, 1_000_000
+                 })
         {
             var decoded = DecodeVarInt32(EncodeVarInt32(value));
             Assert.Equal(value, decoded);
@@ -54,6 +75,7 @@ public class VarIntTests
 
             shift += 7;
         }
+
         return result;
     }
 }

--- a/tests/RustPlusApi.IntegrationTests/CameraClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/CameraClientTests.cs
@@ -21,7 +21,8 @@ public class CameraClientTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var response = await client.SubscribeToCameraAsync("CAM01").WaitAsync(Timeout);
@@ -36,7 +37,8 @@ public class CameraClientTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var input = await client.SendCameraInputAsync(CameraButtons.Forward | CameraButtons.FirePrimary)
@@ -52,7 +54,8 @@ public class CameraClientTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
 
         var received = new TaskCompletionSource<CameraRaysEventArg>(
             TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/RustPlusApi.IntegrationTests/EntityClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/EntityClientTests.cs
@@ -18,12 +18,19 @@ public class EntityClientTests
     /// <param name="request">The incoming request to respond to.</param>
     private static AppMessage? EntityResponder(AppRequest request)
     {
-        var response = new AppResponse { Seq = request.Seq };
+        var response = new AppResponse
+        {
+            Seq = request.Seq
+        };
         if (request.GetEntityInfo is not null)
         {
             response.EntityInfo = MockResponses.SampleSmartSwitch(value: true);
-            return new AppMessage { Response = response };
+            return new AppMessage
+            {
+                Response = response
+            };
         }
+
         if (request.SetEntityValue is not null)
         {
             // SetSmartSwitchValueAsync selects r.Broadcast.EntityChanged.
@@ -32,18 +39,33 @@ public class EntityClientTests
                 Broadcast = MockResponses.SmartSwitchBroadcast((uint)request.EntityId, request.SetEntityValue.Value)
             };
         }
+
         if (request.CheckSubscription is not null)
         {
-            response.Flag = new AppFlag { Value = true };
-            return new AppMessage { Response = response };
+            response.Flag = new AppFlag
+            {
+                Value = true
+            };
+            return new AppMessage
+            {
+                Response = response
+            };
         }
+
         if (request.SendTeamMessage is not null)
         {
             // SendTeamMessageAsync selects r.Broadcast.TeamMessage.Message.ToTeamMessage()
-            return new AppMessage { Broadcast = MockResponses.TeamMessageSendBroadcast(request.PlayerId, request.SendTeamMessage.Message) };
+            return new AppMessage
+            {
+                Broadcast = MockResponses.TeamMessageSendBroadcast(request.PlayerId, request.SendTeamMessage.Message)
+            };
         }
+
         response.Success = new AppSuccess();
-        return new AppMessage { Response = response };
+        return new AppMessage
+        {
+            Response = response
+        };
     }
 
     private static async Task<(MockRustPlusServer, RustPlus)> ConnectEntityAsync()
@@ -80,7 +102,10 @@ public class EntityClientTests
     {
         await using var server = new MockRustPlusServer(req =>
         {
-            var resp = new AppResponse { Seq = req.Seq };
+            var resp = new AppResponse
+            {
+                Seq = req.Seq
+            };
             if (req.GetEntityInfo is not null)
             {
                 resp.EntityInfo = MockResponses.SampleAlarm(value: false);
@@ -90,10 +115,14 @@ public class EntityClientTests
                 resp.Success = new AppSuccess();
             }
 
-            return new AppMessage { Response = resp };
+            return new AppMessage
+            {
+                Response = resp
+            };
         });
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var response = await client.GetAlarmInfoAsync(1).WaitAsync(Timeout);
@@ -106,7 +135,10 @@ public class EntityClientTests
     {
         await using var server = new MockRustPlusServer(req =>
         {
-            var resp = new AppResponse { Seq = req.Seq };
+            var resp = new AppResponse
+            {
+                Seq = req.Seq
+            };
             if (req.GetEntityInfo is not null)
             {
                 resp.EntityInfo = MockResponses.SampleStorageMonitor();
@@ -116,10 +148,14 @@ public class EntityClientTests
                 resp.Success = new AppSuccess();
             }
 
-            return new AppMessage { Response = resp };
+            return new AppMessage
+            {
+                Response = resp
+            };
         });
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var response = await client.GetStorageMonitorInfoAsync(1).WaitAsync(Timeout);

--- a/tests/RustPlusApi.IntegrationTests/RustPlusClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/RustPlusClientTests.cs
@@ -21,7 +21,8 @@ public class RustPlusClientTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var response = await client.GetInfoAsync().WaitAsync(Timeout);
@@ -38,7 +39,8 @@ public class RustPlusClientTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var response = await client.GetTimeAsync().WaitAsync(Timeout);
@@ -52,10 +54,10 @@ public class RustPlusClientTests
     [Fact]
     public async Task GetInfoAsync_WhenServerReturnsError_SurfacesFailure()
     {
-        await using var server = new MockRustPlusServer(
-            request => MockResponses.Error(request.Seq, "not_found"));
+        await using var server = new MockRustPlusServer(request => MockResponses.Error(request.Seq, "not_found"));
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var response = await client.GetInfoAsync().WaitAsync(Timeout);
@@ -70,7 +72,8 @@ public class RustPlusClientTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
 
         var received = new TaskCompletionSource<TeamMessageEventArg>(
             TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/RustPlusApi.IntegrationTests/SocketCorrelationTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketCorrelationTests.cs
@@ -28,10 +28,12 @@ public class SocketCorrelationTests
             {
                 gate.Wait(TimeSpan.FromSeconds(5));
             }
+
             return MockResponses.Default(req);
         });
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var requestTask = client.GetInfoAsync();
@@ -56,11 +58,15 @@ public class SocketCorrelationTests
         // The server never replies, so the request stays pending until the caller's token cancels it.
         await using var server = new MockRustPlusServer(_ => null);
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         using var cts = new CancellationTokenSource();
-        var task = client.SendRequestAsync(new AppRequest { GetInfo = new AppEmpty() }, cancellationToken: cts.Token);
+        var task = client.SendRequestAsync(new AppRequest
+        {
+            GetInfo = new AppEmpty()
+        }, cancellationToken: cts.Token);
 
         await Task.Delay(150);
         Assert.Equal(1, client.PendingRequestCountForTests); // request is in flight
@@ -80,7 +86,8 @@ public class SocketCorrelationTests
         await using var server = new MockRustPlusServer(req =>
             req.SetEntityValue is not null ? null : MockResponses.Default(req));
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         var otherSwitchEvent = new TaskCompletionSource<Data.Events.SmartSwitchEventArg>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         client.OnSmartSwitchTriggered += (_, e) => otherSwitchEvent.TrySetResult(e);
@@ -115,7 +122,8 @@ public class SocketCorrelationTests
         await using var server = new MockRustPlusServer(req =>
             req.SendTeamMessage is not null ? null : MockResponses.Default(req));
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
 
         await client.ConnectAsync().WaitAsync(Timeout);
         await client.GetInfoAsync().WaitAsync(Timeout); // round-trip so the server registers the socket
@@ -148,16 +156,21 @@ public class SocketCorrelationTests
             {
                 gate.Wait(TimeSpan.FromSeconds(5));
             }
+
             return MockResponses.Default(req);
         });
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
 
         await client.ConnectAsync().WaitAsync(Timeout);
         await client.GetInfoAsync().WaitAsync(Timeout); // round-trip so the server registers the socket
 
         var requestTask = client.SendRequestAsync(
-            new AppRequest { GetTime = new AppEmpty() },
+            new AppRequest
+            {
+                GetTime = new AppEmpty()
+            },
             broadcastReplyMatcher: _ => throw new InvalidOperationException("boom"));
         await Task.Delay(150);
 
@@ -178,7 +191,8 @@ public class SocketCorrelationTests
         // Proves the caller token flows the whole public path: GetInfoAsync → ProcessRequestAsync → SendRequestAsync.
         await using var server = new MockRustPlusServer(_ => null);
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         using var cts = new CancellationTokenSource();

--- a/tests/RustPlusApi.IntegrationTests/SocketErrorTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketErrorTests.cs
@@ -23,7 +23,10 @@ public class SocketErrorTests
         await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, 1, 1));
         await client.ConnectAsync().WaitAsync(Timeout);
 
-        var requestTask = client.SendRequestAsync(new AppRequest { GetInfo = new AppEmpty() });
+        var requestTask = client.SendRequestAsync(new AppRequest
+        {
+            GetInfo = new AppEmpty()
+        });
         await Task.Delay(150); // request is in flight
         Assert.Equal(1, client.PendingRequestCountForTests);
 
@@ -44,7 +47,10 @@ public class SocketErrorTests
         await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, 1, 1));
         await client.ConnectAsync().WaitAsync(Timeout);
 
-        var requestTask = client.SendRequestAsync(new AppRequest { GetInfo = new AppEmpty() });
+        var requestTask = client.SendRequestAsync(new AppRequest
+        {
+            GetInfo = new AppEmpty()
+        });
         await Task.Delay(150);
 
         await client.DisconnectAsync(forceClose: true).WaitAsync(Timeout);
@@ -59,12 +65,16 @@ public class SocketErrorTests
         // TimeoutException far sooner than the 30 s default.
         await using var server = new MockRustPlusServer(_ => null);
         server.Start();
-        var options = new RustPlusSocketOptions { RequestTimeout = TimeSpan.FromMilliseconds(500) };
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, 1, 1), options);
+        var options = new RustPlusSocketOptions
+        {
+            RequestTimeout = TimeSpan.FromMilliseconds(500)
+        };
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, 1, 1), options);
         await client.ConnectAsync().WaitAsync(Timeout);
 
-        var ex = await Assert.ThrowsAsync<TimeoutException>(
-            () => client.GetInfoAsync().WaitAsync(TimeSpan.FromSeconds(5)));
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
+            client.GetInfoAsync().WaitAsync(TimeSpan.FromSeconds(5)));
         Assert.Contains("0.5s", ex.Message, StringComparison.Ordinal);
     }
 
@@ -110,7 +120,8 @@ public class SocketErrorTests
     {
         // useFacepunchProxy=true exercises the wss:// URL branch in ConnectAsync; connecting
         // to the Facepunch host will fail in CI, triggering ErrorOccurred + rethrow.
-        await using var client = new RustPlus(new RustPlusConnection("example.invalid", 28083, 1, 1, UseFacepunchProxy: true));
+        await using var client =
+            new RustPlus(new RustPlusConnection("example.invalid", 28083, 1, 1, UseFacepunchProxy: true));
         var error = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
         client.ErrorOccurred += (_, ex) => error.TrySetResult(ex);
 

--- a/tests/RustPlusApi.IntegrationTests/SocketLifecycleTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketLifecycleTests.cs
@@ -149,8 +149,7 @@ public class SocketLifecycleTests
                 EntityId = 5,
                 Payload = new AppEntityPayload
                 {
-                    Capacity = 24,
-                    Value = false
+                    Capacity = 24, Value = false
                 }
             }
         });
@@ -221,10 +220,7 @@ public class SocketLifecycleTests
             await using var request = new MemoryStream();
             Serializer.Serialize(request, new AppRequest
             {
-                Seq = 1,
-                PlayerId = PlayerId,
-                PlayerToken = PlayerToken,
-                GetInfo = new AppEmpty()
+                Seq = 1, PlayerId = PlayerId, PlayerToken = PlayerToken, GetInfo = new AppEmpty()
             });
             await peer.SendAsync(request.ToArray(), WebSocketMessageType.Binary, true, CancellationToken.None)
                 .WaitAsync(Timeout);

--- a/tests/RustPlusApi.IntegrationTests/SocketLifecycleTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketLifecycleTests.cs
@@ -22,7 +22,8 @@ public class SocketLifecycleTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
 
         var events = new List<string>();
         client.Connecting += (_, _) => events.Add("connecting");
@@ -53,7 +54,8 @@ public class SocketLifecycleTests
     [Fact]
     public async Task DisconnectAsync_WhenNotConnected_ReturnsImmediately()
     {
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, 1, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, 1, PlayerId, PlayerToken));
         await client.DisconnectAsync().WaitAsync(Timeout); // early return, no throw
         Assert.False(client.IsConnected);
     }
@@ -63,7 +65,8 @@ public class SocketLifecycleTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var disconnecting = false;
@@ -82,7 +85,8 @@ public class SocketLifecycleTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
 
         await client.ConnectAsync().WaitAsync(Timeout);
         var first = await client.GetInfoAsync().WaitAsync(Timeout);
@@ -105,7 +109,8 @@ public class SocketLifecycleTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => client.ConnectAsync().WaitAsync(Timeout));
@@ -126,8 +131,10 @@ public class SocketLifecycleTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
-        var received = new TaskCompletionSource<StorageMonitorEventArg>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        var received =
+            new TaskCompletionSource<StorageMonitorEventArg>(TaskCreationOptions.RunContinuationsAsynchronously);
         client.OnStorageMonitorTriggered += (_, e) => received.TrySetResult(e);
 
         await client.ConnectAsync().WaitAsync(Timeout);
@@ -140,7 +147,11 @@ public class SocketLifecycleTests
             EntityChanged = new AppEntityChanged
             {
                 EntityId = 5,
-                Payload = new AppEntityPayload { Capacity = 24, Value = false }
+                Payload = new AppEntityPayload
+                {
+                    Capacity = 24,
+                    Value = false
+                }
             }
         });
 
@@ -154,7 +165,8 @@ public class SocketLifecycleTests
     {
         await using var server = new MockRustPlusServer();
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
         // Round-trip so server registers the active socket.
         await client.GetInfoAsync().WaitAsync(Timeout);
@@ -242,7 +254,8 @@ public class SocketLifecycleTests
             return MockResponses.Default(req);
         });
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         var requestTask = client.GetInfoAsync();
@@ -271,7 +284,8 @@ public class SocketLifecycleTests
             return MockResponses.Default(req);
         });
         server.Start();
-        await using var client = new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         await client.ConnectAsync().WaitAsync(Timeout);
 
         await client.GetTimeAsync().WaitAsync(Timeout);

--- a/tests/RustPlusApi.MockServer/MockResponses.cs
+++ b/tests/RustPlusApi.MockServer/MockResponses.cs
@@ -149,8 +149,7 @@ public static class MockResponses
                 EntityId = entityId,
                 Payload = new AppEntityPayload
                 {
-                    Value = value,
-                    Capacity = 0
+                    Value = value, Capacity = 0
                 }
             }
         };
@@ -168,10 +167,7 @@ public static class MockResponses
                 ClanId = clanId,
                 Message = new AppClanMessage
                 {
-                    SteamId = steamId,
-                    Name = name,
-                    Message = message,
-                    Time = 1_700_000_000
+                    SteamId = steamId, Name = name, Message = message, Time = 1_700_000_000
                 }
             }
         };
@@ -204,21 +200,15 @@ public static class MockResponses
                         Type = AppCameraRays.EntityType.Player,
                         Position = new Vector3
                         {
-                            X = 1,
-                            Y = 2,
-                            Z = 3
+                            X = 1, Y = 2, Z = 3
                         },
                         Rotation = new Vector3
                         {
-                            X = 0,
-                            Y = 90,
-                            Z = 0
+                            X = 0, Y = 90, Z = 0
                         },
                         Size = new Vector3
                         {
-                            X = 1,
-                            Y = 1,
-                            Z = 1
+                            X = 1, Y = 1, Z = 1
                         },
                         Name = "Survivor"
                     }
@@ -267,8 +257,7 @@ public static class MockResponses
         Type = AppEntityType.Switch,
         Payload = new AppEntityPayload
         {
-            Value = value,
-            Capacity = 0
+            Value = value, Capacity = 0
         }
     };
 
@@ -307,18 +296,14 @@ public static class MockResponses
         {
             new AppClanMessage
             {
-                SteamId = 76561198000000001,
-                Name = "Tester",
-                Message = "clan chat fixture",
-                Time = 1_700_000_000
+                SteamId = 76561198000000001, Name = "Tester", Message = "clan chat fixture", Time = 1_700_000_000
             }
         }
     };
 
     public static AppNexusAuth SampleNexusAuth() => new()
     {
-        ServerId = "mock-server-id",
-        PlayerToken = 987654321
+        ServerId = "mock-server-id", PlayerToken = 987654321
     };
 
     public static AppCameraInfo SampleCameraInfo() => new()
@@ -399,9 +384,7 @@ public static class MockResponses
             {
                 new AppEntityPayload.Item
                 {
-                    ItemId = 1,
-                    Quantity = 5,
-                    ItemIsBlueprint = false
+                    ItemId = 1, Quantity = 5, ItemIsBlueprint = false
                 }
             }
         }
@@ -416,8 +399,7 @@ public static class MockResponses
         Type = AppEntityType.Alarm,
         Payload = new AppEntityPayload
         {
-            Value = value,
-            Capacity = 0
+            Value = value, Capacity = 0
         }
     };
 

--- a/tests/RustPlusApi.MockServer/MockResponses.cs
+++ b/tests/RustPlusApi.MockServer/MockResponses.cs
@@ -20,7 +20,10 @@ public static class MockResponses
     /// <param name="request">The incoming request to respond to.</param>
     public static AppMessage Default(AppRequest request)
     {
-        var response = new AppResponse { Seq = request.Seq };
+        var response = new AppResponse
+        {
+            Seq = request.Seq
+        };
 
         if (request.GetInfo is not null)
         {
@@ -52,7 +55,10 @@ public static class MockResponses
         }
         else if (request.CheckSubscription is not null)
         {
-            response.Flag = new AppFlag { Value = true };
+            response.Flag = new AppFlag
+            {
+                Value = true
+            };
         }
         else if (request.GetClanInfo is not null)
         {
@@ -72,26 +78,45 @@ public static class MockResponses
         }
         else if (request.SendTeamMessage is not null)
         {
-            return new AppMessage { Broadcast = TeamMessageSendBroadcast(request.PlayerId, request.SendTeamMessage.Message) };
+            return new AppMessage
+            {
+                Broadcast = TeamMessageSendBroadcast(request.PlayerId, request.SendTeamMessage.Message)
+            };
         }
         else
         {
             response.Success = new AppSuccess();
         }
 
-        return new AppMessage { Response = response };
+        return new AppMessage
+        {
+            Response = response
+        };
     }
 
     /// <summary>Builds an error <see cref="AppMessage"/> carrying the given error string.</summary>
     /// <param name="seq">The sequence number to echo back in the response.</param>
     /// <param name="error">The error string to embed.</param>
     public static AppMessage Error(uint seq, string error) =>
-        new() { Response = new AppResponse { Seq = seq, Error = new AppError { Error = error } } };
+        new()
+        {
+            Response = new AppResponse
+            {
+                Seq = seq,
+                Error = new AppError
+                {
+                    Error = error
+                }
+            }
+        };
 
     /// <summary>Wraps a broadcast in an <see cref="AppMessage"/> for injection.</summary>
     /// <param name="broadcast">The broadcast payload to wrap.</param>
     public static AppMessage Broadcast(AppBroadcast broadcast) =>
-        new() { Broadcast = broadcast };
+        new()
+        {
+            Broadcast = broadcast
+        };
 
     /// <summary>A team-chat broadcast, for testing <c>OnTeamChatReceived</c>.</summary>
     /// <param name="steamId">Sender's Steam 64-bit ID.</param>
@@ -122,7 +147,11 @@ public static class MockResponses
             EntityChanged = new AppEntityChanged
             {
                 EntityId = entityId,
-                Payload = new AppEntityPayload { Value = value, Capacity = 0 }
+                Payload = new AppEntityPayload
+                {
+                    Value = value,
+                    Capacity = 0
+                }
             }
         };
 
@@ -149,7 +178,13 @@ public static class MockResponses
 
     /// <summary>A clan-changed broadcast, for testing <c>OnClanChanged</c>.</summary>
     public static AppBroadcast ClanChangedBroadcast() =>
-        new() { ClanChanged = new AppClanChanged { ClanInfo = SampleClan() } };
+        new()
+        {
+            ClanChanged = new AppClanChanged
+            {
+                ClanInfo = SampleClan()
+            }
+        };
 
     /// <summary>A camera-rays broadcast, for testing <c>OnCameraRaysReceived</c>.</summary>
     public static AppBroadcast CameraRaysBroadcast() =>
@@ -167,9 +202,24 @@ public static class MockResponses
                     {
                         EntityId = 99,
                         Type = AppCameraRays.EntityType.Player,
-                        Position = new Vector3 { X = 1, Y = 2, Z = 3 },
-                        Rotation = new Vector3 { X = 0, Y = 90, Z = 0 },
-                        Size = new Vector3 { X = 1, Y = 1, Z = 1 },
+                        Position = new Vector3
+                        {
+                            X = 1,
+                            Y = 2,
+                            Z = 3
+                        },
+                        Rotation = new Vector3
+                        {
+                            X = 0,
+                            Y = 90,
+                            Z = 0
+                        },
+                        Size = new Vector3
+                        {
+                            X = 1,
+                            Y = 1,
+                            Z = 1
+                        },
                         Name = "Survivor"
                     }
                 }
@@ -215,10 +265,17 @@ public static class MockResponses
     public static AppEntityInfo SampleSmartSwitch(bool value) => new()
     {
         Type = AppEntityType.Switch,
-        Payload = new AppEntityPayload { Value = value, Capacity = 0 }
+        Payload = new AppEntityPayload
+        {
+            Value = value,
+            Capacity = 0
+        }
     };
 
-    public static AppClanInfo SampleClanInfo() => new() { ClanInfo = SampleClan() };
+    public static AppClanInfo SampleClanInfo() => new()
+    {
+        ClanInfo = SampleClan()
+    };
 
     public static ClanInfo SampleClan() => new()
     {
@@ -340,7 +397,12 @@ public static class MockResponses
             ProtectionExpiry = 0,
             Items =
             {
-                new AppEntityPayload.Item { ItemId = 1, Quantity = 5, ItemIsBlueprint = false }
+                new AppEntityPayload.Item
+                {
+                    ItemId = 1,
+                    Quantity = 5,
+                    ItemIsBlueprint = false
+                }
             }
         }
     };
@@ -352,7 +414,11 @@ public static class MockResponses
     public static AppEntityInfo SampleAlarm(bool value = false) => new()
     {
         Type = AppEntityType.Alarm,
-        Payload = new AppEntityPayload { Value = value, Capacity = 0 }
+        Payload = new AppEntityPayload
+        {
+            Value = value,
+            Capacity = 0
+        }
     };
 
     /// <summary>

--- a/tests/RustPlusApi.MockServer/MockRustPlusServer.cs
+++ b/tests/RustPlusApi.MockServer/MockRustPlusServer.cs
@@ -57,7 +57,7 @@ public sealed class MockRustPlusServer : IAsyncDisposable
     public Task BroadcastAsync(AppBroadcast broadcast)
     {
         var socket = _activeSocket
-            ?? throw new InvalidOperationException("No client is connected to the mock server.");
+                     ?? throw new InvalidOperationException("No client is connected to the mock server.");
         return SendAsync(socket, MockResponses.Broadcast(broadcast), _cts.Token);
     }
 
@@ -106,6 +106,7 @@ public sealed class MockRustPlusServer : IAsyncDisposable
                         await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, ct);
                         return;
                     }
+
                     await message.WriteAsync(buffer.AsMemory(0, result.Count), ct);
                 } while (!result.EndOfMessage);
             }
@@ -172,8 +173,13 @@ public sealed class MockRustPlusServer : IAsyncDisposable
         if (_acceptLoop is not null)
         {
             try
-            { await _acceptLoop; }
-            catch (OperationCanceledException) { /* expected on shutdown */ }
+            {
+                await _acceptLoop;
+            }
+            catch (OperationCanceledException)
+            {
+                /* expected on shutdown */
+            }
         }
 
         _cts.Dispose();

--- a/tests/RustPlusApi.UnitTests/CameraMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/CameraMapperTests.cs
@@ -29,7 +29,10 @@ public class CameraMapperTests
         var frame = rays.ToCameraRaysEvent();
 
         Assert.Equal(65f, frame.VerticalFov);
-        Assert.Equal(new byte[] { 0, 1, 2, 3, 4 }, frame.RayData);
+        Assert.Equal(new byte[]
+        {
+            0, 1, 2, 3, 4
+        }, frame.RayData);
         var entity = Assert.Single(frame.Entities);
         Assert.Equal(99u, entity.EntityId);
         Assert.Equal(CameraEntityType.Player, entity.Type);

--- a/tests/RustPlusApi.UnitTests/CameraModelMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/CameraModelMapperTests.cs
@@ -21,7 +21,13 @@ public class CameraModelMapperTests
     [Fact]
     public void ToCameraFrame_NullRayData_BecomesEmpty_AndNullVectorsStayNull()
     {
-        var rays = new AppCameraRays { VerticalFov = 90f, SampleOffset = 1, Distance = 50f, RayData = null };
+        var rays = new AppCameraRays
+        {
+            VerticalFov = 90f,
+            SampleOffset = 1,
+            Distance = 50f,
+            RayData = null
+        };
 
         var frame = rays.ToCameraFrame();
 
@@ -40,8 +46,18 @@ public class CameraModelMapperTests
             VerticalFov = 90f,
             RayData = [1],
             TimeOfDay = 0.5f,
-            CameraPosition = new ProtoVector3 { X = 1, Y = 2, Z = 3 },
-            CameraRotation = new ProtoVector3 { X = 4, Y = 5, Z = 6 }
+            CameraPosition = new ProtoVector3
+            {
+                X = 1,
+                Y = 2,
+                Z = 3
+            },
+            CameraRotation = new ProtoVector3
+            {
+                X = 4,
+                Y = 5,
+                Z = 6
+            }
         };
 
         var frame = rays.ToCameraFrame();
@@ -54,7 +70,13 @@ public class CameraModelMapperTests
     [Fact]
     public void ToCameraRaysEvent_NullRayData_BecomesEmpty_AndNullVectorsStayNull()
     {
-        var rays = new AppCameraRays { VerticalFov = 90f, SampleOffset = 1, Distance = 50f, RayData = null };
+        var rays = new AppCameraRays
+        {
+            VerticalFov = 90f,
+            SampleOffset = 1,
+            Distance = 50f,
+            RayData = null
+        };
 
         var frame = rays.ToCameraRaysEvent();
 
@@ -72,8 +94,18 @@ public class CameraModelMapperTests
             VerticalFov = 90f,
             RayData = [1],
             TimeOfDay = 0.75f,
-            CameraPosition = new ProtoVector3 { X = 10, Y = 20, Z = 30 },
-            CameraRotation = new ProtoVector3 { X = 1, Y = 2, Z = 3 }
+            CameraPosition = new ProtoVector3
+            {
+                X = 10,
+                Y = 20,
+                Z = 30
+            },
+            CameraRotation = new ProtoVector3
+            {
+                X = 1,
+                Y = 2,
+                Z = 3
+            }
         };
 
         var frame = rays.ToCameraRaysEvent();

--- a/tests/RustPlusApi.UnitTests/CameraModelMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/CameraModelMapperTests.cs
@@ -23,10 +23,7 @@ public class CameraModelMapperTests
     {
         var rays = new AppCameraRays
         {
-            VerticalFov = 90f,
-            SampleOffset = 1,
-            Distance = 50f,
-            RayData = null
+            VerticalFov = 90f, SampleOffset = 1, Distance = 50f, RayData = null
         };
 
         var frame = rays.ToCameraFrame();
@@ -48,15 +45,11 @@ public class CameraModelMapperTests
             TimeOfDay = 0.5f,
             CameraPosition = new ProtoVector3
             {
-                X = 1,
-                Y = 2,
-                Z = 3
+                X = 1, Y = 2, Z = 3
             },
             CameraRotation = new ProtoVector3
             {
-                X = 4,
-                Y = 5,
-                Z = 6
+                X = 4, Y = 5, Z = 6
             }
         };
 
@@ -72,10 +65,7 @@ public class CameraModelMapperTests
     {
         var rays = new AppCameraRays
         {
-            VerticalFov = 90f,
-            SampleOffset = 1,
-            Distance = 50f,
-            RayData = null
+            VerticalFov = 90f, SampleOffset = 1, Distance = 50f, RayData = null
         };
 
         var frame = rays.ToCameraRaysEvent();
@@ -96,15 +86,11 @@ public class CameraModelMapperTests
             TimeOfDay = 0.75f,
             CameraPosition = new ProtoVector3
             {
-                X = 10,
-                Y = 20,
-                Z = 30
+                X = 10, Y = 20, Z = 30
             },
             CameraRotation = new ProtoVector3
             {
-                X = 1,
-                Y = 2,
-                Z = 3
+                X = 1, Y = 2, Z = 3
             }
         };
 

--- a/tests/RustPlusApi.UnitTests/ClanInfoPresenceTests.cs
+++ b/tests/RustPlusApi.UnitTests/ClanInfoPresenceTests.cs
@@ -8,7 +8,13 @@ namespace RustPlusApi.UnitTests;
 /// <summary>Exercises both sides of every presence fork in <see cref="AppClanInfoToModel"/>.</summary>
 public class ClanInfoPresenceTests
 {
-    private static ProtoClanInfo Minimal() => new() { ClanId = 1, Name = "c", Created = 0, Creator = 0 };
+    private static ProtoClanInfo Minimal() => new()
+    {
+        ClanId = 1,
+        Name = "c",
+        Created = 0,
+        Creator = 0
+    };
 
     [Fact]
     public void ToClanInfo_AllOptionalsUnset_AreNull()
@@ -48,8 +54,17 @@ public class ClanInfoPresenceTests
     [Fact]
     public void ToClanRole_CanAccessScoreEvents_RespectsPresenceAndValue()
     {
-        var setTrue = new ProtoClanInfo.Role { RoleId = 1, Name = "r", CanAccessScoreEvents = true };
-        var unset = new ProtoClanInfo.Role { RoleId = 2, Name = "r" };
+        var setTrue = new ProtoClanInfo.Role
+        {
+            RoleId = 1,
+            Name = "r",
+            CanAccessScoreEvents = true
+        };
+        var unset = new ProtoClanInfo.Role
+        {
+            RoleId = 2,
+            Name = "r"
+        };
         Assert.True(setTrue.ToClanRole().CanAccessScoreEvents);
         Assert.False(unset.ToClanRole().CanAccessScoreEvents);
     }
@@ -57,8 +72,16 @@ public class ClanInfoPresenceTests
     [Fact]
     public void ToClanMember_OptionalNotesAndOnline_RespectPresence()
     {
-        var withOpts = new ProtoClanInfo.Member { SteamId = 1, Notes = "hi", Online = true };
-        var without = new ProtoClanInfo.Member { SteamId = 2 };
+        var withOpts = new ProtoClanInfo.Member
+        {
+            SteamId = 1,
+            Notes = "hi",
+            Online = true
+        };
+        var without = new ProtoClanInfo.Member
+        {
+            SteamId = 2
+        };
         Assert.Equal("hi", withOpts.ToClanMember().Notes);
         Assert.True(withOpts.ToClanMember().Online);
         Assert.Null(without.ToClanMember().Notes);
@@ -68,7 +91,12 @@ public class ClanInfoPresenceTests
     [Fact]
     public void ToClanInvite_MapsFieldsAndTimestamp()
     {
-        var invite = new ProtoClanInfo.Invite { SteamId = 1, Recruiter = 2, Timestamp = 1_700_000_000 };
+        var invite = new ProtoClanInfo.Invite
+        {
+            SteamId = 1,
+            Recruiter = 2,
+            Timestamp = 1_700_000_000
+        };
         var model = invite.ToClanInvite();
         Assert.Equal(1ul, model.SteamId);
         Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1_700_000_000).UtcDateTime, model.Timestamp);
@@ -77,7 +105,10 @@ public class ClanInfoPresenceTests
     [Fact]
     public void ToClanChangedEvent_WrapsClanInfo()
     {
-        var changed = new AppClanChanged { ClanInfo = Minimal() };
+        var changed = new AppClanChanged
+        {
+            ClanInfo = Minimal()
+        };
         Assert.Equal(1, changed.ToClanChangedEvent().ClanInfo!.ClanId);
     }
 }

--- a/tests/RustPlusApi.UnitTests/ClanInfoPresenceTests.cs
+++ b/tests/RustPlusApi.UnitTests/ClanInfoPresenceTests.cs
@@ -10,10 +10,7 @@ public class ClanInfoPresenceTests
 {
     private static ProtoClanInfo Minimal() => new()
     {
-        ClanId = 1,
-        Name = "c",
-        Created = 0,
-        Creator = 0
+        ClanId = 1, Name = "c", Created = 0, Creator = 0
     };
 
     [Fact]
@@ -56,14 +53,11 @@ public class ClanInfoPresenceTests
     {
         var setTrue = new ProtoClanInfo.Role
         {
-            RoleId = 1,
-            Name = "r",
-            CanAccessScoreEvents = true
+            RoleId = 1, Name = "r", CanAccessScoreEvents = true
         };
         var unset = new ProtoClanInfo.Role
         {
-            RoleId = 2,
-            Name = "r"
+            RoleId = 2, Name = "r"
         };
         Assert.True(setTrue.ToClanRole().CanAccessScoreEvents);
         Assert.False(unset.ToClanRole().CanAccessScoreEvents);
@@ -74,9 +68,7 @@ public class ClanInfoPresenceTests
     {
         var withOpts = new ProtoClanInfo.Member
         {
-            SteamId = 1,
-            Notes = "hi",
-            Online = true
+            SteamId = 1, Notes = "hi", Online = true
         };
         var without = new ProtoClanInfo.Member
         {
@@ -93,9 +85,7 @@ public class ClanInfoPresenceTests
     {
         var invite = new ProtoClanInfo.Invite
         {
-            SteamId = 1,
-            Recruiter = 2,
-            Timestamp = 1_700_000_000
+            SteamId = 1, Recruiter = 2, Timestamp = 1_700_000_000
         };
         var model = invite.ToClanInvite();
         Assert.Equal(1ul, model.SteamId);

--- a/tests/RustPlusApi.UnitTests/EntityInfoMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/EntityInfoMapperTests.cs
@@ -11,8 +11,7 @@ public class EntityInfoMapperTests
     private static AppEntityInfo Entity(AppEntityType type, AppEntityPayload payload) =>
         new()
         {
-            Type = type,
-            Payload = payload
+            Type = type, Payload = payload
         };
 
     [Fact]
@@ -57,9 +56,7 @@ public class EntityInfoMapperTests
             {
                 new AppEntityPayload.Item
                 {
-                    ItemId = 1,
-                    Quantity = 5,
-                    ItemIsBlueprint = true
+                    ItemId = 1, Quantity = 5, ItemIsBlueprint = true
                 }
             }
         };

--- a/tests/RustPlusApi.UnitTests/EntityInfoMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/EntityInfoMapperTests.cs
@@ -9,12 +9,19 @@ namespace RustPlusApi.UnitTests;
 public class EntityInfoMapperTests
 {
     private static AppEntityInfo Entity(AppEntityType type, AppEntityPayload payload) =>
-        new() { Type = type, Payload = payload };
+        new()
+        {
+            Type = type,
+            Payload = payload
+        };
 
     [Fact]
     public void ToSmartSwitchInfo_MapsActiveState()
     {
-        var info = Entity(AppEntityType.Switch, new AppEntityPayload { Value = true }).ToSmartSwitchInfo();
+        var info = Entity(AppEntityType.Switch, new AppEntityPayload
+        {
+            Value = true
+        }).ToSmartSwitchInfo();
         Assert.True(info.IsActive);
     }
 
@@ -26,7 +33,10 @@ public class EntityInfoMapperTests
     [Fact]
     public void ToAlarmInfo_MapsActiveState()
     {
-        var info = Entity(AppEntityType.Alarm, new AppEntityPayload { Value = true }).ToAlarmInfo();
+        var info = Entity(AppEntityType.Alarm, new AppEntityPayload
+        {
+            Value = true
+        }).ToAlarmInfo();
         Assert.True(info.IsActive);
     }
 
@@ -43,7 +53,15 @@ public class EntityInfoMapperTests
             Capacity = 48,
             HasProtection = true,
             ProtectionExpiry = 1_700_000_000,
-            Items = { new AppEntityPayload.Item { ItemId = 1, Quantity = 5, ItemIsBlueprint = true } }
+            Items =
+            {
+                new AppEntityPayload.Item
+                {
+                    ItemId = 1,
+                    Quantity = 5,
+                    ItemIsBlueprint = true
+                }
+            }
         };
 
         var info = Entity(AppEntityType.StorageMonitor, payload).ToStorageMonitorInfo();

--- a/tests/RustPlusApi.UnitTests/HtmlColorParserTests.cs
+++ b/tests/RustPlusApi.UnitTests/HtmlColorParserTests.cs
@@ -22,8 +22,8 @@ public class HtmlColorParserTests
     public void ThreeDigitHex_ExpandsNibbles()
     {
         var c = HtmlColorParser.FromHtml("#F80");
-        Assert.Equal(255, c.R);   // 0xF -> 0xFF
-        Assert.Equal(136, c.G);   // 0x8 -> 0x88
+        Assert.Equal(255, c.R); // 0xF -> 0xFF
+        Assert.Equal(136, c.G); // 0x8 -> 0x88
         Assert.Equal(0, c.B);
     }
 
@@ -61,7 +61,7 @@ public class HtmlColorParserTests
         // switch in the netstandard2.0 code path and reaches Color.FromName. Covers the
         // switch default / fall-through branch. The exact colour value is implementation-
         // defined (ColorTranslator or Color.FromName), so we only assert no throw.
-        var ex = Record.Exception(() => HtmlColorParser.FromHtml("#FF"));  // 2 hex digits
+        var ex = Record.Exception(() => HtmlColorParser.FromHtml("#FF")); // 2 hex digits
         Assert.Null(ex);
     }
 }

--- a/tests/RustPlusApi.UnitTests/MapMarkerDispatchTests.cs
+++ b/tests/RustPlusApi.UnitTests/MapMarkerDispatchTests.cs
@@ -14,7 +14,14 @@ public class MapMarkerDispatchTests
         var m = new AppMapMarkers();
         foreach (var (id, type) in markers)
         {
-            m.Markers.Add(new AppMarker { Id = id, X = 1, Y = 1, Type = type, Name = "n" });
+            m.Markers.Add(new AppMarker
+            {
+                Id = id,
+                X = 1,
+                Y = 1,
+                Type = type,
+                Name = "n"
+            });
         }
 
         return m;

--- a/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
@@ -70,10 +70,7 @@ public class MarkerMapperTests
         // PriceMultiplier left default => ShouldSerializePriceMultiplier() is false => null.
         var order = new SellOrder
         {
-            ItemId = 9,
-            Quantity = 1,
-            CostPerItem = 1,
-            AmountInStock = 1
+            ItemId = 9, Quantity = 1, CostPerItem = 1, AmountInStock = 1
         };
         var item = order.ToVendingMachineItem();
         Assert.Null(item.PriceMultiplier);

--- a/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
@@ -68,7 +68,13 @@ public class MarkerMapperTests
     public void ToVendingMachineItem_WhenPriceMultiplierUnset_IsNull()
     {
         // PriceMultiplier left default => ShouldSerializePriceMultiplier() is false => null.
-        var order = new SellOrder { ItemId = 9, Quantity = 1, CostPerItem = 1, AmountInStock = 1 };
+        var order = new SellOrder
+        {
+            ItemId = 9,
+            Quantity = 1,
+            CostPerItem = 1,
+            AmountInStock = 1
+        };
         var item = order.ToVendingMachineItem();
         Assert.Null(item.PriceMultiplier);
     }
@@ -84,9 +90,12 @@ public class MarkerMapperTests
         var (id, x, y) = type switch
         {
             AppMarkerType.Ch47 => (marker.ToCh47Marker().Id, marker.ToCh47Marker().X, marker.ToCh47Marker().Y),
-            AppMarkerType.CargoShip => (marker.ToCargoShipMarker().Id, marker.ToCargoShipMarker().X, marker.ToCargoShipMarker().Y),
-            AppMarkerType.PatrolHelicopter => (marker.ToPatrolHelicopterMarker().Id, marker.ToPatrolHelicopterMarker().X, marker.ToPatrolHelicopterMarker().Y),
-            _ => (marker.ToTravellingVendorMarker().Id, marker.ToTravellingVendorMarker().X, marker.ToTravellingVendorMarker().Y),
+            AppMarkerType.CargoShip => (marker.ToCargoShipMarker().Id, marker.ToCargoShipMarker().X,
+                marker.ToCargoShipMarker().Y),
+            AppMarkerType.PatrolHelicopter => (marker.ToPatrolHelicopterMarker().Id,
+                marker.ToPatrolHelicopterMarker().X, marker.ToPatrolHelicopterMarker().Y),
+            _ => (marker.ToTravellingVendorMarker().Id, marker.ToTravellingVendorMarker().X,
+                marker.ToTravellingVendorMarker().Y),
         };
         Assert.Equal(7u, id);
         Assert.Equal(1.5f, x);

--- a/tests/RustPlusApi.UnitTests/ProtobufRoundTripTests.cs
+++ b/tests/RustPlusApi.UnitTests/ProtobufRoundTripTests.cs
@@ -47,8 +47,7 @@ public class ProtobufRoundTripTests
         {
             Response = new AppResponse
             {
-                Seq = 3,
-                Info = MockResponses.SampleInfo()
+                Seq = 3, Info = MockResponses.SampleInfo()
             }
         };
 
@@ -90,10 +89,7 @@ public class ProtobufRoundTripTests
         };
         var withoutMotd = new ClanInfo
         {
-            ClanId = 1,
-            Name = "c",
-            Created = 0,
-            Creator = 0
+            ClanId = 1, Name = "c", Created = 0, Creator = 0
         };
 
         Assert.True(RoundTrip(withMotd).ShouldSerializeMotd());

--- a/tests/RustPlusApi.UnitTests/ProtobufRoundTripTests.cs
+++ b/tests/RustPlusApi.UnitTests/ProtobufRoundTripTests.cs
@@ -43,7 +43,14 @@ public class ProtobufRoundTripTests
     [Fact]
     public void AppMessage_WithResponse_RoundTrips()
     {
-        var message = new AppMessage { Response = new AppResponse { Seq = 3, Info = MockResponses.SampleInfo() } };
+        var message = new AppMessage
+        {
+            Response = new AppResponse
+            {
+                Seq = 3,
+                Info = MockResponses.SampleInfo()
+            }
+        };
 
         var result = RoundTrip(message);
 
@@ -57,7 +64,10 @@ public class ProtobufRoundTripTests
     [Fact]
     public void AppMessage_WithBroadcast_RoundTrips()
     {
-        var message = new AppMessage { Broadcast = MockResponses.TeamMessageBroadcast(1, "Tester", "hi") };
+        var message = new AppMessage
+        {
+            Broadcast = MockResponses.TeamMessageBroadcast(1, "Tester", "hi")
+        };
 
         var result = RoundTrip(message);
 
@@ -70,8 +80,21 @@ public class ProtobufRoundTripTests
     [Fact]
     public void OptionalScalarPresence_IsTrackedViaShouldSerialize()
     {
-        var withMotd = new ClanInfo { ClanId = 1, Name = "c", Created = 0, Creator = 0, Motd = "hi" };
-        var withoutMotd = new ClanInfo { ClanId = 1, Name = "c", Created = 0, Creator = 0 };
+        var withMotd = new ClanInfo
+        {
+            ClanId = 1,
+            Name = "c",
+            Created = 0,
+            Creator = 0,
+            Motd = "hi"
+        };
+        var withoutMotd = new ClanInfo
+        {
+            ClanId = 1,
+            Name = "c",
+            Created = 0,
+            Creator = 0
+        };
 
         Assert.True(RoundTrip(withMotd).ShouldSerializeMotd());
         Assert.False(RoundTrip(withoutMotd).ShouldSerializeMotd());

--- a/tests/RustPlusApi.UnitTests/RemainingMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/RemainingMapperTests.cs
@@ -12,7 +12,12 @@ public class RemainingMapperTests
     public void ToServerMap_MapsDimensionsAndMonuments()
     {
         var map = MockResponses.SampleMap();
-        map.Monuments.Add(new AppMap.Monument { Token = "cave", X = 1, Y = 2 });
+        map.Monuments.Add(new AppMap.Monument
+        {
+            Token = "cave",
+            X = 1,
+            Y = 2
+        });
 
         var model = map.ToServerMap();
 
@@ -25,7 +30,10 @@ public class RemainingMapperTests
     [Fact]
     public void ToSubscriptionInfo_MapsValue()
     {
-        var info = new AppFlag { Value = true }.ToSubscriptionInfo();
+        var info = new AppFlag
+        {
+            Value = true
+        }.ToSubscriptionInfo();
         Assert.True(info.IsSubscribed);
     }
 
@@ -35,7 +43,10 @@ public class RemainingMapperTests
         var changed = new AppEntityChanged
         {
             EntityId = 99,
-            Payload = new AppEntityPayload { Value = true }
+            Payload = new AppEntityPayload
+            {
+                Value = true
+            }
         };
 
         var ev = changed.ToSmartSwitchEvent();
@@ -55,7 +66,14 @@ public class RemainingMapperTests
                 Capacity = 24,
                 HasProtection = false,
                 ProtectionExpiry = 1_700_000_000,
-                Items = { new AppEntityPayload.Item { ItemId = 1, Quantity = 2 } }
+                Items =
+                {
+                    new AppEntityPayload.Item
+                    {
+                        ItemId = 1,
+                        Quantity = 2
+                    }
+                }
             }
         };
 
@@ -73,7 +91,14 @@ public class RemainingMapperTests
         {
             Messages =
             {
-                new AppTeamMessage { SteamId = 1, Name = "Alice", Message = "hello", Color = "#FF0000", Time = 1_700_000_000 }
+                new AppTeamMessage
+                {
+                    SteamId = 1,
+                    Name = "Alice",
+                    Message = "hello",
+                    Color = "#FF0000",
+                    Time = 1_700_000_000
+                }
             }
         };
 
@@ -89,7 +114,14 @@ public class RemainingMapperTests
     [Fact]
     public void ToTeamMessage_MapsColorAndTime()
     {
-        var proto = new AppTeamMessage { SteamId = 2, Name = "Bob", Message = "hi", Color = "#00FF00", Time = 1_600_000_000 };
+        var proto = new AppTeamMessage
+        {
+            SteamId = 2,
+            Name = "Bob",
+            Message = "hi",
+            Color = "#00FF00",
+            Time = 1_600_000_000
+        };
 
         var msg = proto.ToTeamMessage();
 
@@ -101,7 +133,14 @@ public class RemainingMapperTests
     [Fact]
     public void ToTeamMessageEvent_MapsAllFields()
     {
-        var proto = new AppTeamMessage { SteamId = 3, Name = "Charlie", Message = "wave", Color = "#0000FF", Time = 1_500_000_000 };
+        var proto = new AppTeamMessage
+        {
+            SteamId = 3,
+            Name = "Charlie",
+            Message = "wave",
+            Color = "#0000FF",
+            Time = 1_500_000_000
+        };
 
         var ev = proto.ToTeamMessageEvent();
 
@@ -123,7 +162,13 @@ public class RemainingMapperTests
     [Fact]
     public void ToClanMessage_MapsFields()
     {
-        var proto = new AppClanMessage { SteamId = 1, Name = "D", Message = "hey", Time = 1_700_000_000 };
+        var proto = new AppClanMessage
+        {
+            SteamId = 1,
+            Name = "D",
+            Message = "hey",
+            Time = 1_700_000_000
+        };
         var msg = proto.ToClanMessage();
         Assert.Equal(1ul, msg.SteamId);
         Assert.Equal("D", msg.Name);
@@ -136,7 +181,13 @@ public class RemainingMapperTests
         var broadcast = new AppNewClanMessage
         {
             ClanId = 42,
-            Message = new AppClanMessage { SteamId = 7, Name = "Eve", Message = "sup", Time = 1_600_000_000 }
+            Message = new AppClanMessage
+            {
+                SteamId = 7,
+                Name = "Eve",
+                Message = "sup",
+                Time = 1_600_000_000
+            }
         };
 
         var ev = broadcast.ToClanMessageEvent();

--- a/tests/RustPlusApi.UnitTests/RemainingMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/RemainingMapperTests.cs
@@ -14,9 +14,7 @@ public class RemainingMapperTests
         var map = MockResponses.SampleMap();
         map.Monuments.Add(new AppMap.Monument
         {
-            Token = "cave",
-            X = 1,
-            Y = 2
+            Token = "cave", X = 1, Y = 2
         });
 
         var model = map.ToServerMap();
@@ -70,8 +68,7 @@ public class RemainingMapperTests
                 {
                     new AppEntityPayload.Item
                     {
-                        ItemId = 1,
-                        Quantity = 2
+                        ItemId = 1, Quantity = 2
                     }
                 }
             }
@@ -164,10 +161,7 @@ public class RemainingMapperTests
     {
         var proto = new AppClanMessage
         {
-            SteamId = 1,
-            Name = "D",
-            Message = "hey",
-            Time = 1_700_000_000
+            SteamId = 1, Name = "D", Message = "hey", Time = 1_700_000_000
         };
         var msg = proto.ToClanMessage();
         Assert.Equal(1ul, msg.SteamId);
@@ -183,10 +177,7 @@ public class RemainingMapperTests
             ClanId = 42,
             Message = new AppClanMessage
             {
-                SteamId = 7,
-                Name = "Eve",
-                Message = "sup",
-                Time = 1_600_000_000
+                SteamId = 7, Name = "Eve", Message = "sup", Time = 1_600_000_000
             }
         };
 

--- a/tests/RustPlusApi.UnitTests/RustPlusConnectionTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusConnectionTests.cs
@@ -28,7 +28,10 @@ public class RustPlusConnectionTests
     {
         var a = new RustPlusConnection("host", 1, 2UL, 3);
         var b = new RustPlusConnection("host", 1, 2UL, 3);
-        var differentToken = a with { PlayerToken = 99 };
+        var differentToken = a with
+        {
+            PlayerToken = 99
+        };
 
         Assert.Equal(a, b);
         Assert.Equal(a.GetHashCode(), b.GetHashCode());

--- a/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
@@ -53,7 +53,11 @@ public class RustPlusParseNotificationTests
             EntityChanged = new AppEntityChanged
             {
                 EntityId = 42,
-                Payload = new AppEntityPayload { Value = true, Capacity = 0 }
+                Payload = new AppEntityPayload
+                {
+                    Value = true,
+                    Capacity = 0
+                }
             }
         };
 
@@ -75,7 +79,11 @@ public class RustPlusParseNotificationTests
             EntityChanged = new AppEntityChanged
             {
                 EntityId = 1,
-                Payload = new AppEntityPayload { Value = true, Capacity = 0 }
+                Payload = new AppEntityPayload
+                {
+                    Value = true,
+                    Capacity = 0
+                }
             }
         };
 
@@ -94,7 +102,11 @@ public class RustPlusParseNotificationTests
             EntityChanged = new AppEntityChanged
             {
                 EntityId = 2,
-                Payload = new AppEntityPayload { Value = false, Capacity = 48 } // Capacity != 0 → storage monitor
+                Payload = new AppEntityPayload
+                {
+                    Value = false,
+                    Capacity = 48
+                } // Capacity != 0 → storage monitor
             }
         };
 
@@ -162,7 +174,11 @@ public class RustPlusParseNotificationTests
         {
             ClanChanged = new AppClanChanged
             {
-                ClanInfo = new ClanInfo { ClanId = 1, Name = "TestClan" }
+                ClanInfo = new ClanInfo
+                {
+                    ClanId = 1,
+                    Name = "TestClan"
+                }
             }
         };
 

--- a/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
@@ -55,8 +55,7 @@ public class RustPlusParseNotificationTests
                 EntityId = 42,
                 Payload = new AppEntityPayload
                 {
-                    Value = true,
-                    Capacity = 0
+                    Value = true, Capacity = 0
                 }
             }
         };
@@ -81,8 +80,7 @@ public class RustPlusParseNotificationTests
                 EntityId = 1,
                 Payload = new AppEntityPayload
                 {
-                    Value = true,
-                    Capacity = 0
+                    Value = true, Capacity = 0
                 }
             }
         };
@@ -104,8 +102,7 @@ public class RustPlusParseNotificationTests
                 EntityId = 2,
                 Payload = new AppEntityPayload
                 {
-                    Value = false,
-                    Capacity = 48
+                    Value = false, Capacity = 48
                 } // Capacity != 0 → storage monitor
             }
         };
@@ -152,10 +149,7 @@ public class RustPlusParseNotificationTests
                 ClanId = 42,
                 Message = new AppClanMessage
                 {
-                    SteamId = 76561198000000001,
-                    Name = "Bob",
-                    Message = "clan chat",
-                    Time = 1_700_000_000
+                    SteamId = 76561198000000001, Name = "Bob", Message = "clan chat", Time = 1_700_000_000
                 }
             }
         };
@@ -176,8 +170,7 @@ public class RustPlusParseNotificationTests
             {
                 ClanInfo = new ClanInfo
                 {
-                    ClanId = 1,
-                    Name = "TestClan"
+                    ClanId = 1, Name = "TestClan"
                 }
             }
         };
@@ -196,10 +189,7 @@ public class RustPlusParseNotificationTests
         {
             CameraRays = new AppCameraRays
             {
-                VerticalFov = 65f,
-                SampleOffset = 0,
-                RayData = [0, 1, 2],
-                Distance = 50f
+                VerticalFov = 65f, SampleOffset = 0, RayData = [0, 1, 2], Distance = 50f
             }
         };
 
@@ -234,8 +224,7 @@ public class RustPlusParseNotificationTests
         {
             Response = new AppResponse
             {
-                Seq = 1,
-                Success = new AppSuccess()
+                Seq = 1, Success = new AppSuccess()
                 // Error is null
             }
         };

--- a/tests/RustPlusApi.UnitTests/SpyLogger.cs
+++ b/tests/RustPlusApi.UnitTests/SpyLogger.cs
@@ -10,7 +10,10 @@ public sealed class SpyLogger : ILogger
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
     public bool IsEnabled(LogLevel logLevel) => true;
 
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+    public void Log<TState>(LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
         Func<TState, Exception?, string> formatter)
         => Entries.Add((logLevel, formatter(state, exception)));
 

--- a/tests/RustPlusApi.UnitTests/TeamInfoMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/TeamInfoMapperTests.cs
@@ -33,9 +33,7 @@ public class TeamInfoMapperTests
             {
                 new AppTeamInfo.Note
                 {
-                    Type = 0,
-                    X = 1,
-                    Y = 2
+                    Type = 0, X = 1, Y = 2
                 },
                 new AppTeamInfo.Note
                 {
@@ -101,8 +99,7 @@ public class TeamInfoMapperTests
             {
                 new AppTeamInfo.Note
                 {
-                    Type = 1,
-                    Label = "x"
+                    Type = 1, Label = "x"
                 }
             }
         };

--- a/tests/RustPlusApi.UnitTests/TeamInfoMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/TeamInfoMapperTests.cs
@@ -15,17 +15,50 @@ public class TeamInfoMapperTests
         var info = new AppTeamInfo
         {
             LeaderSteamId = 76561198000000001,
-            Members = { new AppTeamInfo.Member
+            Members =
             {
-                SteamId = 76561198000000001, Name = "Leader", X = 10, Y = 20,
-                IsOnline = true, SpawnTime = 1_600_000_000, IsAlive = true, DeathTime = 1_600_000_500
-            }},
+                new AppTeamInfo.Member
+                {
+                    SteamId = 76561198000000001,
+                    Name = "Leader",
+                    X = 10,
+                    Y = 20,
+                    IsOnline = true,
+                    SpawnTime = 1_600_000_000,
+                    IsAlive = true,
+                    DeathTime = 1_600_000_500
+                }
+            },
             MapNotes =
             {
-                new AppTeamInfo.Note { Type = 0, X = 1, Y = 2 },
-                new AppTeamInfo.Note { Type = 1, X = 3, Y = 4, Icon = 2, ColourIndex = 1, Label = "base" }
+                new AppTeamInfo.Note
+                {
+                    Type = 0,
+                    X = 1,
+                    Y = 2
+                },
+                new AppTeamInfo.Note
+                {
+                    Type = 1,
+                    X = 3,
+                    Y = 4,
+                    Icon = 2,
+                    ColourIndex = 1,
+                    Label = "base"
+                }
             },
-            LeaderMapNotes = { new AppTeamInfo.Note { Type = 1, X = 5, Y = 6, Icon = 0, ColourIndex = 0, Label = "rally" } }
+            LeaderMapNotes =
+            {
+                new AppTeamInfo.Note
+                {
+                    Type = 1,
+                    X = 5,
+                    Y = 6,
+                    Icon = 0,
+                    ColourIndex = 0,
+                    Label = "rally"
+                }
+            }
         };
 
         var model = info.ToTeamInfo();
@@ -46,14 +79,33 @@ public class TeamInfoMapperTests
     [Fact]
     public void ToTeamInfo_UnknownNoteType_Throws()
     {
-        var info = new AppTeamInfo { MapNotes = { new AppTeamInfo.Note { Type = 99 } } };
+        var info = new AppTeamInfo
+        {
+            MapNotes =
+            {
+                new AppTeamInfo.Note
+                {
+                    Type = 99
+                }
+            }
+        };
         Assert.Throws<ArgumentException>(info.ToTeamInfo);
     }
 
     [Fact]
     public void ToTeamInfo_NoDeathNote_LeavesDeathNoteNull()
     {
-        var info = new AppTeamInfo { MapNotes = { new AppTeamInfo.Note { Type = 1, Label = "x" } } };
+        var info = new AppTeamInfo
+        {
+            MapNotes =
+            {
+                new AppTeamInfo.Note
+                {
+                    Type = 1,
+                    Label = "x"
+                }
+            }
+        };
         Assert.Null(info.ToTeamInfo().DeathNote);
     }
 }

--- a/tools/update-proto/ProtoGen/CommittedProto.cs
+++ b/tools/update-proto/ProtoGen/CommittedProto.cs
@@ -96,6 +96,7 @@ internal sealed partial class CommittedProto
             state.TopLevelName = open.Groups[2].Value;
             state.Block = [rawLine];
         }
+
         state.Stack.Add(open.Groups[2].Value);
         DeclOrder.Add(string.Join('.', state.Stack));
         return true;
@@ -123,6 +124,7 @@ internal sealed partial class CommittedProto
             RawTopLevelBlocks[state.TopLevelName] = string.Join('\n', state.Block).TrimEnd();
             state.TopLevelName = null;
         }
+
         return true;
     }
 

--- a/tools/update-proto/ProtoGen/Emitter.cs
+++ b/tools/update-proto/ProtoGen/Emitter.cs
@@ -14,6 +14,7 @@ internal sealed partial class Emitter
     private readonly CommittedProto _committed;
     private readonly HashSet<string> _scopeMessages = new(StringComparer.Ordinal);
     private readonly HashSet<string> _scopeEnums = new(StringComparer.Ordinal);
+
     /// <summary>Committed top-level types that the authoritative closure does not cover: external well-known
     /// types (Vector2/3/4) and unreachable/vestigial types (Half3, Color, Ray, ClanActionResult).
     /// Emitted verbatim from the committed proto — no authoritative claim is made about them.</summary>
@@ -64,9 +65,9 @@ internal sealed partial class Emitter
 
         // Preserve any committed top-level declaration the closure does not authoritatively cover.
         foreach (var name in _committed.DeclOrder
-            .Where(n => !n.Contains('.', StringComparison.Ordinal) &&
-                        !_scopeMessages.Contains(n) && !_scopeEnums.Contains(n) &&
-                        _committed.RawTopLevelBlocks.ContainsKey(n)))
+                     .Where(n => !n.Contains('.', StringComparison.Ordinal) &&
+                                 !_scopeMessages.Contains(n) && !_scopeEnums.Contains(n) &&
+                                 _committed.RawTopLevelBlocks.ContainsKey(n)))
         {
             _preserved.Add(name);
         }
@@ -145,9 +146,9 @@ internal sealed partial class Emitter
         {
             var label = _committed.LabelFor(msg.QualifiedName, f.Number, f.Repeated);
             sb.Append(pad).Append('\t')
-              .Append(label).Append(' ')
-              .Append(EmitTypeName(f.ProtoType, msg.QualifiedName)).Append(' ')
-              .Append(ToSnakeCase(f.Name)).Append(" = ").Append(f.Number).AppendLine(";");
+                .Append(label).Append(' ')
+                .Append(EmitTypeName(f.ProtoType, msg.QualifiedName)).Append(' ')
+                .Append(ToSnakeCase(f.Name)).Append(" = ").Append(f.Number).AppendLine(";");
         }
 
         RenderScope(sb, msg.QualifiedName, indent + 1);
@@ -184,7 +185,7 @@ internal sealed partial class Emitter
             return protoType[(parent.Length + 1)..]; // sibling reference -> simple name
         }
 
-        return protoType;                            // parent->child or distant -> qualified
+        return protoType; // parent->child or distant -> qualified
     }
 
     private static string? ParentOf(string qualified)

--- a/tools/update-proto/ProtoGen/Model.cs
+++ b/tools/update-proto/ProtoGen/Model.cs
@@ -5,10 +5,13 @@ internal sealed class Field
 {
     /// <summary>C# name (camelCase), e.g. "jpgImage".</summary>
     public required string Name { get; init; }
+
     /// <summary>Proto field number.</summary>
     public required int Number { get; init; }
+
     /// <summary>Resolved proto type, e.g. "uint32" or "AppMap.Monument".</summary>
     public required string ProtoType { get; init; }
+
     public required bool Repeated { get; init; }
 }
 
@@ -17,10 +20,13 @@ internal sealed class Message
 {
     /// <summary>Qualified name, e.g. "AppMap.Monument".</summary>
     public required string QualifiedName { get; init; }
+
     /// <summary>Simple name, e.g. "Monument".</summary>
     public required string SimpleName { get; init; }
+
     /// <summary>Null for top-level messages.</summary>
     public string? ParentQualifiedName { get; init; }
+
     public List<Field> Fields { get; } = [];
 }
 

--- a/tools/update-proto/ProtoGen/Program.cs
+++ b/tools/update-proto/ProtoGen/Program.cs
@@ -6,13 +6,17 @@ using ProtoGen;
 
 if (args.Length != 3)
 {
-    await Console.Error.WriteLineAsync("usage: ProtoGen <decompiled.cs> <committed.proto> <output.proto>").ConfigureAwait(false);
+    await Console.Error.WriteLineAsync("usage: ProtoGen <decompiled.cs> <committed.proto> <output.proto>")
+        .ConfigureAwait(false);
     return 2;
 }
 
 var (decompiledPath, committedPath, outputPath) = (args[0], args[1], args[2]);
 
-foreach (var (label, path) in new[] { ("decompiled", decompiledPath), ("committed proto", committedPath) })
+foreach (var (label, path) in new[]
+         {
+             ("decompiled", decompiledPath), ("committed proto", committedPath)
+         })
 {
     if (!File.Exists(path))
     {
@@ -23,7 +27,9 @@ foreach (var (label, path) in new[] { ("decompiled", decompiledPath), ("committe
 
 await Console.Error.WriteLineAsync($">> parsing server contracts: {decompiledPath}").ConfigureAwait(false);
 var server = ServerParser.Parse(decompiledPath);
-await Console.Error.WriteLineAsync($">> parsed {server.Messages.Count} messages, {server.Enums.Count} enums (namespace ProtoBuf)").ConfigureAwait(false);
+await Console.Error
+    .WriteLineAsync($">> parsed {server.Messages.Count} messages, {server.Enums.Count} enums (namespace ProtoBuf)")
+    .ConfigureAwait(false);
 
 var committed = CommittedProto.Parse(committedPath);
 

--- a/tools/update-proto/ProtoGen/ServerParser.cs
+++ b/tools/update-proto/ProtoGen/ServerParser.cs
@@ -14,6 +14,7 @@ internal sealed class ServerParser
 {
     private readonly Dictionary<string, Message> _messages = new(StringComparer.Ordinal);
     private readonly Dictionary<string, EnumDef> _enums = new(StringComparer.Ordinal);
+
     /// <summary>Maps simple names to their fully-qualified names (a simple name like "Member" can be ambiguous).</summary>
     private readonly Dictionary<string, List<string>> _bySimpleName = new(StringComparer.Ordinal);
 
@@ -52,7 +53,7 @@ internal sealed class ServerParser
 
             // class- and struct-based messages (e.g. Half3 is a struct : IProto<Half3>).
             foreach (var type in ns.DescendantNodes().OfType<TypeDeclarationSyntax>()
-                                   .Where(t => t is ClassDeclarationSyntax or StructDeclarationSyntax))
+                         .Where(t => t is ClassDeclarationSyntax or StructDeclarationSyntax))
             {
                 parser.FillFields(type);
             }
@@ -68,7 +69,8 @@ internal sealed class ServerParser
     {
         switch (member)
         {
-            case TypeDeclarationSyntax cls and (ClassDeclarationSyntax or StructDeclarationSyntax) when IsProtoMessage(cls):
+            case TypeDeclarationSyntax cls and (ClassDeclarationSyntax or StructDeclarationSyntax)
+                when IsProtoMessage(cls):
                 DiscoverMessage(cls, parentQualified);
                 break;
             case EnumDeclarationSyntax en:
@@ -84,7 +86,12 @@ internal sealed class ServerParser
     {
         var simple = cls.Identifier.Text;
         var qualified = parentQualified is null ? simple : $"{parentQualified}.{simple}";
-        _messages[qualified] = new Message { QualifiedName = qualified, SimpleName = simple, ParentQualifiedName = parentQualified };
+        _messages[qualified] = new Message
+        {
+            QualifiedName = qualified,
+            SimpleName = simple,
+            ParentQualifiedName = parentQualified
+        };
         Register(simple, qualified);
 
         foreach (var inner in cls.Members)
@@ -100,7 +107,12 @@ internal sealed class ServerParser
     {
         var simple = en.Identifier.Text;
         var qualified = parentQualified is null ? simple : $"{parentQualified}.{simple}";
-        var def = new EnumDef { QualifiedName = qualified, SimpleName = simple, ParentQualifiedName = parentQualified };
+        var def = new EnumDef
+        {
+            QualifiedName = qualified,
+            SimpleName = simple,
+            ParentQualifiedName = parentQualified
+        };
         var next = 0;
         foreach (var m in en.Members)
         {
@@ -113,6 +125,7 @@ internal sealed class ServerParser
             def.Values.Add((m.Identifier.Text, val));
             next = val + 1;
         }
+
         _enums[qualified] = def;
         Register(simple, qualified);
     }
@@ -158,7 +171,8 @@ internal sealed class ServerParser
     /// <summary>Collects the non-static, non-const field declarations of a message as
     /// name -> (csType, repeated, elementType).</summary>
     /// <param name="cls">The type declaration to scan.</param>
-    private static Dictionary<string, (string CsType, bool Repeated, string Element)> CollectFieldDeclarations(TypeDeclarationSyntax cls)
+    private static Dictionary<string, (string CsType, bool Repeated, string Element)> CollectFieldDeclarations(
+        TypeDeclarationSyntax cls)
     {
         var decls = new Dictionary<string, (string CsType, bool Repeated, string Element)>(StringComparer.Ordinal);
         foreach (var fd in cls.Members.OfType<FieldDeclarationSyntax>())
@@ -245,7 +259,10 @@ internal sealed class ServerParser
     private string? ResolveDeclaredQualifiedName(TypeDeclarationSyntax cls)
     {
         // Build the qualified name by walking enclosing class/struct declarations.
-        var parts = new List<string> { cls.Identifier.Text };
+        var parts = new List<string>
+        {
+            cls.Identifier.Text
+        };
         for (var p = cls.Parent; p is ClassDeclarationSyntax or StructDeclarationSyntax; p = p.Parent)
         {
             parts.Insert(0, ((TypeDeclarationSyntax)p).Identifier.Text);
@@ -272,6 +289,7 @@ internal sealed class ServerParser
                 return n;
             }
         }
+
         // instance.X.Add(...)
         foreach (var inv in section.DescendantNodes().OfType<InvocationExpressionSyntax>())
         {
@@ -281,6 +299,7 @@ internal sealed class ServerParser
                 return n;
             }
         }
+
         // ... ref instance.X ...
         foreach (var arg in section.DescendantNodes().OfType<ArgumentSyntax>())
         {
@@ -289,6 +308,7 @@ internal sealed class ServerParser
                 return n;
             }
         }
+
         // fallback: first instance.X anywhere
         foreach (var ma in section.DescendantNodes().OfType<MemberAccessExpressionSyntax>())
         {
@@ -297,6 +317,7 @@ internal sealed class ServerParser
                 return n;
             }
         }
+
         return null;
     }
 
@@ -309,11 +330,15 @@ internal sealed class ServerParser
     {
         foreach (var inv in section.DescendantNodes().OfType<InvocationExpressionSyntax>())
         {
-            if (inv.Expression is MemberAccessExpressionSyntax { Expression: IdentifierNameSyntax { Identifier.Text: "ProtocolParser" } } ma)
+            if (inv.Expression is MemberAccessExpressionSyntax
+                {
+                    Expression: IdentifierNameSyntax { Identifier.Text: "ProtocolParser" }
+                } ma)
             {
                 return ma.Name.Identifier.Text;
             }
         }
+
         return null;
     }
 
@@ -399,7 +424,10 @@ internal sealed class ServerParser
         }
 
         // Walk scope ancestors: "A.B.C" -> "A.B" -> "A" -> ""
-        var scopes = new List<string> { scopeQualified };
+        var scopes = new List<string>
+        {
+            scopeQualified
+        };
         var idx = scopeQualified.LastIndexOf('.');
         while (idx >= 0)
         {
@@ -407,6 +435,7 @@ internal sealed class ServerParser
             scopes.Add(scopeQualified);
             idx = scopeQualified.LastIndexOf('.');
         }
+
         foreach (var s in scopes)
         {
             var nested = $"{s}.{simple}";
@@ -415,6 +444,7 @@ internal sealed class ServerParser
                 return nested;
             }
         }
+
         // prefer a top-level candidate (no dot)
         return candidates.FirstOrDefault(c => !c.Contains('.', StringComparison.Ordinal)) ?? candidates[0];
     }
@@ -429,7 +459,8 @@ internal sealed class ServerParser
                 case LiteralExpressionSyntax { Token.Value: not null } lit:
                     var t = lit.Token.Text.TrimEnd('u', 'U', 'l', 'L');
                     return int.TryParse(t, out value);
-                case PrefixUnaryExpressionSyntax { OperatorToken.RawKind: (int)SyntaxKind.MinusToken } neg when TryParseInt(neg.Operand, out var inner):
+                case PrefixUnaryExpressionSyntax { OperatorToken.RawKind: (int)SyntaxKind.MinusToken } neg
+                    when TryParseInt(neg.Operand, out var inner):
                     value = -inner;
                     return true;
                 case CastExpressionSyntax cast:

--- a/tools/update-proto/ProtoGen/ServerParser.cs
+++ b/tools/update-proto/ProtoGen/ServerParser.cs
@@ -88,9 +88,7 @@ internal sealed class ServerParser
         var qualified = parentQualified is null ? simple : $"{parentQualified}.{simple}";
         _messages[qualified] = new Message
         {
-            QualifiedName = qualified,
-            SimpleName = simple,
-            ParentQualifiedName = parentQualified
+            QualifiedName = qualified, SimpleName = simple, ParentQualifiedName = parentQualified
         };
         Register(simple, qualified);
 
@@ -109,9 +107,7 @@ internal sealed class ServerParser
         var qualified = parentQualified is null ? simple : $"{parentQualified}.{simple}";
         var def = new EnumDef
         {
-            QualifiedName = qualified,
-            SimpleName = simple,
-            ParentQualifiedName = parentQualified
+            QualifiedName = qualified, SimpleName = simple, ParentQualifiedName = parentQualified
         };
         var next = 0;
         foreach (var m in en.Members)
@@ -233,10 +229,7 @@ internal sealed class ServerParser
             var protoType = ResolveProtoType(d.Repeated ? d.Element : d.CsType, readMethod, qualified);
             msg.Fields.Add(new Field
             {
-                Name = fieldName,
-                Number = number,
-                ProtoType = protoType,
-                Repeated = d.Repeated,
+                Name = fieldName, Number = number, ProtoType = protoType, Repeated = d.Repeated,
             });
         }
     }


### PR DESCRIPTION
## Summary

- **ReSharper formatting**: adds `JetBrains.ReSharper.GlobalTools` to the dotnet tool manifest and applies `dotnet jb cleanupcode RustPlusApi.sln --profile="Built-in: Reformat Code"` across the solution, so formatting is reproducible locally before pushing (`dotnet tool restore && dotnet jb cleanupcode RustPlusApi.sln --profile="Built-in: Reformat Code"`).
- **SonarQube**: fixes all 4 open issues —
  - `css:S4666` duplicate selectors (`.rp-card:hover`, `.rp-card h3`) merged in the DocFX template stylesheet;
  - `IDE0130` ×2 suppressed with justification in the two `ServiceCollection` extension classes — the `Microsoft.Extensions.DependencyInjection` namespace is the deliberate MS convention for DI extensions (same pragma pattern as `ProtoBuf/Mcs.cs`).
- **Docs front fix**: the *API Reference* CTA on the landing page rendered as a plain link instead of a button — DocFX replaces `<a href="xref:...">` tags entirely and drops custom classes. It now links to `api/RustPlusApi.yml`, which DocFX rewrites to `.html` while keeping the `btn btn-outline-secondary` classes, so it aligns with *Get Started*.

## Verification

- `dotnet build` — 0 warnings, 0 errors (TreatWarningsAsErrors on)
- `dotnet test` — all 14 suites green
- `docfx docs/docfx.json` — 0 warnings; rendered hero shows both anchors with `btn` classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)