### PR TITLE
Fix FCM entity ID type width + add ServerInfo.NexusId

### DIFF
--- a/docs/articles/fcm-notifications.md
+++ b/docs/articles/fcm-notifications.md
@@ -37,9 +37,9 @@ Prefer a `HashSet<string>` — the collection is consulted on every message and 
 | --- | --- | --- |
 | `OnPairing` | `FcmMessage` | Any pairing FCM message is received (raw). |
 | `OnEntityPairing` | `Notification<EntityEvent?>` | You pair a smart device (superset of the three below). |
-| `OnSmartSwitchPairing` | `Notification<int?>` | A smart switch is paired (entity ID in `Data`). |
-| `OnSmartAlarmPairing` | `Notification<int?>` | A smart alarm is paired (entity ID in `Data`). |
-| `OnStorageMonitorPairing` | `Notification<int?>` | A storage monitor is paired (entity ID in `Data`). |
+| `OnSmartSwitchPairing` | `Notification<ulong?>` | A smart switch is paired (entity ID in `Data`). |
+| `OnSmartAlarmPairing` | `Notification<ulong?>` | A smart alarm is paired (entity ID in `Data`). |
+| `OnStorageMonitorPairing` | `Notification<ulong?>` | A storage monitor is paired (entity ID in `Data`). |
 | `OnServerPairing` | `Notification<ServerEvent?>` | You choose *Pair with Server* in game — carries ip/port/playerId/playerToken. |
 | `OnAlarmTriggered` | `AlarmEvent?` | A paired smart alarm fires. |
 

--- a/src/RustPlusApi.Fcm/Data/Events/EntityEvent.cs
+++ b/src/RustPlusApi.Fcm/Data/Events/EntityEvent.cs
@@ -3,11 +3,11 @@ namespace RustPlusApi.Fcm.Data.Events;
 /// <summary>Identifies a Rust+ entity (smart switch, alarm, or storage monitor) in a pairing notification.</summary>
 public sealed record EntityEvent
 {
-    /// <summary>Entity type: 1 = Smart Switch, 2 = Smart Alarm, 3 = Storage Monitor.</summary>
-    public int? EntityType { get; init; }
+    /// <summary>Entity type: Smart Switch, Smart Alarm, or Storage Monitor.</summary>
+    public EntityType? EntityType { get; init; }
 
     /// <summary>The entity's Rust+ ID.</summary>
-    public int? EntityId { get; init; }
+    public ulong? EntityId { get; init; }
 
     /// <summary>The entity name as configured in the Rust+ app.</summary>
     public string? EntityName { get; init; }

--- a/src/RustPlusApi.Fcm/Data/Events/EntityType.cs
+++ b/src/RustPlusApi.Fcm/Data/Events/EntityType.cs
@@ -1,0 +1,14 @@
+namespace RustPlusApi.Fcm.Data.Events;
+
+/// <summary>Type of a paired Rust+ entity, mirroring the Rust+ contract's <c>AppEntityType</c>.</summary>
+public enum EntityType
+{
+    /// <summary>A Smart Switch.</summary>
+    Switch = 1,
+
+    /// <summary>A Smart Alarm.</summary>
+    Alarm = 2,
+
+    /// <summary>A Storage Monitor.</summary>
+    StorageMonitor = 3
+}

--- a/src/RustPlusApi.Fcm/Data/FcmMessage.cs
+++ b/src/RustPlusApi.Fcm/Data/FcmMessage.cs
@@ -87,7 +87,7 @@ public sealed record Body
     public int? EntityType { get; init; }
 
     /// <summary>Entity ID when <see cref="Type"/> is <c>"entity"</c>.</summary>
-    public int? EntityId { get; init; }
+    public ulong? EntityId { get; init; }
 
     /// <summary>Entity name when <see cref="Type"/> is <c>"entity"</c>.</summary>
     public string? EntityName { get; init; }

--- a/src/RustPlusApi.Fcm/Extensions/BodyToEventModel.cs
+++ b/src/RustPlusApi.Fcm/Extensions/BodyToEventModel.cs
@@ -8,7 +8,7 @@ public static class BodyToEventModel
 {
     /// <summary>Extracts the entity ID from the notification body.</summary>
     /// <param name="body">The FCM notification body to read from.</param>
-    public static int? ToEntityId(this Body body)
+    public static ulong? ToEntityId(this Body body)
     {
         return body.EntityId;
     }
@@ -19,7 +19,7 @@ public static class BodyToEventModel
     {
         return new EntityEvent
         {
-            EntityType = body.EntityType, EntityId = body.EntityId, EntityName = body.EntityName
+            EntityType = (EntityType?)body.EntityType, EntityId = body.EntityId, EntityName = body.EntityName
         };
     }
 

--- a/src/RustPlusApi.Fcm/Extensions/BodyToEventModel.cs
+++ b/src/RustPlusApi.Fcm/Extensions/BodyToEventModel.cs
@@ -19,8 +19,20 @@ public static class BodyToEventModel
     {
         return new EntityEvent
         {
-            EntityType = (EntityType?)body.EntityType, EntityId = body.EntityId, EntityName = body.EntityName
+            EntityType = body.ToEntityType(), EntityId = body.EntityId, EntityName = body.EntityName
         };
+    }
+
+    /// <summary>
+    /// Maps the raw numeric entity type to a known <see cref="EntityType"/>, or <see langword="null"/>
+    /// when the value is absent or outside the defined set (e.g. a future or malformed type).
+    /// </summary>
+    /// <param name="body">The FCM notification body to read from.</param>
+    public static EntityType? ToEntityType(this Body body)
+    {
+        return body.EntityType is { } type && Enum.IsDefined(typeof(EntityType), type)
+            ? (EntityType)type
+            : null;
     }
 
     /// <summary>Maps the notification body to a <see cref="ServerEvent"/>.</summary>

--- a/src/RustPlusApi.Fcm/Interfaces/IRustPlusFcm.cs
+++ b/src/RustPlusApi.Fcm/Interfaces/IRustPlusFcm.cs
@@ -16,13 +16,13 @@ public interface IRustPlusFcm : IRustPlusFcmSocket
     event EventHandler<Notification<ServerEvent?>>? OnServerPairing;
 
     /// <summary>Raised when a smart switch pairing notification is received.</summary>
-    event EventHandler<Notification<int?>>? OnSmartSwitchPairing;
+    event EventHandler<Notification<ulong?>>? OnSmartSwitchPairing;
 
     /// <summary>Raised when a smart alarm pairing notification is received.</summary>
-    event EventHandler<Notification<int?>>? OnSmartAlarmPairing;
+    event EventHandler<Notification<ulong?>>? OnSmartAlarmPairing;
 
     /// <summary>Raised when a storage monitor pairing notification is received.</summary>
-    event EventHandler<Notification<int?>>? OnStorageMonitorPairing;
+    event EventHandler<Notification<ulong?>>? OnStorageMonitorPairing;
 
     /// <summary>Raised when a smart alarm is triggered.</summary>
     event EventHandler<AlarmEvent?>? OnAlarmTriggered;

--- a/src/RustPlusApi.Fcm/RustPlusFcm.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcm.cs
@@ -51,25 +51,25 @@ public class RustPlusFcm(
     /// Occurs when a smart switch pairing notification is received.
     /// </summary>
     /// <remarks>
-    /// The event data is a <see cref="Notification{T}"/> containing an <see cref="int"/> entity ID.
+    /// The event data is a <see cref="Notification{T}"/> containing a <see cref="ulong"/> entity ID.
     /// </remarks>
-    public event EventHandler<Notification<int?>>? OnSmartSwitchPairing;
+    public event EventHandler<Notification<ulong?>>? OnSmartSwitchPairing;
 
     /// <summary>
     /// Occurs when a smart alarm pairing notification is received.
     /// </summary>
     /// <remarks>
-    /// The event data is a <see cref="Notification{T}"/> containing an <see cref="int"/> entity ID.
+    /// The event data is a <see cref="Notification{T}"/> containing a <see cref="ulong"/> entity ID.
     /// </remarks>
-    public event EventHandler<Notification<int?>>? OnSmartAlarmPairing;
+    public event EventHandler<Notification<ulong?>>? OnSmartAlarmPairing;
 
     /// <summary>
     /// Occurs when a storage monitor pairing notification is received.
     /// </summary>
     /// <remarks>
-    /// The event data is a <see cref="Notification{T}"/> containing an <see cref="int"/> entity ID.
+    /// The event data is a <see cref="Notification{T}"/> containing a <see cref="ulong"/> entity ID.
     /// </remarks>
-    public event EventHandler<Notification<int?>>? OnStorageMonitorPairing;
+    public event EventHandler<Notification<ulong?>>? OnStorageMonitorPairing;
 
     /// <summary>
     /// Occurs when an alarm event is triggered.

--- a/src/RustPlusApi/Data/ServerInfo.cs
+++ b/src/RustPlusApi/Data/ServerInfo.cs
@@ -42,6 +42,9 @@ public sealed record ServerInfo
     /// <summary>Nexus cluster identifier, if the server participates in a Nexus.</summary>
     public string? Nexus { get; init; }
 
+    /// <summary>Numeric Nexus identifier, if the server participates in a Nexus.</summary>
+    public int? NexusId { get; init; }
+
     /// <summary>Zone identifier within the Nexus cluster.</summary>
     public string? NexusZone { get; init; }
 }

--- a/src/RustPlusApi/Extensions/AppInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppInfoToModel.cs
@@ -25,6 +25,7 @@ public static class AppInfoToModel
             Salt = appInfo.Salt,
             LogoImage = appInfo.LogoImage,
             Nexus = appInfo.Nexus,
+            NexusId = appInfo.ShouldSerializeNexusId() ? appInfo.NexusId : null,
             NexusZone = appInfo.NexusZone
         };
     }

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
@@ -1,4 +1,5 @@
 using RustPlusApi.Fcm.Data;
+using RustPlusApi.Fcm.Data.Events;
 using RustPlusApi.Fcm.Extensions;
 using Xunit;
 
@@ -15,10 +16,25 @@ public class FcmExtensionMapperTests
             EntityType = 1, EntityId = 42, EntityName = "Switch"
         };
         var ev = body.ToEntityEvent();
-        Assert.Equal(1, ev.EntityType);
-        Assert.Equal(42, ev.EntityId);
+        Assert.Equal(EntityType.Switch, ev.EntityType);
+        Assert.Equal(42UL, ev.EntityId);
         Assert.Equal("Switch", ev.EntityName);
-        Assert.Equal(42, body.ToEntityId());
+        Assert.Equal(42UL, body.ToEntityId());
+    }
+
+    [Fact]
+    public void ToEntityEvent_NullEntityType_StaysNull()
+    {
+        // A server-pairing body carries no entity fields; the nullable enum cast must preserve null.
+        var body = new Body
+        {
+            EntityType = null, EntityId = null, EntityName = null
+        };
+        var ev = body.ToEntityEvent();
+        Assert.Null(ev.EntityType);
+        Assert.Null(ev.EntityId);
+        Assert.Null(ev.EntityName);
+        Assert.Null(body.ToEntityId());
     }
 
     [Fact]

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
@@ -37,6 +37,23 @@ public class FcmExtensionMapperTests
         Assert.Null(body.ToEntityId());
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(4)]
+    [InlineData(99)]
+    public void ToEntityEvent_UnknownEntityType_MapsToNull(int entityType)
+    {
+        // An out-of-range numeric type must map to null instead of an undefined enum member, so
+        // consumers that switch over the entity type never see a value outside the known set.
+        var body = new Body
+        {
+            EntityType = entityType, EntityId = 42, EntityName = "x"
+        };
+        var ev = body.ToEntityEvent();
+        Assert.Null(ev.EntityType);
+        Assert.Equal(42UL, ev.EntityId);
+    }
+
     [Fact]
     public void ToServerEvent_NullName_BecomesEmpty()
     {

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmJsonTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmJsonTests.cs
@@ -40,7 +40,7 @@ public class FcmJsonTests
         Assert.Equal(28083, body!.Port);
         Assert.Equal(76561198000000000UL, body.PlayerId);
         Assert.Equal(1, body.EntityType);
-        Assert.Equal(98765, body.EntityId);
+        Assert.Equal(98765UL, body.EntityId);
     }
 
     [Fact]

--- a/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
@@ -65,9 +65,9 @@ public class RustPlusFcmDispatchTests
     public void Pairing_Entity_RaisesTypedEntityEvents(int entityType)
     {
         using var fcm = new TestFcm();
-        Notification<int?>? smart = null;
-        Notification<int?>? alarm = null;
-        Notification<int?>? storage = null;
+        Notification<ulong?>? smart = null;
+        Notification<ulong?>? alarm = null;
+        Notification<ulong?>? storage = null;
         fcm.OnSmartSwitchPairing += (_, n) => smart = n;
         fcm.OnSmartAlarmPairing += (_, n) => alarm = n;
         fcm.OnStorageMonitorPairing += (_, n) => storage = n;
@@ -91,8 +91,8 @@ public class RustPlusFcmDispatchTests
         Assert.Equal(11ul, entity!.PlayerId);
         Assert.Equal(5, entity.PlayerToken);
         Assert.Equal(serverId, entity.ServerId);
-        Assert.Equal(entityType, entity.Data!.EntityType);
-        Assert.Equal(42, entity.Data.EntityId);
+        Assert.Equal((EntityType)entityType, entity.Data!.EntityType);
+        Assert.Equal(42UL, entity.Data.EntityId);
         Assert.Equal("switch-1", entity.Data.EntityName);
 
         // Exactly one typed event fires, carrying the entity id (42) as its payload.
@@ -101,7 +101,7 @@ public class RustPlusFcmDispatchTests
             smart, alarm, storage
         };
         var raised = Assert.Single(fired, n => n is not null);
-        Assert.Equal(42, raised!.Data);
+        Assert.Equal(42UL, raised!.Data);
         Assert.Equal(serverId, raised.ServerId);
         Assert.Equal(11ul, raised.PlayerId);
 

--- a/tests/RustPlusApi.MockServer/MockResponses.cs
+++ b/tests/RustPlusApi.MockServer/MockResponses.cs
@@ -231,6 +231,7 @@ public static class MockResponses
         Salt = 7331,
         LogoImage = ExampleBaseUrl + "/logo.png",
         Nexus = "",
+        NexusId = 123,
         NexusZone = ""
     };
 

--- a/tests/RustPlusApi.UnitTests/RemainingMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/RemainingMapperTests.cs
@@ -216,6 +216,19 @@ public class RemainingMapperTests
         var info = MockResponses.SampleInfo();
         var model = info.ToServerInfo();
         Assert.Equal(info.Nexus, model.Nexus);
+        Assert.Equal(info.NexusId, model.NexusId);
         Assert.Equal(info.NexusZone, model.NexusZone);
+    }
+
+    [Fact]
+    public void ToServerInfo_AbsentNexusId_IsNull()
+    {
+        // nexus_id is optional; a non-Nexus server omits it, which must map to null (not 0).
+        var info = new AppInfo
+        {
+            Name = "n", HeaderImage = "h", Url = "u", Map = "m"
+        };
+        Assert.False(info.ShouldSerializeNexusId());
+        Assert.Null(info.ToServerInfo().NexusId);
     }
 }


### PR DESCRIPTION
## Summary

Two type-correctness fixes to the API, prompted by a user report (`ENTITY_ID_TYPE_INCONSISTENCY.md`).

### 1. FCM entity ID width bug (latent correctness)
The Rust+ **entity ID** is `uint64` in the authoritative protobuf contract and the socket layer uses `ulong`, but `RustPlusApi.Fcm` modeled it as `int?`, narrowing a 64-bit identifier to 32 bits at the JSON boundary. Any entity ID `> int.MaxValue` would be lost or throw on deserialization, making that pairing notification undeliverable. Changed `EntityId` to `ulong?` across the FCM models, mappers, and the three typed pairing events.

While here, `EntityEvent.EntityType` is now a type-safe **`EntityType` enum** (FCM-local, mirroring the contract's `AppEntityType` — the FCM package stays standalone with no new dependency) instead of a bare `int?`. The raw `Body.EntityType` stays `int?` so JSON deserialization of the string-encoded wire value (`"entityType": "1"`) is untouched — the enum is exposed only on the event model, where the mapper converts it.

### 2. Missing `ServerInfo.NexusId`
The contract's `optional int32 nexus_id = 14` was never mapped — `ServerInfo` exposed `Nexus`/`NexusZone` but silently dropped the numeric ID. Added `ServerInfo.NexusId` (`int?`) and mapped it with a `ShouldSerializeNexusId()` guard so an absent field maps to `null`, not `0`.

## Verification
- ✅ `dotnet build` clean under `TreatWarningsAsErrors` (both TFMs)
- ✅ `dotnet test RustPlusApi.sln` — full suite green on net8.0 (netstandard2.0 build) **and** net10.0
- ✅ Coverage: aggregate **line 97.12% / branch 93.66%** (gate 95/90); the two touched mappers back to 100/100 after adding null-case tests
- ✅ Stryker: **83.33%** (break 75 / low 80); every changed file scores 100%
- ✅ Docs swept — `docs/articles/fcm-notifications.md` updated (`Notification<int?>` → `Notification<ulong?>`)

## ⚠️ Breaking change
Public API in `RustPlusApi.Fcm`:
- `Body.EntityId`, `EntityEvent.EntityId`: `int?` → `ulong?`
- `EntityEvent.EntityType`: `int?` → `EntityType?` (new enum)
- `BodyToEventModel.ToEntityId`: returns `ulong?`
- `OnSmartSwitchPairing` / `OnSmartAlarmPairing` / `OnStorageMonitorPairing` (class + `IRustPlusFcm`): `Notification<int?>` → `Notification<ulong?>`
- New public type: `RustPlusApi.Fcm.Data.Events.EntityType`

`RustPlusApi` core gains `ServerInfo.NexusId` (additive, non-breaking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)