### PR TITLE
Expose alarm server id + rename OnSmartSwitchTriggered to OnSmartDeviceTriggered

### DIFF
--- a/docs/articles/rustplus-client.md
+++ b/docs/articles/rustplus-client.md
@@ -150,7 +150,7 @@ The complete set of public events across `RustPlusSocket` and `RustPlus`:
 | `Disconnecting` | `EventArgs` | `DisconnectAsync` started the close handshake. |
 | `Disconnected` | `EventArgs` | The WebSocket close completed. |
 | `ErrorOccurred` | `Exception` | A transport or receive error occurred. Fires from Connecting or Connected state. |
-| `OnSmartSwitchTriggered` | `SmartSwitchEventArg` | A subscribed smart switch or alarm changed state. |
+| `OnSmartDeviceTriggered` | `SmartSwitchEventArg` | A subscribed binary-state device changed state. The broadcast omits the entity type, so a smart switch and a smart alarm are indistinguishable here — query the entity to learn its type. |
 | `OnStorageMonitorTriggered` | `StorageMonitorEventArg` | A subscribed storage monitor reported a change. |
 | `OnTeamChatReceived` | `TeamMessageEventArg` | A team chat message arrived. |
 | `OnClanChatReceived` | `ClanMessageEventArg` | A clan chat message arrived. |
@@ -158,7 +158,7 @@ The complete set of public events across `RustPlusSocket` and `RustPlus`:
 | `OnCameraRaysReceived` | `CameraRaysEventArg` | A camera frame broadcast arrived for the subscribed camera. |
 
 > [!NOTE]
-> To receive `OnSmartSwitchTriggered` or `OnStorageMonitorTriggered` broadcasts for a given
+> To receive `OnSmartDeviceTriggered` or `OnStorageMonitorTriggered` broadcasts for a given
 > entity, you must first make at least one request on that entity (e.g. `GetSmartSwitchInfoAsync`),
 > which registers it with the server. Camera frame events start after `SubscribeToCameraAsync`.
 

--- a/docs/articles/troubleshooting.md
+++ b/docs/articles/troubleshooting.md
@@ -115,7 +115,7 @@ See [Credentials — upstream fragility](credentials.md#upstream-fragility) for 
 
 ## Entity events never fire
 
-**Symptom:** `OnSmartSwitchTriggered` or `OnStorageMonitorTriggered` never fires even when the
+**Symptom:** `OnSmartDeviceTriggered` or `OnStorageMonitorTriggered` never fires even when the
 device changes state in game.
 
 **Cause:** The server only sends broadcasts for entities that your client has explicitly queried.
@@ -128,8 +128,8 @@ arriving.
 // Register the entity with the server — broadcasts start after this call.
 await rustPlus.GetSmartSwitchInfoAsync(entityId);
 
-rustPlus.OnSmartSwitchTriggered += (_, e) =>
-    Console.WriteLine($"Switch {e.Id}: {(e.IsActive ? "on" : "off")}");
+rustPlus.OnSmartDeviceTriggered += (_, e) =>
+    Console.WriteLine($"Device {e.Id}: {(e.IsActive ? "on" : "off")}");
 ```
 
 > [!NOTE]

--- a/samples/RustPlus.ConsoleApp/Features/LiveEvents.cs
+++ b/samples/RustPlus.ConsoleApp/Features/LiveEvents.cs
@@ -8,8 +8,8 @@ internal sealed class LiveEvents(IRustPlus rustPlus)
 {
     public Task RunAsync()
     {
-        void OnSmartSwitch(object? _, SmartSwitchEventArg e) =>
-            DisplayUtilities.DisplayEvent("SmartSwitchTriggered", e);
+        void OnSmartDevice(object? _, SmartSwitchEventArg e) =>
+            DisplayUtilities.DisplayEvent("SmartDeviceTriggered", e);
 
         void OnStorageMonitor(object? _, StorageMonitorEventArg e) =>
             DisplayUtilities.DisplayEvent("StorageMonitorTriggered", e);
@@ -18,7 +18,7 @@ internal sealed class LiveEvents(IRustPlus rustPlus)
         void OnClanChat(object? _, ClanMessageEventArg e) => DisplayUtilities.DisplayEvent("ClanChatReceived", e);
         void OnClanChanged(object? _, ClanChangedEventArg e) => DisplayUtilities.DisplayEvent("ClanChanged", e);
 
-        rustPlus.OnSmartSwitchTriggered += OnSmartSwitch;
+        rustPlus.OnSmartDeviceTriggered += OnSmartDevice;
         rustPlus.OnStorageMonitorTriggered += OnStorageMonitor;
         rustPlus.OnTeamChatReceived += OnTeamChat;
         rustPlus.OnClanChatReceived += OnClanChat;
@@ -29,7 +29,7 @@ internal sealed class LiveEvents(IRustPlus rustPlus)
         Console.WriteLine("clan changes). Press any key to stop...\n");
         Console.ReadKey(intercept: true);
 
-        rustPlus.OnSmartSwitchTriggered -= OnSmartSwitch;
+        rustPlus.OnSmartDeviceTriggered -= OnSmartDevice;
         rustPlus.OnStorageMonitorTriggered -= OnStorageMonitor;
         rustPlus.OnTeamChatReceived -= OnTeamChat;
         rustPlus.OnClanChatReceived -= OnClanChat;

--- a/src/RustPlusApi.Fcm/Data/Events/AlarmEvent.cs
+++ b/src/RustPlusApi.Fcm/Data/Events/AlarmEvent.cs
@@ -3,6 +3,9 @@ namespace RustPlusApi.Fcm.Data.Events;
 /// <summary>Describes a Rust+ smart alarm that has been triggered.</summary>
 public sealed record AlarmEvent
 {
+    /// <summary>The ID of the Rust+ server the alarm was triggered on.</summary>
+    public Guid ServerId { get; init; }
+
     /// <summary>The alarm title configured in the Rust+ app.</summary>
     public string Title { get; init; } = null!;
 

--- a/src/RustPlusApi.Fcm/Extensions/MessageDataToEventModel.cs
+++ b/src/RustPlusApi.Fcm/Extensions/MessageDataToEventModel.cs
@@ -12,7 +12,7 @@ public static class MessageDataToEventModel
     {
         return new AlarmEvent
         {
-            Title = data.Title, Message = data.Message
+            ServerId = data.Body.Id, Title = data.Title, Message = data.Message
         };
     }
 }

--- a/src/RustPlusApi/Extensions/EntityChangedToModel.cs
+++ b/src/RustPlusApi/Extensions/EntityChangedToModel.cs
@@ -6,9 +6,11 @@ namespace RustPlusApi.Extensions;
 /// <summary>Mapping extensions from protobuf entity-changed broadcasts to event argument types.</summary>
 public static class EntityChangedToModel
 {
-    /// <summary>Maps an <see cref="AppEntityChanged"/> broadcast to a <see cref="SmartSwitchEventArg"/>.</summary>
+    /// <summary>Maps an <see cref="AppEntityChanged"/> broadcast to a <see cref="SmartSwitchEventArg"/>.
+    /// The broadcast carries no entity type, so this represents any binary-state smart device
+    /// (a smart switch or a smart alarm).</summary>
     /// <param name="entityChanged">The protobuf entity-changed broadcast.</param>
-    public static SmartSwitchEventArg ToSmartSwitchEvent(this AppEntityChanged entityChanged)
+    public static SmartSwitchEventArg ToSmartDeviceEvent(this AppEntityChanged entityChanged)
     {
         return new SmartSwitchEventArg
         {

--- a/src/RustPlusApi/Interfaces/IRustPlus.cs
+++ b/src/RustPlusApi/Interfaces/IRustPlus.cs
@@ -9,10 +9,11 @@ namespace RustPlusApi.Interfaces;
 /// <summary>High-level Rust+ API contract — typed events and all supported server commands.</summary>
 public interface IRustPlus : IRustPlusSocket
 {
-    /// <summary>Raised when a subscribed smart switch or smart alarm changes state. The Rust+
-    /// protocol does not distinguish the two: an <c>EntityChanged</c> broadcast whose payload
-    /// carries no item capacity is routed here, so alarm state changes also surface through this event.</summary>
-    event EventHandler<SmartSwitchEventArg>? OnSmartSwitchTriggered;
+    /// <summary>Raised when a subscribed binary-state smart device (a smart switch or a smart alarm)
+    /// changes state. The Rust+ <c>EntityChanged</c> broadcast omits the entity type, so a switch and
+    /// an alarm are indistinguishable here; query the entity explicitly (<c>GetSmartSwitchInfoAsync</c>
+    /// or <c>GetAlarmInfoAsync</c>) to learn its actual type.</summary>
+    event EventHandler<SmartSwitchEventArg>? OnSmartDeviceTriggered;
 
     /// <summary>Raised when a subscribed storage monitor reports a change
     /// (an <c>EntityChanged</c> broadcast whose payload carries item capacity).</summary>

--- a/src/RustPlusApi/README.md
+++ b/src/RustPlusApi/README.md
@@ -26,7 +26,7 @@ var info = await rustPlus.GetInfoAsync();          // Response<ServerInfo?>
 if (info.IsSuccess)
     Console.WriteLine($"{info.Data!.Name} — {info.Data.PlayerCount} players");
 
-rustPlus.OnSmartSwitchTriggered += (_, e) => { /* react to a smart switch */ };
+rustPlus.OnSmartDeviceTriggered += (_, e) => { /* react to a smart switch or alarm state change */ };
 ```
 
 Every request returns a `Response<T>` (`IsSuccess` / `Error` / `Data`). Need credentials? Use the

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -30,12 +30,14 @@ public class RustPlus(
     : RustPlusSocket(connection, options, loggerFactory), IRustPlus
 {
     /// <summary>
-    /// Occurs when a <see cref="SmartSwitchEventArg"/> is triggered by a smart switch or a smart
-    /// alarm. The Rust+ protocol does not distinguish the two: an <c>EntityChanged</c> broadcast
-    /// whose payload carries no item capacity is routed here, so alarm state changes also surface
-    /// through this event.
+    /// Occurs when a binary-state smart device (a smart switch or a smart alarm) changes state.
+    /// The Rust+ <c>EntityChanged</c> broadcast carries only the entity id and payload — it does
+    /// <b>not</b> include the entity type — so a switch and an alarm are indistinguishable here.
+    /// To learn an entity's actual type, query it explicitly with
+    /// <see cref="GetSmartSwitchInfoAsync"/> or <see cref="GetAlarmInfoAsync"/> (both read the
+    /// <c>type</c> field on <c>AppEntityInfo</c>, which the broadcast omits).
     /// </summary>
-    public event EventHandler<SmartSwitchEventArg>? OnSmartSwitchTriggered;
+    public event EventHandler<SmartSwitchEventArg>? OnSmartDeviceTriggered;
 
     /// <summary>
     /// Occurs when a <see cref="StorageMonitorEventArg"/> is triggered by a storage monitor
@@ -441,7 +443,7 @@ public class RustPlus(
             // resolves the request first must produce a result: the broadcast carries the authoritative
             // state, the bare ack means the server accepted the set, so the state is the requested value.
             r => r.Broadcast?.EntityChanged is { } entityChanged
-                ? entityChanged.ToSmartSwitchEvent()
+                ? entityChanged.ToSmartDeviceEvent()
                 : new SmartSwitchEventArg
                 {
                     Id = smartSwitchId, IsActive = smartSwitchValue
@@ -540,7 +542,7 @@ public class RustPlus(
             // If you check the status of an alarm, it will return the same as a smart switch
             if (broadcast.EntityChanged.Payload.Capacity is 0)
             {
-                OnSmartSwitchTriggered?.Invoke(this, broadcast.EntityChanged.ToSmartSwitchEvent());
+                OnSmartDeviceTriggered?.Invoke(this, broadcast.EntityChanged.ToSmartDeviceEvent());
             }
             else
             {

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
@@ -80,13 +80,20 @@ public class FcmExtensionMapperTests
     }
 
     [Fact]
-    public void ToAlarmEvent_MapsTitleAndMessage()
+    public void ToAlarmEvent_MapsServerIdTitleAndMessage()
     {
+        var serverId = Guid.Parse("52d121e8-9d14-4dc5-928a-84aa531cfc9e");
         var data = new MessageData
         {
-            Title = "Base attacked", Message = "Door opened"
+            Title = "Base attacked",
+            Message = "Door opened",
+            Body = new Body
+            {
+                Id = serverId
+            }
         };
         var ev = data.ToAlarmEvent();
+        Assert.Equal(serverId, ev.ServerId);
         Assert.Equal("Base attacked", ev.Title);
         Assert.Equal("Door opened", ev.Message);
     }

--- a/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
@@ -129,6 +129,7 @@ public class RustPlusFcmDispatchTests
     public void Alarm_RaisesOnAlarmTriggered()
     {
         using var fcm = new TestFcm();
+        var serverId = Guid.Parse("52d121e8-9d14-4dc5-928a-84aa531cfc9e");
         AlarmEvent? captured = null;
         fcm.OnAlarmTriggered += (_, e) => captured = e;
 
@@ -136,12 +137,19 @@ public class RustPlusFcmDispatchTests
         {
             Data = new MessageData
             {
-                ChannelId = "alarm", Title = "the title", Message = "the message"
+                ChannelId = "alarm",
+                Title = "the title",
+                Message = "the message",
+                Body = new Body
+                {
+                    Id = serverId
+                }
             }
         });
 
         Assert.NotNull(captured);
-        Assert.Equal("the title", captured!.Title);
+        Assert.Equal(serverId, captured!.ServerId);
+        Assert.Equal("the title", captured.Title);
         Assert.Equal("the message", captured.Message);
     }
 

--- a/tests/RustPlusApi.IntegrationTests/SocketCorrelationTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/SocketCorrelationTests.cs
@@ -90,7 +90,7 @@ public class SocketCorrelationTests
             new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
         var otherSwitchEvent = new TaskCompletionSource<Data.Events.SmartSwitchEventArg>(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        client.OnSmartSwitchTriggered += (_, e) => otherSwitchEvent.TrySetResult(e);
+        client.OnSmartDeviceTriggered += (_, e) => otherSwitchEvent.TrySetResult(e);
 
         await client.ConnectAsync().WaitAsync(Timeout);
         await client.GetInfoAsync().WaitAsync(Timeout); // round-trip so the server registers the socket

--- a/tests/RustPlusApi.MockServer/MockResponses.cs
+++ b/tests/RustPlusApi.MockServer/MockResponses.cs
@@ -138,7 +138,7 @@ public static class MockResponses
             }
         };
 
-    /// <summary>An entity-changed broadcast (smart switch), for testing <c>OnSmartSwitchTriggered</c>.</summary>
+    /// <summary>An entity-changed broadcast (smart switch), for testing <c>OnSmartDeviceTriggered</c>.</summary>
     /// <param name="entityId">The entity to report as changed.</param>
     /// <param name="value">The new switch state.</param>
     public static AppBroadcast SmartSwitchBroadcast(uint entityId, bool value) =>

--- a/tests/RustPlusApi.UnitTests/RemainingMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/RemainingMapperTests.cs
@@ -36,7 +36,7 @@ public class RemainingMapperTests
     }
 
     [Fact]
-    public void ToSmartSwitchEvent_MapsIdAndActiveState()
+    public void ToSmartDeviceEvent_MapsIdAndActiveState()
     {
         var changed = new AppEntityChanged
         {
@@ -47,7 +47,7 @@ public class RemainingMapperTests
             }
         };
 
-        var ev = changed.ToSmartSwitchEvent();
+        var ev = changed.ToSmartDeviceEvent();
 
         Assert.Equal(99u, ev.Id);
         Assert.True(ev.IsActive);

--- a/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
@@ -32,7 +32,7 @@ public class RustPlusParseNotificationTests
     {
         using var sut = new TestRustPlus();
         RustPlusApi.Data.Events.SmartSwitchEventArg? captured = null;
-        sut.OnSmartSwitchTriggered += (_, e) => captured = e;
+        sut.OnSmartDeviceTriggered += (_, e) => captured = e;
 
         var broadcast = new AppBroadcast
         {
@@ -57,7 +57,7 @@ public class RustPlusParseNotificationTests
     public void SmartSwitch_NoSubscriber_DoesNotThrow()
     {
         using var sut = new TestRustPlus();
-        // OnSmartSwitchTriggered intentionally NOT subscribed
+        // OnSmartDeviceTriggered intentionally NOT subscribed
 
         var broadcast = new AppBroadcast
         {


### PR DESCRIPTION
## Summary

Two related changes that came out of investigating how alarms surface through the API.

### 1. `AlarmEvent.ServerId` (FCM) — non-breaking
The alarm FCM push already decodes the originating server into its body (`Body.Id`), but `ToAlarmEvent` discarded everything except `Title`/`Message`. This adds `AlarmEvent.ServerId` so consumers can tell **which server** an alarm came from.

> Note: the triggering *entity* cannot be exposed — the alarm push sends `EntityId`/`EntityName`/`EntityType` as `null` (verified against a live payload). `ServerId` is the only differentiator the push carries.

### 2. Rename `OnSmartSwitchTriggered` → `OnSmartDeviceTriggered` (core) — **breaking**
The `EntityChanged` broadcast (`AppEntityChanged`) carries only `entity_id` + `payload` and **omits** the `AppEntityType` discriminator (`Switch`/`Alarm`/`StorageMonitor`). That enum exists only in `AppEntityInfo`, obtained by *querying* the entity (`GetSmartSwitchInfoAsync` / `GetAlarmInfoAsync`). So a smart switch and a smart alarm are genuinely indistinguishable at broadcast time — the old event name implied a specificity the protocol can't deliver.

Renamed:
- event `OnSmartSwitchTriggered` → `OnSmartDeviceTriggered`
- mapper `ToSmartSwitchEvent` → `ToSmartDeviceEvent`

Docs (`README`, `rustplus-client.md`, `troubleshooting.md`) updated to state plainly that the type isn't knowable from the broadcast and how to resolve it. The `SmartSwitchEventArg` type is **unchanged** (it's shared with the genuinely switch-specific `SetSmartSwitchValueAsync` path).

## Breaking changes
- `IRustPlus.OnSmartSwitchTriggered` → `OnSmartDeviceTriggered`
- `EntityChangedToModel.ToSmartSwitchEvent` → `ToSmartDeviceEvent`

## Test plan
- [x] Full solution builds (0 warnings / 0 errors, strict analyzers)
- [x] Entire test suite passes on **both** TFM hosts (net8.0 = netstandard2.0 build, net10.0)
- [x] Updated unit tests assert `AlarmEvent.ServerId` round-trips and the renamed event/mapper behave identically
- [x] Pre-push ReSharper format check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)