### PR TITLE
fix: resolve engineering-review findings — socket hardening, error codes, registration robustness

### DIFF
--- a/docs/articles/credentials.md
+++ b/docs/articles/credentials.md
@@ -126,3 +126,10 @@ var listener = new RustPlusFcm(credentials);
 ```
 
 The legacy rustplus.js `rustplus.config.json` format is also accepted by the FCM sample's loader.
+
+> [!WARNING]
+> `rustplus.config.json` contains long-lived push credentials (the GCM security token and
+> FCM/Expo tokens) in plain JSON — anyone who can read the file can receive your pairing
+> notifications. Treat it like a password file: keep it out of version control and shared
+> directories. On .NET 10+ on Linux/macOS, `CredentialsStore.Save` restricts it to owner
+> read/write; on other targets, restrict permissions yourself.

--- a/docs/articles/fcm-notifications.md
+++ b/docs/articles/fcm-notifications.md
@@ -29,6 +29,7 @@ listener.Disconnect();
 `persistentIds` is an optional `ICollection<string>` of already-seen notification IDs to skip on
 reconnect. Pass the same collection instance across reconnects — the socket appends every newly-seen
 ID to it as they arrive, so passing it back to a new instance automatically deduplicates replays.
+Prefer a `HashSet<string>` — the collection is consulted on every message and grows for the lifetime of the listener, so a `List<string>`'s linear scan degrades over long sessions.
 
 ## Events
 
@@ -88,7 +89,7 @@ notifications already processed are not replayed.
 var credentials = CredentialsStore.Load("rustplus.config.json");
 
 // Persist this collection across reconnects to deduplicate replayed notifications.
-ICollection<string> persistentIds = new List<string>();
+ICollection<string> persistentIds = new HashSet<string>();
 
 RustPlusFcm? listener = null;
 var delay = TimeSpan.FromSeconds(5);

--- a/src/RustPlusApi.Fcm.Registration/CredentialsStore.cs
+++ b/src/RustPlusApi.Fcm.Registration/CredentialsStore.cs
@@ -33,13 +33,27 @@ public static class CredentialsStore
     /// <param name="credentials">The credentials to persist.</param>
     public static void Save(string path, Credentials credentials)
     {
-        File.WriteAllText(path, Serialize(credentials));
 #if NET10_0_OR_GREATER
         if (!OperatingSystem.IsWindows())
         {
-            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            // Create the file with the restrictive mode from the first byte, so it is never
+            // observable with the umask default. The create mode only applies to new files —
+            // overwriting keeps the existing inode's mode — so tighten it afterwards as well.
+            const UnixFileMode ownerReadWrite = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+            using (var stream = new FileStream(path, new FileStreamOptions
+                   {
+                       Mode = FileMode.Create, Access = FileAccess.Write, UnixCreateMode = ownerReadWrite,
+                   }))
+            using (var writer = new StreamWriter(stream))
+            {
+                writer.Write(Serialize(credentials));
+            }
+
+            File.SetUnixFileMode(path, ownerReadWrite);
+            return;
         }
 #endif
+        File.WriteAllText(path, Serialize(credentials));
     }
 
     /// <summary>Reads the file at <paramref name="path"/> and deserializes it into a <see cref="Credentials"/> instance.</summary>

--- a/src/RustPlusApi.Fcm.Registration/CredentialsStore.cs
+++ b/src/RustPlusApi.Fcm.Registration/CredentialsStore.cs
@@ -26,11 +26,21 @@ public static class CredentialsStore
         JsonSerializer.Deserialize<Credentials>(json)
         ?? throw new InvalidOperationException("Could not deserialize credentials.");
 
-    /// <summary>Serializes <paramref name="credentials"/> and writes the result to <paramref name="path"/>.</summary>
+    /// <summary>Serializes <paramref name="credentials"/> and writes the result to <paramref name="path"/>.
+    /// The file contains long-lived push credentials (GCM security token, FCM/Expo tokens) in plain
+    /// JSON — treat it like a password file. On .NET 10+ on Unix it is restricted to owner read/write.</summary>
     /// <param name="path">The file path to write to.</param>
     /// <param name="credentials">The credentials to persist.</param>
-    public static void Save(string path, Credentials credentials) =>
+    public static void Save(string path, Credentials credentials)
+    {
         File.WriteAllText(path, Serialize(credentials));
+#if NET10_0_OR_GREATER
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+#endif
+    }
 
     /// <summary>Reads the file at <paramref name="path"/> and deserializes it into a <see cref="Credentials"/> instance.</summary>
     /// <param name="path">The file path previously written by <see cref="Save"/>.</param>

--- a/src/RustPlusApi.Fcm.Registration/Steps/AndroidFcmRegister.cs
+++ b/src/RustPlusApi.Fcm.Registration/Steps/AndroidFcmRegister.cs
@@ -170,9 +170,15 @@ public sealed class AndroidFcmRegister(HttpClient? httpClient = null)
             var responseText = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
 #endif
 
-            if (!responseText.Contains("Error", StringComparison.Ordinal))
+            // Success is "token=<value>", failure is "Error=<reason>". Prefix-match the error key
+            // and cut at the FIRST '=' so a token that itself contains '=' or the substring
+            // "Error" is never mangled. A response without '=' is treated as a failure to retry.
+#pragma warning disable CA1307 // the StringComparison overload of IndexOf(char) is unavailable on netstandard2.0; a char search is already ordinal
+            var separatorIndex = responseText.IndexOf('=');
+#pragma warning restore CA1307
+            if (!responseText.StartsWith("Error=", StringComparison.Ordinal) && separatorIndex >= 0)
             {
-                return responseText.Split('=')[1];
+                return responseText.Substring(separatorIndex + 1);
             }
 
             await Task.Delay(1000, cancellationToken).ConfigureAwait(false);

--- a/src/RustPlusApi.Fcm.Registration/Steps/SteamLoginService.cs
+++ b/src/RustPlusApi.Fcm.Registration/Steps/SteamLoginService.cs
@@ -44,6 +44,11 @@ public sealed class SteamLoginService(int port = 3000)
         using var listener = new HttpListener();
         listener.Prefixes.Add($"http://localhost:{port}/");
         listener.Start();
+        // GetContextAsync takes no cancellation token: stopping the listener is the only way to
+        // unblock the wait promptly, so cancellation must not have to wait for the next request.
+#pragma warning disable RCS1261 // CancellationTokenRegistration.DisposeAsync is not available on netstandard2.0
+        using var cancellationRegistration = cancellationToken.Register(listener.Stop);
+#pragma warning restore RCS1261
 
         var workDir = Path.Combine(Path.GetTempPath(), "rustplusapi-" + Guid.NewGuid().ToString("N"));
         var profileDir = Path.Combine(workDir, "profile");
@@ -60,7 +65,19 @@ public sealed class SteamLoginService(int port = 3000)
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                var context = await listener.GetContextAsync().ConfigureAwait(false);
+                HttpListenerContext context;
+                try
+                {
+                    context = await listener.GetContextAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is HttpListenerException or ObjectDisposedException)
+                {
+                    // The listener was stopped under the wait — by the cancellation registration
+                    // above (expected; rethrow as cancellation) or by an unrelated teardown.
+                    cancellationToken.ThrowIfCancellationRequested();
+                    throw;
+                }
+
                 var token = await ReadTokenAsync(context.Request).ConfigureAwait(false);
                 await RespondAsync(context, "<h1>Done. You can close this window.</h1>").ConfigureAwait(false);
                 if (!string.IsNullOrEmpty(token))

--- a/src/RustPlusApi.Fcm/RustPlusFcm.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcm.cs
@@ -12,7 +12,10 @@ namespace RustPlusApi.Fcm;
 /// Inherits from <see cref="RustPlusFcmSocket"/>.
 /// </summary>
 /// <param name="credentials">The <see cref="Credentials"/> used for authentication.</param>
-/// <param name="persistentIds">The collection of persistent IDs as <see cref="ICollection{T}"/> of <see cref="string"/>.</param>
+/// <param name="persistentIds">Already-processed message IDs, used for de-duplication. Every data
+/// message is checked against and appended to this collection, so for a long-lived listener prefer
+/// a set-like implementation (e.g. <see cref="HashSet{T}"/>) — with a <see cref="List{T}"/> the
+/// duplicate check is a linear scan that degrades as the collection grows unboundedly.</param>
 /// <param name="options">Tuning options (heartbeat interval, inactivity timeout); defaults are used when <see langword="null"/>.</param>
 /// <param name="loggerFactory">Routes the client's diagnostics into your logging stack; logging is
 /// disabled (a no-op <c>NullLogger</c>) when <see langword="null"/>.</param>

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -61,8 +61,17 @@ public abstract class RustPlusFcmSocket(
     private Task? _receiveLoop;
     private Task? _heartbeatLoop;
 
-    /// <summary>UTC timestamp of the last received frame, observed by the inactivity watchdog.</summary>
-    private DateTime _lastTraffic = DateTime.UtcNow;
+    /// <summary>UTC tick count of the last received frame, observed by the inactivity watchdog.
+    /// Stored as ticks behind <see cref="Volatile"/> because the watchdog reads it from another
+    /// thread, and a non-volatile 64-bit read can tear on 32-bit netstandard2.0 hosts.</summary>
+    private long _lastTrafficTicks = DateTime.UtcNow.Ticks;
+
+    /// <summary>Tear-free accessor over <see cref="_lastTrafficTicks"/>.</summary>
+    private DateTime LastTrafficUtc
+    {
+        get => new(Volatile.Read(ref _lastTrafficTicks), DateTimeKind.Utc);
+        set => Volatile.Write(ref _lastTrafficTicks, value.Ticks);
+    }
 
     /// <summary>Incoming MCS stream position: the count of frames received since login (the
     /// LoginResponse is 1). Reported back to the server as <c>LastStreamIdReceived</c> on stream
@@ -206,7 +215,7 @@ public abstract class RustPlusFcmSocket(
             Connected?.Invoke(this, EventArgs.Empty);
 
             // Truly async: the loop yields at the first awaited read instead of holding a thread-pool thread.
-            _lastTraffic = DateTime.UtcNow;
+            LastTrafficUtc = DateTime.UtcNow;
             _receiveLoop = ReceiveMessagesAsync();
 
             // Client-initiated heartbeat + inactivity watchdog: a NAT that silently drops the idle
@@ -380,7 +389,7 @@ public abstract class RustPlusFcmSocket(
     internal Task RunHeartbeatLoopOverStreamAsync(Stream stream)
     {
         _transport = stream;
-        _lastTraffic = DateTime.UtcNow;
+        LastTrafficUtc = DateTime.UtcNow;
         _heartbeatLoop = RunHeartbeatLoopAsync();
         return _heartbeatLoop;
     }
@@ -400,7 +409,7 @@ public abstract class RustPlusFcmSocket(
             {
                 await Task.Delay(_options.HeartbeatInterval, CancellationToken).ConfigureAwait(false);
 
-                if (DateTime.UtcNow - _lastTraffic > _options.InactivityTimeout)
+                if (DateTime.UtcNow - LastTrafficUtc > _options.InactivityTimeout)
                 {
                     var error = new TimeoutException(
                         $"No FCM traffic for {_options.InactivityTimeout.TotalMinutes:0.#} min; the connection is presumed dead.");
@@ -513,7 +522,7 @@ public abstract class RustPlusFcmSocket(
     {
         // Any decoded frame counts as traffic for the inactivity watchdog,
         // and advances the incoming stream position the server expects us to ack.
-        _lastTraffic = DateTime.UtcNow;
+        LastTrafficUtc = DateTime.UtcNow;
         _streamIdIn++;
 
         try

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -22,7 +22,10 @@ namespace RustPlusApi.Fcm;
 /// Represents a RustPlus FCM listener client for handling FCM connections and notifications.
 /// </summary>
 /// <param name="credentials">The <see cref="Credentials"/> used for authentication.</param>
-/// <param name="persistentIds">The collection of persistent IDs as <see cref="ICollection{T}"/> of <see cref="string"/>.</param>
+/// <param name="persistentIds">Already-processed message IDs, used for de-duplication. Every data
+/// message is checked against and appended to this collection, so for a long-lived listener prefer
+/// a set-like implementation (e.g. <see cref="HashSet{T}"/>) — with a <see cref="List{T}"/> the
+/// duplicate check is a linear scan that degrades as the collection grows unboundedly.</param>
 /// <param name="options">Tuning options (heartbeat interval, inactivity timeout); defaults are used when <see langword="null"/>.</param>
 /// <param name="loggerFactory">Routes the client's diagnostics into your logging stack; logging is
 /// disabled (a no-op <c>NullLogger</c>) when <see langword="null"/>.</param>

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -43,12 +43,7 @@ public abstract class RustPlusFcmSocket(
 
     /// <summary>Tuning values for this instance — a private snapshot taken at construction, so later
     /// mutation of the caller's (possibly shared) options object cannot affect a live socket.</summary>
-    private readonly RustPlusFcmSocketOptions _options = options is null
-        ? new RustPlusFcmSocketOptions()
-        : new()
-        {
-            HeartbeatInterval = options.HeartbeatInterval, InactivityTimeout = options.InactivityTimeout,
-        };
+    private readonly RustPlusFcmSocketOptions _options = options?.Clone() ?? new RustPlusFcmSocketOptions();
 
     /// <summary>The client's logger; <c>NullLogger</c> when no factory was supplied.
     /// Exposed to derived classes (e.g. <see cref="RustPlusFcm"/>) so they log through the same categorised sink.</summary>

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -786,6 +786,14 @@ public abstract class RustPlusFcmSocket(
 
         var bodyData = JsonSerializer.Deserialize<Body>(body, _parsingOptions);
 
+        if (bodyData is null)
+        {
+            // A JSON-literal null body deserializes to null without throwing; skip it here
+            // instead of deferring a NullReferenceException into downstream event handlers.
+            Logger.LogNullNotificationBody();
+            return;
+        }
+
         var fcmMessage = new FcmMessage
         {
             PersistentId = dataMessage.PersistentId ?? string.Empty,
@@ -795,7 +803,7 @@ public abstract class RustPlusFcmSocket(
             {
                 ChannelId = channelId,
                 ProjectId = Guid.Parse(projectId ?? Guid.Empty.ToString()),
-                Body = bodyData!,
+                Body = bodyData,
                 Title = title ?? string.Empty,
                 Message = message ?? string.Empty,
                 ExperienceId = experienceId ?? string.Empty,

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocketLog.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocketLog.cs
@@ -30,6 +30,9 @@ internal static partial class RustPlusFcmSocketLog
     [LoggerMessage(Level = LogLevel.Warning, Message = "Not a Rust+ notification - missing channelId or body.")]
     public static partial void LogNotRustNotification(this ILogger logger);
 
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Notification body deserialized to null; message skipped.")]
+    public static partial void LogNullNotificationBody(this ILogger logger);
+
     [LoggerMessage(Level = LogLevel.Warning, Message = "Unknown channel: {ChannelId}")]
     public static partial void LogUnknownChannel(this ILogger logger, string channelId);
 

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocketOptions.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocketOptions.cs
@@ -18,4 +18,12 @@ public sealed class RustPlusFcmSocketOptions
     /// <see cref="HeartbeatInterval"/> so a single delayed ack doesn't kill a healthy connection.
     /// Default: 12 minutes.</summary>
     public TimeSpan InactivityTimeout { get; set; } = TimeSpan.FromMinutes(12);
+
+    /// <summary>Creates a copy of this instance — the single place that knows every option, so the
+    /// per-socket snapshot cannot silently miss a newly added property.</summary>
+    internal RustPlusFcmSocketOptions Clone() => new()
+    {
+        HeartbeatInterval = HeartbeatInterval,
+        InactivityTimeout = InactivityTimeout,
+    };
 }

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocketOptions.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocketOptions.cs
@@ -23,7 +23,6 @@ public sealed class RustPlusFcmSocketOptions
     /// per-socket snapshot cannot silently miss a newly added property.</summary>
     internal RustPlusFcmSocketOptions Clone() => new()
     {
-        HeartbeatInterval = HeartbeatInterval,
-        InactivityTimeout = InactivityTimeout,
+        HeartbeatInterval = HeartbeatInterval, InactivityTimeout = InactivityTimeout,
     };
 }

--- a/src/RustPlusApi/Data/Response.cs
+++ b/src/RustPlusApi/Data/Response.cs
@@ -30,4 +30,8 @@ public sealed record ErrorMessage
 {
     /// <summary>Human-readable description of the error returned by the server.</summary>
     public string? Message { get; init; }
+
+    /// <summary>Machine-readable identifier parsed from <see cref="Message"/>;
+    /// <see cref="RustPlusErrorCode.Unknown"/> when the identifier is not recognized.</summary>
+    public RustPlusErrorCode Code { get; init; }
 }

--- a/src/RustPlusApi/Data/RustPlusErrorCode.cs
+++ b/src/RustPlusApi/Data/RustPlusErrorCode.cs
@@ -1,0 +1,50 @@
+namespace RustPlusApi.Data;
+
+/// <summary>
+/// Machine-readable Rust+ server error identifiers, parsed from the raw error string so consumers
+/// can branch on failure type without string comparisons. The raw identifier always remains
+/// available on <see cref="ErrorMessage.Message"/>; unrecognized identifiers map to <see cref="Unknown"/>.
+/// The numeric values are part of the public contract: append new members, never renumber.
+/// </summary>
+public enum RustPlusErrorCode
+{
+    /// <summary>The server returned an identifier this library does not recognize (or none at all);
+    /// inspect <see cref="ErrorMessage.Message"/> for the raw value.</summary>
+    Unknown = 0,
+
+    /// <summary><c>server_error</c> — the server failed to process the request.</summary>
+    ServerError = 1,
+
+    /// <summary><c>banned</c> — the player is banned from the server.</summary>
+    Banned = 2,
+
+    /// <summary><c>rate_limit</c> — the request was throttled; retry later.</summary>
+    RateLimit = 3,
+
+    /// <summary><c>not_found</c> — the requested entity or resource does not exist.</summary>
+    NotFound = 4,
+
+    /// <summary><c>wrong_type</c> — the entity exists but is not of the requested kind.</summary>
+    WrongType = 5,
+
+    /// <summary><c>no_team</c> — the player is not in a team.</summary>
+    NoTeam = 6,
+
+    /// <summary><c>no_clan</c> — the player is not in a clan.</summary>
+    NoClan = 7,
+
+    /// <summary><c>no_map</c> — the server has no map image available.</summary>
+    NoMap = 8,
+
+    /// <summary><c>access_denied</c> — the player token does not grant access to this resource.</summary>
+    AccessDenied = 9,
+
+    /// <summary><c>message_not_sent</c> — the team chat message was rejected.</summary>
+    MessageNotSent = 10,
+
+    /// <summary><c>too_many_subscribers</c> — the entity has reached its subscription limit.</summary>
+    TooManySubscribers = 11,
+
+    /// <summary><c>not_enabled</c> — the requested feature is disabled on this server.</summary>
+    NotEnabled = 12,
+}

--- a/src/RustPlusApi/Interfaces/IRustPlus.cs
+++ b/src/RustPlusApi/Interfaces/IRustPlus.cs
@@ -9,10 +9,13 @@ namespace RustPlusApi.Interfaces;
 /// <summary>High-level Rust+ API contract — typed events and all supported server commands.</summary>
 public interface IRustPlus : IRustPlusSocket
 {
-    /// <summary>Raised when a subscribed smart switch changes state.</summary>
+    /// <summary>Raised when a subscribed smart switch or smart alarm changes state. The Rust+
+    /// protocol does not distinguish the two: an <c>EntityChanged</c> broadcast whose payload
+    /// carries no item capacity is routed here, so alarm state changes also surface through this event.</summary>
     event EventHandler<SmartSwitchEventArg>? OnSmartSwitchTriggered;
 
-    /// <summary>Raised when a subscribed storage monitor reports a change.</summary>
+    /// <summary>Raised when a subscribed storage monitor reports a change
+    /// (an <c>EntityChanged</c> broadcast whose payload carries item capacity).</summary>
     event EventHandler<StorageMonitorEventArg>? OnStorageMonitorTriggered;
 
     /// <summary>Raised when a new team chat message arrives.</summary>

--- a/src/RustPlusApi/Interfaces/IRustPlusSocket.cs
+++ b/src/RustPlusApi/Interfaces/IRustPlusSocket.cs
@@ -12,10 +12,12 @@ public interface IRustPlusSocket : IDisposable, IAsyncDisposable
     /// <summary>Raised when the WebSocket connection is established.</summary>
     event EventHandler? Connected;
 
-    /// <summary>Raised when a request is about to be sent to the server.</summary>
+    /// <summary>Raised when a request is about to be queued for transmission.</summary>
     event EventHandler? SendingRequest;
 
-    /// <summary>Raised after a request has been serialized and sent.</summary>
+    /// <summary>Raised when a request has been queued for transmission. The request is handed to the
+    /// background send loop at this point; the actual WebSocket send happens asynchronously
+    /// shortly after, so this event does not confirm the bytes left the machine.</summary>
     event EventHandler<AppRequest>? RequestSent;
 
     /// <summary>Raised for every inbound <c>AppMessage</c>, before routing.</summary>

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -124,6 +124,7 @@ public class RustPlus(
     /// than <c>response.Response</c>. Unrelated broadcasts stay pure notifications.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the processed result.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the client is not connected.</exception>
     protected async Task<Response<T?>> ProcessRequestAsync<T>(AppRequest request,
         Func<AppMessage, T> successSelector,
         Func<AppBroadcast, bool>? broadcastReplyMatcher = null,
@@ -144,6 +145,7 @@ public class RustPlus(
     /// <param name="request">The request to be processed.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <returns>A <see cref="Task{TResult}"/> whose result is a payload-free <see cref="Response"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the client is not connected.</exception>
     protected async Task<Response> ProcessAckRequestAsync(AppRequest request,
         CancellationToken cancellationToken = default)
     {

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -30,12 +30,16 @@ public class RustPlus(
     : RustPlusSocket(connection, options, loggerFactory), IRustPlus
 {
     /// <summary>
-    /// Occurs when a <see cref="SmartSwitchEventArg"/> is triggered by a smart switch or alarm.
+    /// Occurs when a <see cref="SmartSwitchEventArg"/> is triggered by a smart switch or a smart
+    /// alarm. The Rust+ protocol does not distinguish the two: an <c>EntityChanged</c> broadcast
+    /// whose payload carries no item capacity is routed here, so alarm state changes also surface
+    /// through this event.
     /// </summary>
     public event EventHandler<SmartSwitchEventArg>? OnSmartSwitchTriggered;
 
     /// <summary>
-    /// Occurs when a <see cref="StorageMonitorEventArg"/> is triggered by a storage monitor.
+    /// Occurs when a <see cref="StorageMonitorEventArg"/> is triggered by a storage monitor
+    /// (an <c>EntityChanged</c> broadcast whose payload carries item capacity).
     /// </summary>
     public event EventHandler<StorageMonitorEventArg>? OnStorageMonitorTriggered;
 

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -224,6 +224,19 @@ public abstract class RustPlusSocket(
                 throw;
             }
 
+            // Anything still queued belongs to the previous connection: its waiters were already
+            // failed (or timed out), so replaying it now would fire stale, out-of-context requests
+            // nobody awaits. Sends cannot race this drain — the connected-state guard rejects
+            // callers until the new socket is published below.
+            // Anything still queued belongs to the previous connection: its waiters were already
+            // failed (or timed out), so replaying it now would fire stale, out-of-context requests
+            // nobody awaits. Sends cannot race this drain — the connected-state guard rejects
+            // callers until the new socket is published below.
+            while (_sendChannel.Reader.TryRead(out _))
+            {
+                // Discard the stale backlog item.
+            }
+
             _webSocket = webSocket;
 
             // The background loops outlive the connect call, so they track the instance token only.

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -402,10 +402,11 @@ public abstract class RustPlusSocket(
             }
 
             // Bound the close handshake: a dead peer that never acks must not hang teardown.
-            using var closeTimeout = new CancellationTokenSource(_options.TeardownTimeout);
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, closeTimeout.Token);
             try
             {
+                using var closeTimeout = new CancellationTokenSource(_options.TeardownTimeout);
+                using var linked =
+                    CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, closeTimeout.Token);
                 await _webSocket!.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, linked.Token)
                     .ConfigureAwait(false);
             }
@@ -416,6 +417,11 @@ public abstract class RustPlusSocket(
             catch (WebSocketException)
             {
                 // Peer already gone; nothing to close gracefully.
+            }
+            catch (ObjectDisposedException)
+            {
+                // A concurrent dispose released the instance token source or the socket while this
+                // disconnect was draining its in-flight requests: there is nothing left to close.
             }
 
             Disconnected?.Invoke(this, EventArgs.Empty);

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -210,7 +210,8 @@ public abstract class RustPlusSocket(
             try
             {
                 // Either the caller's token or the instance token can cancel the connect handshake.
-                using var linked = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, cancellationToken);
+                using var linked =
+                    CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, cancellationToken);
                 await webSocket.ConnectAsync(uri, linked.Token).ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -51,13 +51,15 @@ public abstract class RustPlusSocket(
     public event EventHandler? Connected;
 
     /// <summary>
-    /// Occurs when a request is about to be sent to the Rust+ server.
+    /// Occurs when a request is about to be queued for transmission.
     /// </summary>
     /// <seealso cref="SendRequestAsync"/>
     public event EventHandler? SendingRequest;
 
     /// <summary>
-    /// Occurs after a request has been sent to the Rust+ server.
+    /// Occurs when a request has been queued for transmission. The request is handed to the
+    /// background send loop at this point; the actual WebSocket send happens asynchronously
+    /// shortly after, so this event does not confirm the bytes left the machine.
     /// </summary>
     /// <seealso cref="SendRequestAsync"/>
     public event EventHandler<AppRequest>? RequestSent;
@@ -159,7 +161,8 @@ public abstract class RustPlusSocket(
     /// </summary>
     /// <remarks>Connect/disconnect transitions are serialized internally and are not reentrant:
     /// an event handler (e.g. <see cref="Connected"/>) must not call back into
-    /// <see cref="ConnectAsync"/> or <see cref="DisconnectAsync"/> and wait for it, or it will deadlock.</remarks>
+    /// <see cref="ConnectAsync"/> or <see cref="DisconnectAsync"/> and wait for it, or it will deadlock.
+    /// A lifecycle call racing a concurrent dispose may surface <see cref="ObjectDisposedException"/>.</remarks>
     /// <param name="cancellationToken">A token to cancel the connection attempt.</param>
     /// <exception cref="ObjectDisposedException">Thrown when the client has been disposed.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the client is already connected.</exception>
@@ -375,7 +378,8 @@ public abstract class RustPlusSocket(
     /// </summary>
     /// <remarks>Connect/disconnect transitions are serialized internally and are not reentrant:
     /// an event handler (e.g. <see cref="Disconnected"/>) must not call back into
-    /// <see cref="ConnectAsync"/> or <see cref="DisconnectAsync"/> and wait for it, or it will deadlock.</remarks>
+    /// <see cref="ConnectAsync"/> or <see cref="DisconnectAsync"/> and wait for it, or it will deadlock.
+    /// A lifecycle call racing a concurrent dispose may surface <see cref="ObjectDisposedException"/>.</remarks>
     /// <param name="forceClose">When <see langword="true"/>, skips draining in-flight requests.</param>
     public async Task DisconnectAsync(bool forceClose = false)
     {

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -142,6 +142,10 @@ public abstract class RustPlusSocket(
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private CancellationToken CancellationToken => _cancellationTokenSource.Token;
 
+    /// <summary>Serializes connect/disconnect transitions so concurrent lifecycle calls cannot race
+    /// on <see cref="_webSocket"/> (leaking a connection or briefly running two receive loops).</summary>
+    private readonly SemaphoreSlim _lifecycleLock = new(1, 1);
+
     /// <summary>Test seam: the tracked receive loop, so tests can assert it actually completed on teardown.</summary>
     internal Task? ReceiveLoopForTests { get; private set; }
 
@@ -161,10 +165,15 @@ public abstract class RustPlusSocket(
     /// An instance can reconnect: after <see cref="DisconnectAsync"/> (or a dropped connection), calling
     /// this again opens a fresh socket; the previous one is released, never leaked.
     /// </summary>
+    /// <remarks>Connect/disconnect transitions are serialized internally and are not reentrant:
+    /// an event handler (e.g. <see cref="Connected"/>) must not call back into
+    /// <see cref="ConnectAsync"/> or <see cref="DisconnectAsync"/> and wait for it, or it will deadlock.</remarks>
     /// <param name="cancellationToken">A token to cancel the connection attempt.</param>
     /// <exception cref="ObjectDisposedException">Thrown when the client has been disposed.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the client is already connected.</exception>
     /// <exception cref="WebSocketException">Thrown when the WebSocket connect fails (also raised via <see cref="ErrorOccurred"/>).</exception>
+    /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is
+    /// cancelled while waiting for a concurrent lifecycle transition or during the connect handshake.</exception>
     public async Task ConnectAsync(CancellationToken cancellationToken = default)
     {
 #if NET10_0_OR_GREATER
@@ -177,61 +186,78 @@ public abstract class RustPlusSocket(
         }
 #endif
 
-        if (IsConnected)
-        {
-            throw new InvalidOperationException("Already connected. Call DisconnectAsync before reconnecting.");
-        }
-
-        // Reconnect support: release the previous (closed/dead) socket so it is never leaked, and
-        // make sure its receive loop has exited so two loops can never read concurrently.
-        if (_webSocket is not null)
-        {
-            _webSocket.Dispose();
-            _webSocket = null;
-            await WaitForReceiveLoopExitAsync().ConfigureAwait(false);
-        }
-
-        var webSocket = new ClientWebSocket();
-        webSocket.Options.KeepAliveInterval = _options.KeepAliveInterval;
-
-        var uri = connection.UseFacepunchProxy
-            ? new Uri($"wss://companion-rust.facepunch.com/game/{connection.Server}/{connection.Port}")
-            : new Uri($"ws://{connection.Server}:{connection.Port}");
-
-        Connecting?.Invoke(this, EventArgs.Empty);
-
+        await _lifecycleLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            // Either the caller's token or the instance token can cancel the connect handshake.
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, cancellationToken);
-            await webSocket.ConnectAsync(uri, linked.Token).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            // Surface the failure on the event *and* to the caller: awaiting ConnectAsync must never
-            // "succeed" against a server that was never reached.
-            webSocket.Dispose();
-            Logger.LogConnectFailed(ex);
-            ErrorOccurred?.Invoke(this, ex);
-            throw;
-        }
+            if (IsConnected)
+            {
+                throw new InvalidOperationException("Already connected. Call DisconnectAsync before reconnecting.");
+            }
 
-        _webSocket = webSocket;
+            // Reconnect support: release the previous (closed/dead) socket so it is never leaked, and
+            // make sure its receive loop has exited so two loops can never read concurrently.
+            if (_webSocket is not null)
+            {
+                _webSocket.Dispose();
+                _webSocket = null;
+                await WaitForReceiveLoopExitAsync().ConfigureAwait(false);
+            }
 
-        // The background loops outlive the connect call, so they track the instance token only.
-        // The receive loop is bound to its own socket so a stale loop can never read a newer connection.
+            var webSocket = new ClientWebSocket();
+            webSocket.Options.KeepAliveInterval = _options.KeepAliveInterval;
+
+            var uri = connection.UseFacepunchProxy
+                ? new Uri($"wss://companion-rust.facepunch.com/game/{connection.Server}/{connection.Port}")
+                : new Uri($"ws://{connection.Server}:{connection.Port}");
+
+            Connecting?.Invoke(this, EventArgs.Empty);
+
+            try
+            {
+                // Either the caller's token or the instance token can cancel the connect handshake.
+                using var linked = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, cancellationToken);
+                await webSocket.ConnectAsync(uri, linked.Token).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Surface the failure on the event *and* to the caller: awaiting ConnectAsync must never
+                // "succeed" against a server that was never reached.
+                webSocket.Dispose();
+                Logger.LogConnectFailed(ex);
+                ErrorOccurred?.Invoke(this, ex);
+                throw;
+            }
+
+            _webSocket = webSocket;
+
+            // The background loops outlive the connect call, so they track the instance token only.
+            // The receive loop is bound to its own socket so a stale loop can never read a newer connection.
 #pragma warning disable CA2025 // the loop owns this socket's read side by design; teardown/reconnect awaits the loop before disposing it
-        ReceiveLoopForTests = Task.Run(() => ReceiveAsync(webSocket), CancellationToken);
+            ReceiveLoopForTests = Task.Run(() => ReceiveAsync(webSocket), CancellationToken);
 #pragma warning restore CA2025
 
-        // The send loop drains a single channel across reconnects; only start it if it is not running
-        // (first connect, or it exited when a previous connection broke mid-send).
-        if (SendLoopForTests is not { IsCompleted: false })
-        {
-            SendLoopForTests = Task.Run(ProcessSendQueueAsync, CancellationToken);
-        }
+            // The send loop drains a single channel across reconnects; only start it if it is not running
+            // (first connect, or it exited when a previous connection broke mid-send).
+            if (SendLoopForTests is not { IsCompleted: false })
+            {
+                SendLoopForTests = Task.Run(ProcessSendQueueAsync, CancellationToken);
+            }
 
-        Connected?.Invoke(this, EventArgs.Empty);
+            Connected?.Invoke(this, EventArgs.Empty);
+        }
+        finally
+        {
+            try
+            {
+                _lifecycleLock.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+                // A concurrent dispose tore the instance down mid-transition. Disposal is
+                // deliberately not serialized behind this lock — teardown must stay bounded —
+                // so the semaphore can be gone by the time this transition unwinds.
+            }
+        }
     }
 
     /// <summary>
@@ -355,41 +381,61 @@ public abstract class RustPlusSocket(
     /// Asynchronously disconnects from the Rust+ server, waiting for pending responses unless <paramref name="forceClose"/> is true.
     /// Raises <c>Disconnecting</c> before disconnecting and <c>Disconnected</c> after.
     /// </summary>
+    /// <remarks>Connect/disconnect transitions are serialized internally and are not reentrant:
+    /// an event handler (e.g. <see cref="Disconnected"/>) must not call back into
+    /// <see cref="ConnectAsync"/> or <see cref="DisconnectAsync"/> and wait for it, or it will deadlock.</remarks>
     /// <param name="forceClose">When <see langword="true"/>, skips draining in-flight requests.</param>
     public async Task DisconnectAsync(bool forceClose = false)
     {
-        if (!IsConnected)
-        {
-            return;
-        }
-
-        Disconnecting?.Invoke(this, EventArgs.Empty);
-
-        if (!forceClose)
-        {
-            // Drain by awaiting the in-flight requests' completion (bounded), instead of polling a queue
-            // and sleeping a fixed second before closing.
-            await WaitForPendingRequestsAsync().ConfigureAwait(false);
-        }
-
-        // Bound the close handshake: a dead peer that never acks must not hang teardown.
-        using var closeTimeout = new CancellationTokenSource(_options.TeardownTimeout);
-        using var linked = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, closeTimeout.Token);
+        await _lifecycleLock.WaitAsync().ConfigureAwait(false);
         try
         {
-            await _webSocket!.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, linked.Token)
-                .ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            // Bounded close timed out (or the instance token was cancelled): drop the socket regardless.
-        }
-        catch (WebSocketException)
-        {
-            // Peer already gone; nothing to close gracefully.
-        }
+            if (!IsConnected)
+            {
+                return;
+            }
 
-        Disconnected?.Invoke(this, EventArgs.Empty);
+            Disconnecting?.Invoke(this, EventArgs.Empty);
+
+            if (!forceClose)
+            {
+                // Drain by awaiting the in-flight requests' completion (bounded), instead of polling a queue
+                // and sleeping a fixed second before closing.
+                await WaitForPendingRequestsAsync().ConfigureAwait(false);
+            }
+
+            // Bound the close handshake: a dead peer that never acks must not hang teardown.
+            using var closeTimeout = new CancellationTokenSource(_options.TeardownTimeout);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, closeTimeout.Token);
+            try
+            {
+                await _webSocket!.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, linked.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Bounded close timed out (or the instance token was cancelled): drop the socket regardless.
+            }
+            catch (WebSocketException)
+            {
+                // Peer already gone; nothing to close gracefully.
+            }
+
+            Disconnected?.Invoke(this, EventArgs.Empty);
+        }
+        finally
+        {
+            try
+            {
+                _lifecycleLock.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+                // A concurrent dispose tore the instance down mid-transition. Disposal is
+                // deliberately not serialized behind this lock — teardown must stay bounded —
+                // so the semaphore can be gone by the time this transition unwinds.
+            }
+        }
     }
 
     /// <summary>
@@ -423,6 +469,7 @@ public abstract class RustPlusSocket(
         _sendChannel.Writer.TryComplete();
         _webSocket?.Dispose();
         _cancellationTokenSource.Dispose();
+        _lifecycleLock.Dispose();
     }
 
     /// <summary>
@@ -457,6 +504,7 @@ public abstract class RustPlusSocket(
 
         _webSocket?.Dispose();
         _cancellationTokenSource.Dispose();
+        _lifecycleLock.Dispose();
     }
 
     /// <summary>

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -28,15 +28,7 @@ public abstract class RustPlusSocket(
 {
     /// <summary>Tuning values for this instance — a private snapshot taken at construction, so later
     /// mutation of the caller's (possibly shared) options object cannot affect a live socket.</summary>
-    private readonly RustPlusSocketOptions _options = options is null
-        ? new RustPlusSocketOptions()
-        : new()
-        {
-            RequestTimeout = options.RequestTimeout,
-            KeepAliveInterval = options.KeepAliveInterval,
-            TeardownTimeout = options.TeardownTimeout,
-            ReceiveBufferSize = options.ReceiveBufferSize,
-        };
+    private readonly RustPlusSocketOptions _options = options?.Clone() ?? new RustPlusSocketOptions();
 
     /// <summary>The client logger; <c>NullLogger</c> when no factory was supplied. Exposed to derived
     /// classes (e.g. <see cref="RustPlus"/>) so they log through the same categorised sink.</summary>

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -134,6 +134,11 @@ public abstract class RustPlusSocket(
     /// <summary>Test seam: the number of in-flight requests awaiting a seq-bearing response.</summary>
     internal int PendingRequestCountForTests => _pendingRequests.Count;
 
+    /// <summary>Test seam: enqueues a request directly onto the send channel, bypassing
+    /// <see cref="SendRequestAsync"/>'s state checks, to exercise the send loop's fault path.</summary>
+    /// <param name="request">The request to enqueue.</param>
+    internal void EnqueueRequestForTests(AppRequest request) => _sendChannel.Writer.TryWrite(request);
+
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private CancellationToken CancellationToken => _cancellationTokenSource.Token;
 
@@ -573,6 +578,18 @@ public abstract class RustPlusSocket(
         {
             // The socket broke under us (e.g. peer closed): surface it, stop draining, and fail the
             // in-flight requests now — none of them can ever be answered on this connection.
+            Logger.LogSendLoopFaulted(ex);
+            ErrorOccurred?.Invoke(this, ex);
+            FailPendingRequests(ex);
+        }
+        catch (Exception ex)
+        {
+            // A concurrent reconnect can dispose/null _webSocket while this loop is draining
+            // (NullReferenceException / ObjectDisposedException). Left uncaught, the loop dies
+            // invisibly and every pending request waits out its full timeout — surface the fault
+            // and fail them now instead. The receive loop's generic catch backs off and retries,
+            // but exiting is correct here because the faulted socket cannot send anything again —
+            // ConnectAsync restarts a completed send loop on the next connect.
             Logger.LogSendLoopFaulted(ex);
             ErrorOccurred?.Invoke(this, ex);
             FailPendingRequests(ex);

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -278,11 +278,21 @@ public abstract class RustPlusSocket(
     /// broadcasts (other players' messages, other entities) are left to the notification pipeline.</param>
     /// <param name="cancellationToken">A token to cancel waiting for the response.</param>
     /// <returns>A task that represents the asynchronous operation and contains the <see cref="AppMessage"/> response.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the client is not connected.</exception>
     /// <exception cref="TimeoutException">Thrown when no response arrives within the request timeout.</exception>
     public async Task<AppMessage> SendRequestAsync(AppRequest request,
         Func<AppBroadcast, bool>? broadcastReplyMatcher = null,
         CancellationToken cancellationToken = default)
     {
+        if (!IsConnected)
+        {
+            // Queueing here would mean a generic 30s timeout now and a stale, out-of-context
+            // request transmitted on the next reconnect — fail fast instead. The socket can still
+            // die between this check and the actual send — that residual race is owned by the
+            // send loop's fault handler, which fails the pending requests immediately.
+            throw new InvalidOperationException("Not connected. Call ConnectAsync before sending requests.");
+        }
+
         // RunContinuationsAsynchronously keeps the receive loop from running awaiters inline when it resolves the TCS.
         var tcs = new TaskCompletionSource<AppMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/src/RustPlusApi/RustPlusSocketOptions.cs
+++ b/src/RustPlusApi/RustPlusSocketOptions.cs
@@ -22,4 +22,14 @@ public sealed class RustPlusSocketOptions
     /// <summary>The receive buffer size in bytes. Map images arrive as multi-megabyte messages, so
     /// a larger buffer means far fewer reads per message. Default: 64 KB.</summary>
     public int ReceiveBufferSize { get; set; } = 64 * 1024;
+
+    /// <summary>Creates a copy of this instance — the single place that knows every option, so the
+    /// per-socket snapshot cannot silently miss a newly added property.</summary>
+    internal RustPlusSocketOptions Clone() => new()
+    {
+        RequestTimeout = RequestTimeout,
+        KeepAliveInterval = KeepAliveInterval,
+        TeardownTimeout = TeardownTimeout,
+        ReceiveBufferSize = ReceiveBufferSize,
+    };
 }

--- a/src/RustPlusApi/Utils/ResponseHelper.cs
+++ b/src/RustPlusApi/Utils/ResponseHelper.cs
@@ -17,9 +17,7 @@ public static class ResponseHelper
     {
         return new Response<T?>
         {
-            IsSuccess = isSuccess,
-            Error = BuildError(message),
-            Data = data
+            IsSuccess = isSuccess, Error = BuildError(message), Data = data
         };
     }
 
@@ -33,8 +31,7 @@ public static class ResponseHelper
     {
         return new Response
         {
-            IsSuccess = isSuccess,
-            Error = BuildError(message)
+            IsSuccess = isSuccess, Error = BuildError(message)
         };
     }
 
@@ -46,8 +43,7 @@ public static class ResponseHelper
             ? null
             : new ErrorMessage
             {
-                Message = message,
-                Code = ParseErrorCode(message)
+                Message = message, Code = ParseErrorCode(message)
             };
 
     /// <summary>Maps a raw Rust+ server error identifier to its <see cref="RustPlusErrorCode"/>;

--- a/src/RustPlusApi/Utils/ResponseHelper.cs
+++ b/src/RustPlusApi/Utils/ResponseHelper.cs
@@ -18,12 +18,7 @@ public static class ResponseHelper
         return new Response<T?>
         {
             IsSuccess = isSuccess,
-            Error = message is null
-                ? null
-                : new ErrorMessage
-                {
-                    Message = message
-                },
+            Error = BuildError(message),
             Data = data
         };
     }
@@ -39,12 +34,41 @@ public static class ResponseHelper
         return new Response
         {
             IsSuccess = isSuccess,
-            Error = message is null
-                ? null
-                : new ErrorMessage
-                {
-                    Message = message
-                }
+            Error = BuildError(message)
         };
     }
+
+    /// <summary>Builds the <see cref="ErrorMessage"/> for a raw server identifier, or
+    /// <see langword="null"/> when there is no error.</summary>
+    /// <param name="message">The raw server error identifier, or <see langword="null"/>.</param>
+    private static ErrorMessage? BuildError(string? message) =>
+        message is null
+            ? null
+            : new ErrorMessage
+            {
+                Message = message,
+                Code = ParseErrorCode(message)
+            };
+
+    /// <summary>Maps a raw Rust+ server error identifier to its <see cref="RustPlusErrorCode"/>;
+    /// unrecognized identifiers map to <see cref="RustPlusErrorCode.Unknown"/>. The match is
+    /// deliberately exact and case-sensitive — the wire identifiers are stable lowercase strings.
+    /// Keep these arms in sync with the <see cref="RustPlusErrorCode"/> members.</summary>
+    /// <param name="message">The raw server error identifier.</param>
+    private static RustPlusErrorCode ParseErrorCode(string message) => message switch
+    {
+        "server_error" => RustPlusErrorCode.ServerError,
+        "banned" => RustPlusErrorCode.Banned,
+        "rate_limit" => RustPlusErrorCode.RateLimit,
+        "not_found" => RustPlusErrorCode.NotFound,
+        "wrong_type" => RustPlusErrorCode.WrongType,
+        "no_team" => RustPlusErrorCode.NoTeam,
+        "no_clan" => RustPlusErrorCode.NoClan,
+        "no_map" => RustPlusErrorCode.NoMap,
+        "access_denied" => RustPlusErrorCode.AccessDenied,
+        "message_not_sent" => RustPlusErrorCode.MessageNotSent,
+        "too_many_subscribers" => RustPlusErrorCode.TooManySubscribers,
+        "not_enabled" => RustPlusErrorCode.NotEnabled,
+        _ => RustPlusErrorCode.Unknown
+    };
 }

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/AndroidFcmRegisterTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/AndroidFcmRegisterTests.cs
@@ -279,7 +279,10 @@ public class AndroidFcmRegisterTests
         var register = new AndroidFcmRegister(handler.CreateClient());
 
         var token = await register.RegisterFcmAsync(
-            new RustPlusApi.Fcm.Data.Gcm { AndroidId = 42, SecurityToken = 99 },
+            new RustPlusApi.Fcm.Data.Gcm
+            {
+                AndroidId = 42, SecurityToken = 99
+            },
             "fis-auth-token");
 
         Assert.Equal("abc=def==", token);
@@ -294,7 +297,10 @@ public class AndroidFcmRegisterTests
         var register = new AndroidFcmRegister(handler.CreateClient());
 
         var token = await register.RegisterFcmAsync(
-            new RustPlusApi.Fcm.Data.Gcm { AndroidId = 42, SecurityToken = 99 },
+            new RustPlusApi.Fcm.Data.Gcm
+            {
+                AndroidId = 42, SecurityToken = 99
+            },
             "fis-auth-token");
 
         Assert.Equal("AErrorB", token);
@@ -310,10 +316,12 @@ public class AndroidFcmRegisterTests
         var handler = StubHttpMessageHandler.Always(HttpStatusCode.OK, "garbage");
         var register = new AndroidFcmRegister(handler.CreateClient());
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => register.RegisterFcmAsync(
-                new RustPlusApi.Fcm.Data.Gcm { AndroidId = 42, SecurityToken = 99 },
-                "fis-auth-token"));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => register.RegisterFcmAsync(
+            new RustPlusApi.Fcm.Data.Gcm
+            {
+                AndroidId = 42, SecurityToken = 99
+            },
+            "fis-auth-token"));
     }
 
     [Fact]

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/AndroidFcmRegisterTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/AndroidFcmRegisterTests.cs
@@ -271,6 +271,52 @@ public class AndroidFcmRegisterTests
     }
 
     [Fact]
+    public async Task RegisterFcmAsync_TokenContainingEquals_ReturnsFullToken()
+    {
+        // The token is everything after the FIRST '=': a base64-ish token with '=' padding
+        // must not be truncated at its own '='.
+        var handler = StubHttpMessageHandler.Always(HttpStatusCode.OK, "token=abc=def==");
+        var register = new AndroidFcmRegister(handler.CreateClient());
+
+        var token = await register.RegisterFcmAsync(
+            new RustPlusApi.Fcm.Data.Gcm { AndroidId = 42, SecurityToken = 99 },
+            "fis-auth-token");
+
+        Assert.Equal("abc=def==", token);
+    }
+
+    [Fact]
+    public async Task RegisterFcmAsync_TokenContainingErrorSubstring_Succeeds()
+    {
+        // Only the "Error=" key marks a failure; a token that merely contains the substring
+        // "Error" is a valid success response and must not trigger the retry loop.
+        var handler = StubHttpMessageHandler.Always(HttpStatusCode.OK, "token=AErrorB");
+        var register = new AndroidFcmRegister(handler.CreateClient());
+
+        var token = await register.RegisterFcmAsync(
+            new RustPlusApi.Fcm.Data.Gcm { AndroidId = 42, SecurityToken = 99 },
+            "fis-auth-token");
+
+        Assert.Equal("AErrorB", token);
+        Assert.Single(handler.Requests); // success on the first attempt, no spurious retry
+    }
+
+    [Fact]
+    [Trait("Category", "Slow")]
+    public async Task RegisterFcmAsync_ResponseWithoutEquals_RetriesThenThrows()
+    {
+        // A malformed response with no key/value shape used to crash with an index-out-of-range
+        // exception; it must instead be treated like an error response: retried, then surfaced cleanly.
+        var handler = StubHttpMessageHandler.Always(HttpStatusCode.OK, "garbage");
+        var register = new AndroidFcmRegister(handler.CreateClient());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => register.RegisterFcmAsync(
+                new RustPlusApi.Fcm.Data.Gcm { AndroidId = 42, SecurityToken = 99 },
+                "fis-auth-token"));
+    }
+
+    [Fact]
     public void GenerateFirebaseId_ProducesUnpaddedBase64UrlWithLeadingFidNibble()
     {
         var id = AndroidFcmRegister.GenerateFirebaseId();

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/CredentialsStoreFileTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/CredentialsStoreFileTests.cs
@@ -73,4 +73,37 @@ public class CredentialsStoreFileTests
         Assert.False(string.IsNullOrEmpty(ex.Message));
         Assert.Contains("deserialize", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
+
+#if NET10_0_OR_GREATER
+    [Fact]
+    public void Save_OnUnix_RestrictsFileModeToOwner()
+    {
+        // The file holds long-lived push credentials; other local users must not be able to read it.
+        if (OperatingSystem.IsWindows())
+        {
+            return; // Windows has no unix file modes; ACLs are out of scope.
+        }
+
+        var path = Path.Combine(Path.GetTempPath(), $"creds-{Guid.NewGuid():N}.json");
+        try
+        {
+            CredentialsStore.Save(path, new Credentials
+            {
+                Gcm = new Gcm
+                {
+                    AndroidId = 1, SecurityToken = 2
+                }
+            });
+
+            Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(path));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+#endif
 }

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/CredentialsStoreFileTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/CredentialsStoreFileTests.cs
@@ -105,5 +105,41 @@ public class CredentialsStoreFileTests
             }
         }
     }
+
+    [Fact]
+    public void Save_OverExistingWorldReadableFile_TightensFileMode()
+    {
+        // Overwriting keeps the existing inode's mode during the write, so Save must tighten a
+        // pre-existing broader mode afterwards.
+        if (OperatingSystem.IsWindows())
+        {
+            return; // Windows has no unix file modes; ACLs are out of scope.
+        }
+
+        var path = Path.Combine(Path.GetTempPath(), $"creds-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(path, "{}");
+            File.SetUnixFileMode(path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+            CredentialsStore.Save(path, new Credentials
+            {
+                Gcm = new Gcm
+                {
+                    AndroidId = 1, SecurityToken = 2
+                }
+            });
+
+            Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(path));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
 #endif
 }

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
@@ -286,6 +286,27 @@ public class FcmSocketFramingTests
     }
 
     [Fact]
+    public async Task DataMessage_BodyDeserializesToNull_IsSkippedWithoutFaulting()
+    {
+        // A JSON-literal null body deserializes to null without throwing; the message must be
+        // skipped with a log instead of deferring a NullReferenceException into downstream event handlers.
+        await using var socket = NewSocket();
+        string? notification = null;
+        Exception? error = null;
+        socket.NotificationReceived += (_, n) => notification = n;
+        socket.ErrorOccurred += (_, ex) => error = ex;
+
+        var script = Build(
+            FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
+            NextFrame(McsProtoTag.KDataMessageStanzaTag, RustNotification(body: "null")));
+
+        await socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script));
+
+        Assert.Null(notification); // skipped, not dispatched with a null Body
+        Assert.Null(error);        // and skipped cleanly, not via the catch-all
+    }
+
+    [Fact]
     public async Task HeartbeatPing_WritesHeartbeatAckBackToStream()
     {
         await using var socket = NewSocket();

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
@@ -303,7 +303,7 @@ public class FcmSocketFramingTests
         await socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script));
 
         Assert.Null(notification); // skipped, not dispatched with a null Body
-        Assert.Null(error);        // and skipped cleanly, not via the catch-all
+        Assert.Null(error); // and skipped cleanly, not via the catch-all
     }
 
     [Fact]

--- a/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmSocketOptionsTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmSocketOptionsTests.cs
@@ -1,0 +1,28 @@
+using System;
+using Xunit;
+
+namespace RustPlusApi.Fcm.UnitTests;
+
+/// <summary>Clone is the single place that knows every option; this guards it copying all of them.</summary>
+public class RustPlusFcmSocketOptionsTests
+{
+    [Fact]
+    public void Clone_CopiesEveryPublicProperty()
+    {
+        var options = new RustPlusFcmSocketOptions
+        {
+            HeartbeatInterval = TimeSpan.FromMinutes(1),
+            InactivityTimeout = TimeSpan.FromMinutes(2),
+        };
+
+        var clone = options.Clone();
+
+        Assert.NotSame(options, clone);
+        // Reflection sweep: a property added later but forgotten in Clone() fails here as long as
+        // it is also initialised above to a non-default value — extend both together.
+        foreach (var property in typeof(RustPlusFcmSocketOptions).GetProperties())
+        {
+            Assert.Equal(property.GetValue(options), property.GetValue(clone));
+        }
+    }
+}

--- a/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmSocketOptionsTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmSocketOptionsTests.cs
@@ -11,8 +11,7 @@ public class RustPlusFcmSocketOptionsTests
     {
         var options = new RustPlusFcmSocketOptions
         {
-            HeartbeatInterval = TimeSpan.FromMinutes(1),
-            InactivityTimeout = TimeSpan.FromMinutes(2),
+            HeartbeatInterval = TimeSpan.FromMinutes(1), InactivityTimeout = TimeSpan.FromMinutes(2),
         };
 
         var clone = options.Clone();

--- a/tests/RustPlusApi.IntegrationTests/RustPlusClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/RustPlusClientTests.cs
@@ -1,3 +1,4 @@
+using RustPlusApi.Data;
 using RustPlusApi.Data.Events;
 using RustPlusApi.MockServer;
 using Xunit;
@@ -65,6 +66,7 @@ public class RustPlusClientTests
         Assert.False(response.IsSuccess);
         Assert.NotNull(response.Error);
         Assert.Equal("not_found", response.Error!.Message);
+        Assert.Equal(RustPlusErrorCode.NotFound, response.Error.Code);
     }
 
     [Fact]

--- a/tests/RustPlusApi.IntegrationTests/SocketErrorTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketErrorTests.cs
@@ -1,5 +1,6 @@
 using RustPlusApi.MockServer;
 using RustPlusContracts;
+using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using Xunit;
 
@@ -211,5 +212,48 @@ public class SocketErrorTests
             $"Unexpected fault type: {observed.GetType()}");
         // The loop exited through the fault handler instead of dying mid-iteration unobserved.
         await client.SendLoopForTests!.WaitAsync(Timeout);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_AfterSendLoopFault_DoesNotReplayStaleBacklog()
+    {
+        // Requests still queued when the send loop faults have had their waiters failed; replaying
+        // them on a later reconnect would fire stale, out-of-context requests nobody awaits. The
+        // reconnect must drop that backlog before starting the new send loop.
+        var received = new ConcurrentBag<AppRequest>();
+        await using var server = new MockRustPlusServer(req =>
+        {
+            received.Add(req);
+            return MockResponses.Default(req);
+        });
+        server.Start();
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await client.ConnectAsync().WaitAsync(Timeout);
+        await client.DisconnectAsync();
+
+        // Fault the still-running send loop: a send attempt on the closed socket kills it.
+        var errorTcs = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.ErrorOccurred += (_, ex) => errorTcs.TrySetResult(ex);
+        client.EnqueueRequestForTests(new AppRequest
+        {
+            GetTime = new AppEmpty()
+        });
+        await errorTcs.Task.WaitAsync(Timeout);
+        await client.SendLoopForTests!.WaitAsync(Timeout);
+
+        // With the loop dead, this request parks in the channel as stale backlog.
+        client.EnqueueRequestForTests(new AppRequest
+        {
+            GetTime = new AppEmpty()
+        });
+
+        await client.ConnectAsync().WaitAsync(Timeout);
+        var response = await client.GetInfoAsync().WaitAsync(Timeout);
+
+        // The channel is FIFO: had the backlog survived, the server would have seen the stale
+        // GetTime before answering the GetInfo round-trip above.
+        Assert.True(response.IsSuccess);
+        Assert.DoesNotContain(received, static r => r.GetTime is not null);
     }
 }

--- a/tests/RustPlusApi.IntegrationTests/SocketErrorTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketErrorTests.cs
@@ -11,6 +11,8 @@ namespace RustPlusApi.IntegrationTests;
 /// </summary>
 public class SocketErrorTests
 {
+    private const ulong PlayerId = 76561198000000000;
+    private const int PlayerToken = 123456789;
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
 
     [Fact]
@@ -130,5 +132,39 @@ public class SocketErrorTests
         var ex = await error.Task.WaitAsync(Timeout);
         Assert.NotNull(ex);
         Assert.False(client.IsConnected);
+    }
+
+    [Fact]
+    public async Task SendLoop_NonWebSocketFault_RaisesErrorOccurredAndExits()
+    {
+        // A failed reconnect leaves _webSocket null while the send loop (started by the first
+        // connect) is still draining the channel. A request entering the channel in that window
+        // must surface on ErrorOccurred and exit the loop cleanly — not kill it silently.
+        var server = new MockRustPlusServer(MockResponses.Default);
+        server.Start();
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+
+        await client.ConnectAsync().WaitAsync(Timeout);
+        await client.DisconnectAsync();
+        await server.DisposeAsync(); // free the endpoint so the reconnect below is refused
+
+        // The reconnect disposes/nulls the old socket, then fails; the send loop stays alive.
+        await Assert.ThrowsAnyAsync<Exception>(() => client.ConnectAsync().WaitAsync(Timeout));
+
+        // Subscribe only now, so the connect failure above cannot satisfy the assertion.
+        var errorTcs = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.ErrorOccurred += (_, ex) => errorTcs.TrySetResult(ex);
+
+        client.EnqueueRequestForTests(new AppRequest
+        {
+            GetInfo = new AppEmpty()
+        });
+
+        var observed = await errorTcs.Task.WaitAsync(Timeout);
+        Assert.True(observed is NullReferenceException or ObjectDisposedException,
+            $"Unexpected fault type: {observed.GetType()}");
+        // The loop exited through the fault handler instead of dying mid-iteration unobserved.
+        await client.SendLoopForTests!.WaitAsync(Timeout);
     }
 }

--- a/tests/RustPlusApi.IntegrationTests/SocketErrorTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketErrorTests.cs
@@ -135,6 +135,51 @@ public class SocketErrorTests
     }
 
     [Fact]
+    public async Task SendRequestAsync_NeverConnected_ThrowsInvalidOperationException()
+    {
+        // Fail fast with a clear error instead of queueing into a 30s TimeoutException
+        // (and instead of transmitting the stale request on a later reconnect).
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, 1, PlayerId, PlayerToken));
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetInfoAsync());
+        Assert.Contains("Not connected", thrown.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SendRequestAsync_AfterDisconnect_ThrowsInvalidOperationException()
+    {
+        await using var server = new MockRustPlusServer(MockResponses.Default);
+        server.Start();
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await client.ConnectAsync().WaitAsync(Timeout);
+        await client.DisconnectAsync();
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetInfoAsync());
+        Assert.Contains("Not connected", thrown.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SendRequestAsync_AfterFailedReconnect_ThrowsInvalidOperationException()
+    {
+        // After a failed reconnect the socket reference is gone but the client is not disposed:
+        // the guard must treat this exactly like never-connected instead of queueing.
+        var server = new MockRustPlusServer(MockResponses.Default);
+        server.Start();
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await client.ConnectAsync().WaitAsync(Timeout);
+        await client.DisconnectAsync();
+        await server.DisposeAsync(); // free the endpoint so the reconnect below is refused
+
+        await Assert.ThrowsAnyAsync<Exception>(() => client.ConnectAsync().WaitAsync(Timeout));
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetInfoAsync());
+        Assert.Contains("Not connected", thrown.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task SendLoop_NonWebSocketFault_RaisesErrorOccurredAndExits()
     {
         // A failed reconnect leaves _webSocket null while the send loop (started by the first

--- a/tests/RustPlusApi.IntegrationTests/SocketLifecycleTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketLifecycleTests.cs
@@ -289,4 +289,68 @@ public class SocketLifecycleTests
         Assert.Equal(PlayerId, observedId);
         Assert.Equal(PlayerToken, observedToken);
     }
+
+    [Fact]
+    public async Task ConnectAsync_ConcurrentCalls_ExactlyOneSucceeds()
+    {
+        // Lifecycle transitions are serialized: of two racing connects, one wins and the other
+        // observes the connected state and throws — neither leaks a socket nor starts a second
+        // receive loop.
+        await using var server = new MockRustPlusServer(MockResponses.Default);
+        server.Start();
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+
+        var outcomes = await Task.WhenAll(
+            ObserveAsync(client.ConnectAsync()),
+            ObserveAsync(client.ConnectAsync()));
+
+        Assert.True(client.IsConnected);
+        Assert.Equal(1, outcomes.Count(static e => e is null));
+        Assert.Equal(1, outcomes.Count(static e => e is InvalidOperationException));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_RacingParkedDisconnect_NeitherThrows()
+    {
+        // A graceful disconnect parks inside the pending-request drain while holding the
+        // lifecycle lock; a concurrent dispose must neither deadlock nor cause the lock-release
+        // in the disconnect path to throw when the semaphore has already been torn down.
+        // The server never replies, so its responder always returns null.
+        await using var server = new MockRustPlusServer(_ => null);
+        server.Start();
+        var client = new RustPlus(
+            new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken),
+            new RustPlusSocketOptions
+            {
+                TeardownTimeout = TimeSpan.FromMilliseconds(500)
+            });
+        await client.ConnectAsync().WaitAsync(Timeout);
+
+        // A request the server never answers keeps the disconnect drain parked.
+        var pending = client.GetInfoAsync();
+
+        var disconnectTask = client.DisconnectAsync();
+        await client.DisposeAsync().AsTask().WaitAsync(Timeout);
+
+        await disconnectTask.WaitAsync(Timeout); // must complete without throwing
+
+        // The orphaned request fails via cancellation/teardown; observe it so nothing is unobserved.
+        await Assert.ThrowsAnyAsync<Exception>(() => pending.WaitAsync(Timeout));
+    }
+
+    /// <summary>Awaits <paramref name="task"/> and returns its exception instead of throwing.</summary>
+    /// <param name="task">The task whose outcome to observe.</param>
+    private static async Task<Exception?> ObserveAsync(Task task)
+    {
+        try
+        {
+            await task;
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+    }
 }

--- a/tests/RustPlusApi.UnitTests/ErrorCodeTests.cs
+++ b/tests/RustPlusApi.UnitTests/ErrorCodeTests.cs
@@ -1,0 +1,48 @@
+using RustPlusApi.Data;
+using RustPlusApi.Utils;
+using Xunit;
+
+namespace RustPlusApi.UnitTests;
+
+/// <summary>The raw server error identifier is surfaced as a machine-readable
+/// <see cref="RustPlusErrorCode"/> alongside the untouched <see cref="ErrorMessage.Message"/>.</summary>
+public class ErrorCodeTests
+{
+    [Theory]
+    [InlineData("server_error", RustPlusErrorCode.ServerError)]
+    [InlineData("banned", RustPlusErrorCode.Banned)]
+    [InlineData("rate_limit", RustPlusErrorCode.RateLimit)]
+    [InlineData("not_found", RustPlusErrorCode.NotFound)]
+    [InlineData("wrong_type", RustPlusErrorCode.WrongType)]
+    [InlineData("no_team", RustPlusErrorCode.NoTeam)]
+    [InlineData("no_clan", RustPlusErrorCode.NoClan)]
+    [InlineData("no_map", RustPlusErrorCode.NoMap)]
+    [InlineData("access_denied", RustPlusErrorCode.AccessDenied)]
+    [InlineData("message_not_sent", RustPlusErrorCode.MessageNotSent)]
+    [InlineData("too_many_subscribers", RustPlusErrorCode.TooManySubscribers)]
+    [InlineData("not_enabled", RustPlusErrorCode.NotEnabled)]
+    [InlineData("unknown-error", RustPlusErrorCode.Unknown)]
+    [InlineData("some_future_identifier", RustPlusErrorCode.Unknown)]
+    public void BuildAckOutput_MapsServerIdentifierToCode(string identifier, RustPlusErrorCode expected)
+    {
+        var response = ResponseHelper.BuildAckOutput(false, identifier);
+
+        Assert.NotNull(response.Error);
+        Assert.Equal(expected, response.Error!.Code);
+        Assert.Equal(identifier, response.Error.Message); // the raw string stays available
+    }
+
+    [Fact]
+    public void BuildGenericOutput_MapsServerIdentifierToCode()
+    {
+        var response = ResponseHelper.BuildGenericOutput<string>(false, default!, "not_found");
+
+        Assert.Equal(RustPlusErrorCode.NotFound, response.Error!.Code);
+    }
+
+    [Fact]
+    public void BuildAckOutput_Success_HasNoError()
+    {
+        Assert.Null(ResponseHelper.BuildAckOutput(true).Error);
+    }
+}

--- a/tests/RustPlusApi.UnitTests/RustPlusSocketOptionsTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusSocketOptionsTests.cs
@@ -1,0 +1,30 @@
+using System;
+using Xunit;
+
+namespace RustPlusApi.UnitTests;
+
+/// <summary>Clone is the single place that knows every option; this guards it copying all of them.</summary>
+public class RustPlusSocketOptionsTests
+{
+    [Fact]
+    public void Clone_CopiesEveryPublicProperty()
+    {
+        var options = new RustPlusSocketOptions
+        {
+            RequestTimeout = TimeSpan.FromSeconds(1),
+            KeepAliveInterval = TimeSpan.FromSeconds(2),
+            TeardownTimeout = TimeSpan.FromSeconds(3),
+            ReceiveBufferSize = 1234,
+        };
+
+        var clone = options.Clone();
+
+        Assert.NotSame(options, clone);
+        // Reflection sweep: a property added later but forgotten in Clone() fails here as long as
+        // it is also initialised above to a non-default value — extend both together.
+        foreach (var property in typeof(RustPlusSocketOptions).GetProperties())
+        {
+            Assert.Equal(property.GetValue(options), property.GetValue(clone));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Resolves the open findings from the 2026-06-11 engineering review (M1–M3, M5–M6, L1–L8). M4 was already fixed by #64; L9 (camera variable renaming) stays deferred until a golden-frame capture lands in the repo.

### Medium severity
- **M1** — the send loop now catches unexpected faults (reconnect-window `NullReferenceException`/`ObjectDisposedException`), raising `ErrorOccurred` and failing pending requests instead of dying silently
- **M2** — sending while disconnected throws `InvalidOperationException` immediately instead of queueing into a 30 s timeout and replaying the stale request on the next reconnect
- **M3** — connect/disconnect transitions are serialized by a lifecycle `SemaphoreSlim`; non-reentrancy documented; dispose-race covered by a regression test
- **M5** — FCM register-token parsing cuts at the first `=` and prefix-matches `Error=`, so tokens containing `=` padding or the substring "Error" are no longer mangled
- **M6** — new `RustPlusErrorCode` enum + `ErrorMessage.Code` for programmatic error branching (additive, binary-compatible; raw `Message` unchanged)

### Low severity
- **L1** — options snapshots single-sourced via `Clone()` on both options classes
- **L4** — `_lastTraffic` stored as ticks behind `Volatile` (tear-free on 32-bit ns2.0 hosts)
- **L6** — FCM messages whose body deserializes to JSON `null` are skipped with a log instead of deferring an NRE into event handlers
- **L7** — cancelling `SteamLoginService.LoginAsync` now unblocks the `HttpListener` wait immediately
- **L8** — `CredentialsStore.Save` restricts the file to owner read/write on .NET 10+/Unix; docs flag the file as credential-sensitive
- **L2/L3/L5** — doc accuracy: `RequestSent` fires on enqueue; switch-vs-alarm routing heuristic documented on the public events; `HashSet<string>` recommended for `persistentIds`

### Public API delta
- New: `RustPlusApi.Data.RustPlusErrorCode` (append-only numeric contract), `ErrorMessage.Code`
- Behavior: send-while-disconnected now throws `InvalidOperationException` (documented via `<exception>` tags) instead of timing out
- No removals, renames, or signature changes

### Follow-up (out of scope)
- `_streamIdIn` in `RustPlusFcmSocket` is read cross-thread by the heartbeat loop without a barrier (staleness, not tearing) — candidate for the same `Volatile`/`Interlocked` treatment as L4

## Test plan
- [x] Full solution builds with 0 warnings (`TreatWarningsAsErrors`, latest-all analyzers, Sonar)
- [x] 757 test executions pass across all 7 test projects on net8.0 and net10.0 (28 new tests, incl. race regressions: concurrent connect, dispose-racing-disconnect, send-loop fault surfacing)
- [x] Merged coverage 97.18% line / 93.32% branch (gate: 95/90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)