### PR TITLE
FCM notification overhaul: persistentIds round-trip + unified notification hierarchy

### DIFF
--- a/docs/articles/fcm-notifications.md
+++ b/docs/articles/fcm-notifications.md
@@ -39,6 +39,11 @@ pruning (ids have a server-side lifespan).
 
 ## Events
 
+Every typed event payload derives `NotificationBase`, which carries `ServerId` (the originating
+Rust+ server) and `PersistentId` (the FCM message id — correlate with the `PersistentIdReceived`
+harvested set to de-duplicate or audit). `Notification<T>` adds `PlayerId`/`PlayerToken`/`Data`
+for pairing events; `AlarmNotification` adds `Title`/`Message` for alarm events.
+
 | Event | Payload type | Fires when |
 | --- | --- | --- |
 | `OnPairing` | `FcmMessage` | Any pairing FCM message is received (raw). |
@@ -47,7 +52,7 @@ pruning (ids have a server-side lifespan).
 | `OnSmartAlarmPairing` | `Notification<ulong?>` | A smart alarm is paired (entity ID in `Data`). |
 | `OnStorageMonitorPairing` | `Notification<ulong?>` | A storage monitor is paired (entity ID in `Data`). |
 | `OnServerPairing` | `Notification<ServerEvent?>` | You choose *Pair with Server* in game — carries ip/port/playerId/playerToken. |
-| `OnAlarmTriggered` | `AlarmEvent?` | A paired smart alarm fires. |
+| `OnAlarmTriggered` | `AlarmNotification?` | A paired smart alarm fires. |
 
 Socket lifecycle events (from `IRustPlusFcmSocket`):
 

--- a/docs/articles/fcm-notifications.md
+++ b/docs/articles/fcm-notifications.md
@@ -26,10 +26,16 @@ await listener.ConnectAsync();
 listener.Disconnect();
 ```
 
-`persistentIds` is an optional `ICollection<string>` of already-seen notification IDs to skip on
-reconnect. Pass the same collection instance across reconnects — the socket appends every newly-seen
-ID to it as they arrive, so passing it back to a new instance automatically deduplicates replays.
-Prefer a `HashSet<string>` — the collection is consulted on every message and grows for the lifetime of the listener, so a `List<string>`'s linear scan degrades over long sessions.
+`persistentIds` is an optional `ICollection<string>` of already-seen notification IDs. These are
+server-assigned ids that the socket replays to the FCM server at login so it won't redeliver
+messages you've already processed. Prefer a `HashSet<string>` — the collection is consulted on
+every message and grows over time, so a `List<string>`'s linear scan degrades over long sessions.
+
+The socket adds each newly-harvested id to your collection and then raises `PersistentIdReceived`
+with that id — subscribe to persist ids incrementally and avoid a redelivery window after a restart
+(not just a reconnect). Read the full tracked set at any time via `PersistentIds`, which returns a
+never-null snapshot. The caller's set is **not** cleared on login; you own its lifecycle, including
+pruning (ids have a server-side lifespan).
 
 ## Events
 
@@ -133,6 +139,28 @@ async Task ConnectWithRetryAsync(CancellationToken ct)
 
 await ConnectWithRetryAsync(CancellationToken.None);
 ```
+
+### Persisting across restarts
+
+The reconnect loop above keeps ids in memory only — a process restart loses them and the server may
+replay recently-delivered messages. To survive restarts, load the set from disk on startup and save
+it incrementally via `PersistentIdReceived`:
+
+```csharp
+const string IdsFile = "persistent-ids.json";
+
+// Load on startup.
+ICollection<string> persistentIds = File.Exists(IdsFile)
+    ? JsonSerializer.Deserialize<HashSet<string>>(File.ReadAllText(IdsFile)) ?? new HashSet<string>()
+    : new HashSet<string>();
+
+// Wire up before ConnectAsync so no id is missed.
+listener.PersistentIdReceived += (_, _) =>
+    File.WriteAllText(IdsFile, JsonSerializer.Serialize(listener.PersistentIds));
+```
+
+For a real app, prune the stored set periodically — FCM persistent ids have a server-side lifespan
+and the set grows without bound otherwise.
 
 ## One-await pairing
 

--- a/samples/RustPlus.Fcm.ConsoleApp/Program.cs
+++ b/samples/RustPlus.Fcm.ConsoleApp/Program.cs
@@ -32,7 +32,19 @@ catch (Exception ex)
     return;
 }
 
-using var listener = new RustPlusFcm(credentials);
+// Persist the server-assigned persistentIds between runs so already-processed notifications are not
+// redelivered after a restart. Stored next to the config (gitignored). Ids have a server-side
+// lifespan; a real app should prune this (e.g. cap the count) — kept simple here.
+var persistentIdsPath = Path.Combine(AppContext.BaseDirectory, "persistent-ids.json");
+var persistentIds = File.Exists(persistentIdsPath)
+    ? JsonSerializer.Deserialize<HashSet<string>>(await File.ReadAllTextAsync(persistentIdsPath)) ?? []
+    : new HashSet<string>();
+Console.WriteLine($"Loaded {persistentIds.Count} persistent id(s).");
+
+using var listener = new RustPlusFcm(credentials, persistentIds);
+
+listener.PersistentIdReceived += (_, _) =>
+    File.WriteAllText(persistentIdsPath, JsonSerializer.Serialize(listener.PersistentIds));
 
 listener.Connecting += (_, _) => Console.WriteLine($"[CONNECTING]: {DateTime.Now}");
 listener.Connected += (_, _) => Console.WriteLine($"[CONNECTED]: {DateTime.Now}");

--- a/src/RustPlusApi.Fcm.Extensions.DependencyInjection/IRustPlusFcmFactory.cs
+++ b/src/RustPlusApi.Fcm.Extensions.DependencyInjection/IRustPlusFcmFactory.cs
@@ -13,9 +13,12 @@ public interface IRustPlusFcmFactory
 {
     /// <summary>Creates a new, unconnected listener for <paramref name="credentials"/>.</summary>
     /// <param name="credentials">The FCM credentials to authenticate with.</param>
-    /// <param name="persistentIds">Already-processed message IDs to skip. When <see langword="null"/>, the
-    /// factory supplies a fresh empty list, so in-session deduplication is always enabled (unlike the
-    /// <see cref="RustPlusApi.Fcm.RustPlusFcm"/> constructor, where <see langword="null"/> disables it).</param>
+    /// <param name="persistentIds">Already-processed message ids to skip, and the set new ids are
+    /// harvested into. When <see langword="null"/>, the factory supplies a fresh empty list, so
+    /// in-session deduplication is always enabled (unlike the
+    /// <see cref="RustPlusApi.Fcm.RustPlusFcm"/> constructor, where <see langword="null"/> disables
+    /// it). Read ids back via <c>PersistentIds</c> / <c>PersistentIdReceived</c> on the returned
+    /// listener to persist them across reconnects.</param>
     /// <returns>A caller-owned <see cref="IRustPlusFcm"/>; call <c>ConnectAsync</c> to connect.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="credentials"/> is <see langword="null"/>.</exception>
     IRustPlusFcm Create(Credentials credentials, ICollection<string>? persistentIds = null);

--- a/src/RustPlusApi.Fcm/Data/Events/AlarmNotification.cs
+++ b/src/RustPlusApi.Fcm/Data/Events/AlarmNotification.cs
@@ -1,11 +1,11 @@
+using RustPlusApi.Fcm.Data;
+
 namespace RustPlusApi.Fcm.Data.Events;
 
-/// <summary>Describes a Rust+ smart alarm that has been triggered.</summary>
-public sealed record AlarmEvent
+/// <summary>A triggered Rust+ smart alarm, on top of the shared <see cref="NotificationBase"/>
+/// server/persistent-id envelope. Alarms carry no player context (the server sends none).</summary>
+public sealed record AlarmNotification : NotificationBase
 {
-    /// <summary>The ID of the Rust+ server the alarm was triggered on.</summary>
-    public Guid ServerId { get; init; }
-
     /// <summary>The alarm title configured in the Rust+ app.</summary>
     public string Title { get; init; } = null!;
 

--- a/src/RustPlusApi.Fcm/Data/Notification.cs
+++ b/src/RustPlusApi.Fcm/Data/Notification.cs
@@ -1,17 +1,15 @@
 namespace RustPlusApi.Fcm.Data;
 
-/// <summary>Wraps a typed FCM pairing payload with the originating player and server context.</summary>
-/// <typeparam name="T">The pairing data type (e.g. <see cref="Events.EntityEvent"/>, <see cref="Events.ServerEvent"/>, or <see cref="int"/>).</typeparam>
-public record Notification<T>
+/// <summary>Wraps a typed FCM pairing payload with the originating player context, on top of the
+/// shared <see cref="NotificationBase"/> server/persistent-id envelope.</summary>
+/// <typeparam name="T">The pairing data type (e.g. <see cref="Events.EntityEvent"/>, <see cref="Events.ServerEvent"/>, or <see cref="ulong"/>).</typeparam>
+public record Notification<T> : NotificationBase
 {
     /// <summary>Steam ID of the player who performed the pairing.</summary>
     public ulong PlayerId { get; init; }
 
     /// <summary>Rust+ player token for the pairing player.</summary>
     public int PlayerToken { get; init; }
-
-    /// <summary>The Rust+ server ID the pairing is associated with.</summary>
-    public Guid ServerId { get; init; }
 
     /// <summary>The typed pairing payload.</summary>
     public T? Data { get; init; }

--- a/src/RustPlusApi.Fcm/Data/NotificationBase.cs
+++ b/src/RustPlusApi.Fcm/Data/NotificationBase.cs
@@ -1,0 +1,14 @@
+namespace RustPlusApi.Fcm.Data;
+
+/// <summary>The common envelope for every typed FCM notification: the originating server and the
+/// FCM persistent id, so any event can be tied back to its server and de-duplicated/correlated with
+/// the id harvested by the socket (see <c>PersistentIdReceived</c> / <c>PersistentIds</c>).</summary>
+public abstract record NotificationBase
+{
+    /// <summary>The Rust+ server ID the notification originated from.</summary>
+    public Guid ServerId { get; init; }
+
+    /// <summary>The FCM persistent id of the underlying message; <see langword="null"/> if the
+    /// message carried none. Use it to correlate this event with the harvested id set.</summary>
+    public string? PersistentId { get; init; }
+}

--- a/src/RustPlusApi.Fcm/Extensions/MessageDataToEventModel.cs
+++ b/src/RustPlusApi.Fcm/Extensions/MessageDataToEventModel.cs
@@ -6,13 +6,15 @@ namespace RustPlusApi.Fcm.Extensions;
 /// <summary>Extension methods that project a <see cref="MessageData"/> into FCM event model types.</summary>
 public static class MessageDataToEventModel
 {
-    /// <summary>Maps the notification message data to an <see cref="AlarmEvent"/>.</summary>
+    /// <summary>Maps the notification message data to an <see cref="AlarmNotification"/>.</summary>
     /// <param name="data">The message data to map.</param>
-    public static AlarmEvent ToAlarmEvent(this MessageData data)
+    /// <param name="serverId">The ID of the server the alarm was triggered on.</param>
+    /// <param name="persistentId">The FCM persistent id of the alarm message (may be <see langword="null"/>).</param>
+    public static AlarmNotification ToAlarmNotification(this MessageData data, Guid serverId, string? persistentId)
     {
-        return new AlarmEvent
+        return new AlarmNotification
         {
-            ServerId = data.Body.Id, Title = data.Title, Message = data.Message
+            ServerId = serverId, PersistentId = persistentId, Title = data.Title, Message = data.Message
         };
     }
 }

--- a/src/RustPlusApi.Fcm/Interfaces/IRustPlusFcm.cs
+++ b/src/RustPlusApi.Fcm/Interfaces/IRustPlusFcm.cs
@@ -24,6 +24,6 @@ public interface IRustPlusFcm : IRustPlusFcmSocket
     /// <summary>Raised when a storage monitor pairing notification is received.</summary>
     event EventHandler<Notification<ulong?>>? OnStorageMonitorPairing;
 
-    /// <summary>Raised when a smart alarm is triggered.</summary>
-    event EventHandler<AlarmEvent?>? OnAlarmTriggered;
+    /// <summary>Raised when a smart alarm is triggered. Payload is an <see cref="AlarmNotification"/>.</summary>
+    event EventHandler<AlarmNotification?>? OnAlarmTriggered;
 }

--- a/src/RustPlusApi.Fcm/Interfaces/IRustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/Interfaces/IRustPlusFcmSocket.cs
@@ -25,6 +25,15 @@ public interface IRustPlusFcmSocket : IDisposable, IAsyncDisposable
     /// <summary>Raised when an unhandled exception occurs on the receive loop.</summary>
     event EventHandler<Exception>? ErrorOccurred;
 
+    /// <summary>Raised once per newly-harvested FCM <c>persistentId</c>, after it is tracked.
+    /// Subscribe to persist ids incrementally and minimise the cross-session redelivery window.</summary>
+    event EventHandler<string>? PersistentIdReceived;
+
+    /// <summary>A never-null snapshot of the <c>persistentId</c>s currently tracked for
+    /// de-duplication. Persist and replay these via the constructor to suppress redelivery across
+    /// reconnects; ids have a server-side lifespan, so pruning your stored copy is your job.</summary>
+    IReadOnlyCollection<string> PersistentIds { get; }
+
     /// <summary>Connects to the FCM MCS endpoint and begins receiving notifications. On failure,
     /// <c>ErrorOccurred</c> is raised and the exception is rethrown. Instances are single-connection:
     /// after <see cref="Disconnect"/> or disposal, create a new instance to reconnect.</summary>

--- a/src/RustPlusApi.Fcm/Interfaces/IRustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/Interfaces/IRustPlusFcmSocket.cs
@@ -4,6 +4,11 @@ namespace RustPlusApi.Fcm.Interfaces;
 /// Clients are disposable; prefer <see cref="IAsyncDisposable.DisposeAsync"/> so teardown drains background work.</summary>
 public interface IRustPlusFcmSocket : IDisposable, IAsyncDisposable
 {
+    /// <summary>A never-null snapshot of the <c>persistentId</c>s currently tracked for
+    /// de-duplication. Persist and replay these via the constructor to suppress redelivery across
+    /// reconnects; ids have a server-side lifespan, so pruning your stored copy is your job.</summary>
+    IReadOnlyCollection<string> PersistentIds { get; }
+
     /// <summary>Raised when the client begins connecting to the FCM server.</summary>
     event EventHandler? Connecting;
 
@@ -28,11 +33,6 @@ public interface IRustPlusFcmSocket : IDisposable, IAsyncDisposable
     /// <summary>Raised once per newly-harvested FCM <c>persistentId</c>, after it is tracked.
     /// Subscribe to persist ids incrementally and minimise the cross-session redelivery window.</summary>
     event EventHandler<string>? PersistentIdReceived;
-
-    /// <summary>A never-null snapshot of the <c>persistentId</c>s currently tracked for
-    /// de-duplication. Persist and replay these via the constructor to suppress redelivery across
-    /// reconnects; ids have a server-side lifespan, so pruning your stored copy is your job.</summary>
-    IReadOnlyCollection<string> PersistentIds { get; }
 
     /// <summary>Connects to the FCM MCS endpoint and begins receiving notifications. On failure,
     /// <c>ErrorOccurred</c> is raised and the exception is rethrown. Instances are single-connection:

--- a/src/RustPlusApi.Fcm/Interfaces/IRustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/Interfaces/IRustPlusFcmSocket.cs
@@ -7,6 +7,14 @@ public interface IRustPlusFcmSocket : IDisposable, IAsyncDisposable
     /// <summary>A never-null snapshot of the <c>persistentId</c>s currently tracked for
     /// de-duplication. Persist and replay these via the constructor to suppress redelivery across
     /// reconnects; ids have a server-side lifespan, so pruning your stored copy is your job.</summary>
+    /// <remarks>
+    /// <para><b>Thread safety:</b> the snapshot enumerates the caller-owned collection with no lock.
+    /// The receive loop adds ids on its own task, so reading <see cref="PersistentIds"/> from an
+    /// unrelated thread while live traffic is flowing can throw
+    /// <c>InvalidOperationException</c> (collection modified during enumeration).
+    /// Safe read points: inside a <see cref="PersistentIdReceived"/> handler or any other
+    /// notification event (same thread as the harvest), or after <see cref="Disconnect"/>.</para>
+    /// </remarks>
     IReadOnlyCollection<string> PersistentIds { get; }
 
     /// <summary>Raised when the client begins connecting to the FCM server.</summary>

--- a/src/RustPlusApi.Fcm/RustPlusFcm.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcm.cs
@@ -78,9 +78,9 @@ public class RustPlusFcm(
     /// Occurs when an alarm event is triggered.
     /// </summary>
     /// <remarks>
-    /// The event data is an <see cref="AlarmEvent"/>.
+    /// The event data is an <see cref="AlarmNotification"/> (server id + persistent id + title/message).
     /// </remarks>
-    public event EventHandler<AlarmEvent?>? OnAlarmTriggered;
+    public event EventHandler<AlarmNotification?>? OnAlarmTriggered;
 
     /// <summary>
     /// Parses an incoming <see cref="FcmMessage"/> and dispatches events based on its channel.
@@ -98,7 +98,7 @@ public class RustPlusFcm(
                 ParsePairing(message.Data.Body, message.PersistentId);
                 break;
             case "alarm":
-                OnAlarmTriggered?.Invoke(this, message.Data.ToAlarmEvent());
+                OnAlarmTriggered?.Invoke(this, message.Data.ToAlarmNotification(message.Data.Body.Id, message.PersistentId));
                 break;
             default:
                 Logger.LogUnknownChannel(message.Data.ChannelId);

--- a/src/RustPlusApi.Fcm/RustPlusFcm.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcm.cs
@@ -95,7 +95,7 @@ public class RustPlusFcm(
         {
             case "pairing":
                 OnPairing?.Invoke(this, message);
-                ParsePairing(message.Data.Body);
+                ParsePairing(message.Data.Body, message.PersistentId);
                 break;
             case "alarm":
                 OnAlarmTriggered?.Invoke(this, message.Data.ToAlarmEvent());
@@ -110,20 +110,21 @@ public class RustPlusFcm(
     /// Handles pairing notifications by type and dispatches related events.
     /// </summary>
     /// <param name="body">The <see cref="Body"/> of the notification.</param>
+    /// <param name="persistentId">The FCM persistent id of the underlying message (may be <see langword="null"/>).</param>
     /// <remarks>
     /// Invokes <see cref="OnEntityPairing"/>, <see cref="OnServerPairing"/>, and calls <see cref="ParsePairingEntity"/>.
     /// </remarks>
-    private void ParsePairing(Body body)
+    private void ParsePairing(Body body, string? persistentId)
     {
         switch (body.Type)
         {
             case "entity":
-                var entity = BuildGenericOutput(body, body.ToEntityEvent());
+                var entity = BuildGenericOutput(body, body.ToEntityEvent(), persistentId);
                 OnEntityPairing?.Invoke(this, entity);
-                ParsePairingEntity(body);
+                ParsePairingEntity(body, persistentId);
                 break;
             case "server":
-                var server = BuildGenericOutput(body, body.ToServerEvent());
+                var server = BuildGenericOutput(body, body.ToServerEvent(), persistentId);
                 OnServerPairing?.Invoke(this, server);
                 break;
             default:
@@ -136,12 +137,13 @@ public class RustPlusFcm(
     /// Handles entity-specific pairing notifications and dispatches events based on entity type.
     /// </summary>
     /// <param name="body">The <see cref="Body"/> of the notification.</param>
+    /// <param name="persistentId">The FCM persistent id of the underlying message (may be <see langword="null"/>).</param>
     /// <remarks>
     /// Invokes <see cref="OnSmartSwitchPairing"/>, <see cref="OnSmartAlarmPairing"/>, and <see cref="OnStorageMonitorPairing"/>.
     /// </remarks>
-    private void ParsePairingEntity(Body body)
+    private void ParsePairingEntity(Body body, string? persistentId)
     {
-        var response = BuildGenericOutput(body, body.ToEntityId());
+        var response = BuildGenericOutput(body, body.ToEntityId(), persistentId);
 
         switch (body.EntityType)
         {

--- a/src/RustPlusApi.Fcm/RustPlusFcm.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcm.cs
@@ -12,10 +12,13 @@ namespace RustPlusApi.Fcm;
 /// Inherits from <see cref="RustPlusFcmSocket"/>.
 /// </summary>
 /// <param name="credentials">The <see cref="Credentials"/> used for authentication.</param>
-/// <param name="persistentIds">Already-processed message IDs, used for de-duplication. Every data
-/// message is checked against and appended to this collection, so for a long-lived listener prefer
-/// a set-like implementation (e.g. <see cref="HashSet{T}"/>) — with a <see cref="List{T}"/> the
-/// duplicate check is a linear scan that degrades as the collection grows unboundedly.</param>
+/// <param name="persistentIds">Already-processed message ids, used for de-duplication, and the
+/// collection the socket harvests new ids into — pass a mutable, caller-owned set (prefer a
+/// <see cref="HashSet{T}"/>; a <see cref="List{T}"/> makes the duplicate check an O(n) scan). When
+/// <see langword="null"/>, de-duplication is disabled. The set is NOT cleared on login, so seeded
+/// ids survive reconnect. Read the current ids back via <see cref="PersistentIds"/> (snapshot) or
+/// subscribe to <see cref="PersistentIdReceived"/> (incremental) to persist them; ids have a
+/// server-side lifespan, so pruning your stored copy is your responsibility.</param>
 /// <param name="options">Tuning options (heartbeat interval, inactivity timeout); defaults are used when <see langword="null"/>.</param>
 /// <param name="loggerFactory">Routes the client's diagnostics into your logging stack; logging is
 /// disabled (a no-op <c>NullLogger</c>) when <see langword="null"/>.</param>

--- a/src/RustPlusApi.Fcm/RustPlusFcm.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcm.cs
@@ -98,7 +98,8 @@ public class RustPlusFcm(
                 ParsePairing(message.Data.Body, message.PersistentId);
                 break;
             case "alarm":
-                OnAlarmTriggered?.Invoke(this, message.Data.ToAlarmNotification(message.Data.Body.Id, message.PersistentId));
+                OnAlarmTriggered?.Invoke(this,
+                    message.Data.ToAlarmNotification(message.Data.Body.Id, message.PersistentId));
                 break;
             default:
                 Logger.LogUnknownChannel(message.Data.ChannelId);

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -747,7 +747,9 @@ public abstract class RustPlusFcmSocket(
         switch (e.Tag)
         {
             case McsProtoTag.KLoginResponseTag:
-                persistentIds?.Clear();
+                // Do NOT clear the caller's set: the seeded ids were already replayed to the server in
+                // the login request (ReceivedPersistentIds), and the caller owns this collection for
+                // cross-reconnect persistence. Clearing it would destroy their history.
                 break;
             case McsProtoTag.KDataMessageStanzaTag:
                 OnDataMessage(e.Object as DataMessageStanza);

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -159,6 +159,14 @@ public abstract class RustPlusFcmSocket(
     /// collection is never <see langword="null"/> (empty when no ids are tracked). Ids have a
     /// server-side lifespan; pruning your persisted copy is the caller's responsibility.
     /// </summary>
+    /// <remarks>
+    /// <para><b>Thread safety:</b> the snapshot enumerates the caller-owned collection with no lock.
+    /// The receive loop adds ids on its own task, so reading <see cref="PersistentIds"/> from an
+    /// unrelated thread while live traffic is flowing can throw
+    /// <see cref="System.InvalidOperationException"/> (collection modified during enumeration).
+    /// Safe read points: inside a <see cref="PersistentIdReceived"/> handler or any other
+    /// notification event (same thread as the harvest), or after <see cref="Disconnect"/>.</para>
+    /// </remarks>
     public IReadOnlyCollection<string> PersistentIds =>
         persistentIds is null ? [] : [.. persistentIds];
 

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -22,10 +22,13 @@ namespace RustPlusApi.Fcm;
 /// Represents a RustPlus FCM listener client for handling FCM connections and notifications.
 /// </summary>
 /// <param name="credentials">The <see cref="Credentials"/> used for authentication.</param>
-/// <param name="persistentIds">Already-processed message IDs, used for de-duplication. Every data
-/// message is checked against and appended to this collection, so for a long-lived listener prefer
-/// a set-like implementation (e.g. <see cref="HashSet{T}"/>) — with a <see cref="List{T}"/> the
-/// duplicate check is a linear scan that degrades as the collection grows unboundedly.</param>
+/// <param name="persistentIds">Already-processed message ids, used for de-duplication, and the
+/// collection the socket harvests new ids into — pass a mutable, caller-owned set (prefer a
+/// <see cref="HashSet{T}"/>; a <see cref="List{T}"/> makes the duplicate check an O(n) scan). When
+/// <see langword="null"/>, de-duplication is disabled. The set is NOT cleared on login, so seeded
+/// ids survive reconnect. Read the current ids back via <see cref="PersistentIds"/> (snapshot) or
+/// subscribe to <see cref="PersistentIdReceived"/> (incremental) to persist them; ids have a
+/// server-side lifespan, so pruning your stored copy is your responsibility.</param>
 /// <param name="options">Tuning options (heartbeat interval, inactivity timeout); defaults are used when <see langword="null"/>.</param>
 /// <param name="loggerFactory">Routes the client's diagnostics into your logging stack; logging is
 /// disabled (a no-op <c>NullLogger</c>) when <see langword="null"/>.</param>

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -141,6 +141,25 @@ public abstract class RustPlusFcmSocket(
     public event EventHandler<Exception>? ErrorOccurred;
 
     /// <summary>
+    /// Occurs once for each newly-harvested FCM <c>persistentId</c>, immediately after it is added to
+    /// the tracked set. Subscribe to persist ids incrementally so a crash or quick restart cannot
+    /// reopen the redelivery window (the server only stops redelivering a message once its id is
+    /// replayed in a later login's <c>ReceivedPersistentIds</c>).
+    /// </summary>
+    /// <remarks>The event data is the harvested <c>persistentId</c> as a <see cref="string"/>.</remarks>
+    public event EventHandler<string>? PersistentIdReceived;
+
+    /// <summary>
+    /// A snapshot of the FCM <c>persistentId</c>s currently tracked for de-duplication — the ids
+    /// supplied at construction plus every id harvested since. Persist these and pass them back into
+    /// a new instance to suppress redelivery of already-processed messages across reconnects. The
+    /// collection is never <see langword="null"/> (empty when no ids are tracked). Ids have a
+    /// server-side lifespan; pruning your persisted copy is the caller's responsibility.
+    /// </summary>
+    public IReadOnlyCollection<string> PersistentIds =>
+        persistentIds is null ? [] : [.. persistentIds];
+
+    /// <summary>
     /// Connects to the FCM MCS server over TLS, performs the MCS login handshake,
     /// and starts the background message-receive loop.
     /// On failure, <see cref="ErrorOccurred"/> is raised, the partial transport is released (so the
@@ -811,9 +830,10 @@ public abstract class RustPlusFcmSocket(
             }
         };
 
-        if (dataMessage.PersistentId is not null)
+        if (dataMessage.PersistentId is not null && persistentIds is not null)
         {
-            persistentIds?.Add(dataMessage.PersistentId);
+            persistentIds.Add(dataMessage.PersistentId);
+            PersistentIdReceived?.Invoke(this, dataMessage.PersistentId);
         }
 
         ParseNotification(fcmMessage);

--- a/src/RustPlusApi.Fcm/Utils/ResponseHelper.cs
+++ b/src/RustPlusApi.Fcm/Utils/ResponseHelper.cs
@@ -6,17 +6,19 @@ namespace RustPlusApi.Fcm.Utils;
 /// <summary>Builds typed <see cref="Notification{T}"/> wrappers from raw FCM notification bodies.</summary>
 public static class ResponseHelper
 {
-    /// <summary>Wraps a typed pairing payload with the player and server context from the notification body.</summary>
+    /// <summary>Wraps a typed pairing payload with the player/server context and persistent id from the notification.</summary>
     /// <typeparam name="T">The type of the pairing payload.</typeparam>
     /// <param name="body">The raw notification body providing player and server context.</param>
     /// <param name="data">The typed pairing payload to wrap.</param>
-    public static Notification<T?> BuildGenericOutput<T>(Body body, T data)
+    /// <param name="persistentId">The FCM persistent id of the underlying message (may be <see langword="null"/>).</param>
+    public static Notification<T?> BuildGenericOutput<T>(Body body, T data, string? persistentId)
     {
         return new Notification<T?>
         {
             PlayerId = body.PlayerId,
             PlayerToken = int.Parse(body.PlayerToken, CultureInfo.InvariantCulture),
             ServerId = body.Id,
+            PersistentId = persistentId,
             Data = data
         };
     }

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
@@ -87,7 +87,10 @@ public class FcmExtensionMapperTests
         {
             Title = "Base attacked",
             Message = "Door opened",
-            Body = new Body { Id = serverId }
+            Body = new Body
+            {
+                Id = serverId
+            }
         };
         var ev = data.ToAlarmNotification(serverId, "alarm-pid");
         Assert.Equal(serverId, ev.ServerId);

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmExtensionMapperTests.cs
@@ -80,20 +80,18 @@ public class FcmExtensionMapperTests
     }
 
     [Fact]
-    public void ToAlarmEvent_MapsServerIdTitleAndMessage()
+    public void ToAlarmNotification_MapsServerIdPersistentIdTitleAndMessage()
     {
         var serverId = Guid.Parse("52d121e8-9d14-4dc5-928a-84aa531cfc9e");
         var data = new MessageData
         {
             Title = "Base attacked",
             Message = "Door opened",
-            Body = new Body
-            {
-                Id = serverId
-            }
+            Body = new Body { Id = serverId }
         };
-        var ev = data.ToAlarmEvent();
+        var ev = data.ToAlarmNotification(serverId, "alarm-pid");
         Assert.Equal(serverId, ev.ServerId);
+        Assert.Equal("alarm-pid", ev.PersistentId);
         Assert.Equal("Base attacked", ev.Title);
         Assert.Equal("Door opened", ev.Message);
     }

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
@@ -433,8 +433,8 @@ public class FcmSocketFramingTests
     [Fact]
     public async Task DuplicatePersistentId_IsSkipped()
     {
-        // The LoginResponse handler clears the dedupe set, so seeding it up front would not survive.
-        // Instead send the same PersistentId twice: the first populates the set, the second is skipped.
+        // Send the same PersistentId twice within one session: the first harvests it into the set,
+        // the second is recognised as a duplicate and skipped. (LoginResponse no longer clears the set.)
         await using var socket = NewSocket([]);
         var count = 0;
         socket.NotificationReceived += (_, _) => count++;
@@ -986,31 +986,28 @@ public class FcmSocketFramingTests
     }
 
     /// <summary>
-    /// Asserts that the initial LoginResponse frame IS dispatched via OnGotMessageBytes —
-    /// killing the Statement mutation that removes that call at L219.  The side-effect of
-    /// dispatching LoginResponse is that it clears <c>persistentIds</c>, which is observable.
+    /// Asserts the initial LoginResponse frame IS dispatched: a valid LoginResponse first frame must
+    /// be consumed as the login (not faulted as a non-login first frame), after which a fresh-id
+    /// DataMessage is delivered normally. Kills the Statement mutation that removes the first-frame
+    /// dispatch call — without it, the first frame is mis-handled and no notification is delivered.
     /// </summary>
     [Fact]
-    public async Task LoginResponse_DispatchedViaOnGotMessageBytes_ClearsPersistentIds()
+    public async Task LoginResponse_IsDispatched_ThenDataMessageDelivered()
     {
-        var ids = new List<string>
-        {
-            "old-id"
-        };
-        await using var socket = NewSocket(ids);
+        await using var socket = NewSocket([]);
         var count = 0;
         socket.NotificationReceived += (_, _) => count++;
 
         var script = Build(
             FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
-            NextFrame(McsProtoTag.KDataMessageStanzaTag, RustNotification("old-id")),
+            NextFrame(McsProtoTag.KDataMessageStanzaTag, RustNotification("fresh-id")),
             NextFrame(McsProtoTag.KCloseTag, new Close()));
 
-        await socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script));
+        var exception = await Record.ExceptionAsync(
+            () => socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script)));
 
-        // If OnGotMessageBytes was NOT called for LoginResponse, persistentIds would NOT be cleared,
-        // "old-id" would still be in the set, and the DataMessage would be skipped (count == 0).
-        Assert.Equal(1, count);
+        Assert.Null(exception);  // LoginResponse accepted as the login frame
+        Assert.Equal(1, count);  // subsequent DataMessage delivered
     }
 
     /// <summary>

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
@@ -467,9 +467,9 @@ public class FcmSocketFramingTests
         await socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script));
 
         // Event fired once per NEW id, in order.
-        Assert.Equal((string[]) ["id-1", "id-2"], harvested);
+        Assert.Equal((string[])["id-1", "id-2"], harvested);
         // Snapshot exposes the same ids (no Clear destroyed them).
-        Assert.Equal((string[]) ["id-1", "id-2"], socket.PersistentIds.Order());
+        Assert.Equal((string[])["id-1", "id-2"], socket.PersistentIds.Order());
     }
 
     [Fact]
@@ -487,7 +487,7 @@ public class FcmSocketFramingTests
 
         await socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script));
 
-        Assert.Equal((string[]) ["dup"], harvested); // duplicate did not re-raise
+        Assert.Equal((string[])["dup"], harvested); // duplicate did not re-raise
     }
 
     [Fact]
@@ -911,7 +911,10 @@ public class FcmSocketFramingTests
     [Fact]
     public async Task LoginResponse_PreservesPreSeededPersistentIds()
     {
-        var ids = new HashSet<string> { "pre-existing-id" };
+        var ids = new HashSet<string>
+        {
+            "pre-existing-id"
+        };
         await using var socket = NewSocket(ids);
         var count = 0;
         socket.NotificationReceived += (_, _) => count++;
@@ -1006,11 +1009,10 @@ public class FcmSocketFramingTests
             NextFrame(McsProtoTag.KDataMessageStanzaTag, RustNotification("fresh-id")),
             NextFrame(McsProtoTag.KCloseTag, new Close())));
 
-        var exception = await Record.ExceptionAsync(
-            () => socket.RunReceiveLoopOverStreamAsync(stream));
+        var exception = await Record.ExceptionAsync(() => socket.RunReceiveLoopOverStreamAsync(stream));
 
-        Assert.Null(exception);  // LoginResponse accepted as the login frame
-        Assert.Equal(1, count);  // subsequent DataMessage delivered
+        Assert.Null(exception); // LoginResponse accepted as the login frame
+        Assert.Equal(1, count); // subsequent DataMessage delivered
 
         // The StreamAck must report LastStreamIdReceived == 2: LoginResponse counted as frame 1,
         // DataMessage as frame 2. Under the line-493 mutation the login frame is never dispatched,

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
@@ -903,33 +903,29 @@ public class FcmSocketFramingTests
     }
 
     /// <summary>
-    /// Asserts that LoginResponse clears the persistentIds collection, so a message whose
-    /// persistent ID was known BEFORE login is redelivered after login — kills the
-    /// Statement mutation that removes <c>persistentIds?.Clear()</c> in the LoginResponse arm.
+    /// Asserts that LoginResponse does NOT clear the caller's persistentIds set: a message whose id
+    /// was seeded BEFORE login is still de-duplicated (skipped) after login, and the seeded id
+    /// survives in the public snapshot. The seeded ids have already been replayed to the server in
+    /// the login request, so the caller's local history must be preserved for reconnect.
     /// </summary>
     [Fact]
-    public async Task LoginResponse_ClearsPreSeededPersistentIds()
+    public async Task LoginResponse_PreservesPreSeededPersistentIds()
     {
-        // Pre-seed the set with a known ID so that, WITHOUT clearing, the second delivery
-        // would be skipped by the dedup check.
-        var ids = new List<string>
-        {
-            "pre-existing-id"
-        };
+        var ids = new HashSet<string> { "pre-existing-id" };
         await using var socket = NewSocket(ids);
         var count = 0;
         socket.NotificationReceived += (_, _) => count++;
 
         var script = Build(
-            // LoginResponse should clear the set (removing "pre-existing-id").
             FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
-            // This message has the same ID — it should be DELIVERED because the set was cleared.
+            // Same id as the seed — must be SKIPPED because the set was NOT cleared.
             NextFrame(McsProtoTag.KDataMessageStanzaTag, RustNotification(persistentId: "pre-existing-id")),
             NextFrame(McsProtoTag.KCloseTag, new Close()));
 
         await socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script));
 
-        Assert.Equal(1, count);
+        Assert.Equal(0, count); // duplicate of a seeded id is suppressed
+        Assert.Contains("pre-existing-id", socket.PersistentIds);
     }
 
     /// <summary>

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
@@ -451,6 +451,54 @@ public class FcmSocketFramingTests
     }
 
     [Fact]
+    public async Task PersistentIdReceived_RaisedPerHarvestedId_AndSnapshotReflectsThem()
+    {
+        var ids = new HashSet<string>();
+        await using var socket = NewSocket(ids);
+        var harvested = new List<string>();
+        socket.PersistentIdReceived += (_, id) => harvested.Add(id);
+
+        var script = Build(
+            FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
+            NextFrame(McsProtoTag.KDataMessageStanzaTag, RustNotification(persistentId: "id-1")),
+            NextFrame(McsProtoTag.KDataMessageStanzaTag, RustNotification(persistentId: "id-2")),
+            NextFrame(McsProtoTag.KCloseTag, new Close()));
+
+        await socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script));
+
+        // Event fired once per NEW id, in order.
+        Assert.Equal((string[]) ["id-1", "id-2"], harvested);
+        // Snapshot exposes the same ids (no Clear destroyed them).
+        Assert.Equal((string[]) ["id-1", "id-2"], socket.PersistentIds.Order());
+    }
+
+    [Fact]
+    public async Task PersistentIdReceived_NotRaisedForDuplicate()
+    {
+        await using var socket = NewSocket([]);
+        var harvested = new List<string>();
+        socket.PersistentIdReceived += (_, id) => harvested.Add(id);
+
+        var script = Build(
+            FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
+            NextFrame(McsProtoTag.KDataMessageStanzaTag, RustNotification(persistentId: "dup")),
+            NextFrame(McsProtoTag.KDataMessageStanzaTag, RustNotification(persistentId: "dup")),
+            NextFrame(McsProtoTag.KCloseTag, new Close()));
+
+        await socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script));
+
+        Assert.Equal((string[]) ["dup"], harvested); // duplicate did not re-raise
+    }
+
+    [Fact]
+    public void PersistentIds_NullCollection_SnapshotIsEmptyNotNull()
+    {
+        using var socket = NewSocket(persistentIds: null);
+        Assert.NotNull(socket.PersistentIds);
+        Assert.Empty(socket.PersistentIds);
+    }
+
+    [Fact]
     public async Task ReadVarInt32_MultiByteSize_FrameDelivered()
     {
         // Build a DataMessageStanza whose serialized payload length >= 128, so the size varint

--- a/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/FcmSocketFramingTests.cs
@@ -986,10 +986,13 @@ public class FcmSocketFramingTests
     }
 
     /// <summary>
-    /// Asserts the initial LoginResponse frame IS dispatched: a valid LoginResponse first frame must
-    /// be consumed as the login (not faulted as a non-login first frame), after which a fresh-id
-    /// DataMessage is delivered normally. Kills the Statement mutation that removes the first-frame
-    /// dispatch call — without it, the first frame is mis-handled and no notification is delivered.
+    /// Asserts that the LoginResponse first frame IS dispatched through
+    /// <c>OnGotMessageBytesAsync</c> (RustPlusFcmSocket.cs line 493). Each call to
+    /// <c>OnGotMessageBytesAsync</c> increments <c>_streamIdIn</c>, so after LoginResponse
+    /// (frame 1) + DataMessageStanza (frame 2) the StreamAck written back carries
+    /// <c>LastStreamIdReceived == 2</c>. Under the line-493 Statement mutation (first-frame
+    /// dispatch removed), <c>_streamIdIn</c> is only incremented once (for the DataMessage),
+    /// and the ack carries <c>1</c> instead — killing the mutation.
     /// </summary>
     [Fact]
     public async Task LoginResponse_IsDispatched_ThenDataMessageDelivered()
@@ -998,16 +1001,24 @@ public class FcmSocketFramingTests
         var count = 0;
         socket.NotificationReceived += (_, _) => count++;
 
-        var script = Build(
+        var stream = new ScriptedStream(Build(
             FirstFrame(McsProtoTag.KLoginResponseTag, new LoginResponse()),
             NextFrame(McsProtoTag.KDataMessageStanzaTag, RustNotification("fresh-id")),
-            NextFrame(McsProtoTag.KCloseTag, new Close()));
+            NextFrame(McsProtoTag.KCloseTag, new Close())));
 
         var exception = await Record.ExceptionAsync(
-            () => socket.RunReceiveLoopOverStreamAsync(new ScriptedStream(script)));
+            () => socket.RunReceiveLoopOverStreamAsync(stream));
 
         Assert.Null(exception);  // LoginResponse accepted as the login frame
         Assert.Equal(1, count);  // subsequent DataMessage delivered
+
+        // The StreamAck must report LastStreamIdReceived == 2: LoginResponse counted as frame 1,
+        // DataMessage as frame 2. Under the line-493 mutation the login frame is never dispatched,
+        // _streamIdIn is only bumped once, and the ack would report 1 — detecting the mutation.
+        var (tag, payload) = Assert.Single(ParseClientFrames(stream.Writes.ToArray()));
+        Assert.Equal((int)McsProtoTag.KIqStanzaTag, tag);
+        var iq = Serializer.Deserialize<IqStanza>(new MemoryStream(payload));
+        Assert.Equal(2, iq.LastStreamIdReceived); // LoginResponse = 1, DataMessageStanza = 2
     }
 
     /// <summary>

--- a/tests/RustPlusApi.Fcm.UnitTests/NotificationHierarchyTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/NotificationHierarchyTests.cs
@@ -12,7 +12,11 @@ public class NotificationHierarchyTests
         var serverId = Guid.NewGuid();
         NotificationBase n = new Notification<int?>
         {
-            ServerId = serverId, PersistentId = "pid-1", PlayerId = 7, PlayerToken = 9, Data = 42
+            ServerId = serverId,
+            PersistentId = "pid-1",
+            PlayerId = 7,
+            PlayerToken = 9,
+            Data = 42
         };
 
         Assert.Equal(serverId, n.ServerId);

--- a/tests/RustPlusApi.Fcm.UnitTests/NotificationHierarchyTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/NotificationHierarchyTests.cs
@@ -1,0 +1,25 @@
+using RustPlusApi.Fcm.Data;
+using RustPlusApi.Fcm.Data.Events;
+using Xunit;
+
+namespace RustPlusApi.Fcm.UnitTests;
+
+public class NotificationHierarchyTests
+{
+    [Fact]
+    public void NotificationOfT_DerivesNotificationBase_AndCarriesServerIdAndPersistentId()
+    {
+        var serverId = Guid.NewGuid();
+        NotificationBase n = new Notification<int?>
+        {
+            ServerId = serverId, PersistentId = "pid-1", PlayerId = 7, PlayerToken = 9, Data = 42
+        };
+
+        Assert.Equal(serverId, n.ServerId);
+        Assert.Equal("pid-1", n.PersistentId);
+        var typed = Assert.IsType<Notification<int?>>(n);
+        Assert.Equal(7ul, typed.PlayerId);
+        Assert.Equal(9, typed.PlayerToken);
+        Assert.Equal(42, typed.Data);
+    }
+}

--- a/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
@@ -145,7 +145,10 @@ public class RustPlusFcmDispatchTests
                 ChannelId = "alarm",
                 Title = "the title",
                 Message = "the message",
-                Body = new Body { Id = serverId }
+                Body = new Body
+                {
+                    Id = serverId
+                }
             }
         });
 

--- a/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
@@ -12,6 +12,7 @@ public class RustPlusFcmDispatchTests
     private static FcmMessage Pairing(Body body) =>
         new()
         {
+            PersistentId = "pair-pid",
             Data = new MessageData
             {
                 ChannelId = "pairing", Body = body
@@ -46,6 +47,7 @@ public class RustPlusFcmDispatchTests
         Assert.Equal(7ul, captured!.PlayerId);
         Assert.Equal(9, captured.PlayerToken);
         Assert.Equal(serverId, captured.ServerId);
+        Assert.Equal("pair-pid", captured.PersistentId);
         // Mapped ServerEvent payload (ToServerEvent).
         var server = captured.Data!;
         Assert.Equal(serverId, server.Id);
@@ -94,6 +96,7 @@ public class RustPlusFcmDispatchTests
         Assert.Equal((EntityType)entityType, entity.Data!.EntityType);
         Assert.Equal(42UL, entity.Data.EntityId);
         Assert.Equal("switch-1", entity.Data.EntityName);
+        Assert.Equal("pair-pid", entity.PersistentId);
 
         // Exactly one typed event fires, carrying the entity id (42) as its payload.
         var fired = new[]
@@ -104,6 +107,7 @@ public class RustPlusFcmDispatchTests
         Assert.Equal(42UL, raised!.Data);
         Assert.Equal(serverId, raised.ServerId);
         Assert.Equal(11ul, raised.PlayerId);
+        Assert.Equal("pair-pid", raised.PersistentId);
 
         Assert.Equal(entityType == 1, smart is not null);
         Assert.Equal(entityType == 2, alarm is not null);

--- a/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
+++ b/tests/RustPlusApi.Fcm.UnitTests/RustPlusFcmDispatchTests.cs
@@ -134,25 +134,24 @@ public class RustPlusFcmDispatchTests
     {
         using var fcm = new TestFcm();
         var serverId = Guid.Parse("52d121e8-9d14-4dc5-928a-84aa531cfc9e");
-        AlarmEvent? captured = null;
+        AlarmNotification? captured = null;
         fcm.OnAlarmTriggered += (_, e) => captured = e;
 
         fcm.Feed(new FcmMessage
         {
+            PersistentId = "alarm-pid",
             Data = new MessageData
             {
                 ChannelId = "alarm",
                 Title = "the title",
                 Message = "the message",
-                Body = new Body
-                {
-                    Id = serverId
-                }
+                Body = new Body { Id = serverId }
             }
         });
 
         Assert.NotNull(captured);
         Assert.Equal(serverId, captured!.ServerId);
+        Assert.Equal("alarm-pid", captured.PersistentId);
         Assert.Equal("the title", captured.Title);
         Assert.Equal("the message", captured.Message);
     }


### PR DESCRIPTION
## Summary

Two interdependent FCM improvements that together make notifications persistable and consistent. They ship as one PR because the second builds directly on the first (`NotificationBase.PersistentId` depends on the persistentIds work).

### 1. persistentIds round-trip — let consumers read back the harvested ids
The MCS socket harvests Google's server-assigned `persistentId`s for de-duplication, but there was **no way out**: the set was input-only (the caller had to hold a reference to a collection the library secretly mutated), and the library **cleared that set on login**, destroying seeded history.

- Added `IReadOnlyCollection<string> PersistentIds { get; }` — a never-null snapshot — and `event EventHandler<string>? PersistentIdReceived` (raised per newly-harvested id) to `RustPlusFcmSocket` **and** `IRustPlusFcmSocket`. Subscribe to persist incrementally and avoid duplicate notifications after a restart (not just a reconnect).
- **Stopped clearing the caller's set on login-response** — the caller now owns its lifecycle (the ids were already replayed to the server at login; eviction/TTL is the caller's documented responsibility).
- Sample, docs, and the `PersistentIds` concurrency/safe-read contract documented.

### 2. Unified notification hierarchy — every event carries ServerId + PersistentId
FCM events were inconsistent: pairing events were wrapped in `Notification<T>`, but the alarm was a bare `AlarmEvent` that re-implemented `ServerId` itself — and no event payload carried the `PersistentId` to correlate against the harvested set.

```
NotificationBase            // ServerId + PersistentId — universal envelope
 ├─ Notification<T>         // + PlayerId, PlayerToken, Data — pairing
 └─ AlarmNotification       // + Title, Message — alarms (no player context)
```

- `NotificationBase` (abstract) carries `ServerId` + `PersistentId`; `Notification<T>` derives it; new `AlarmNotification : NotificationBase` **replaces** the bare `AlarmEvent` (alarms carry no player context — the server sends `PlayerId=0`/`PlayerToken=null`, so a dedicated type avoids meaningless fields).
- `PersistentId` is threaded from `ParseNotification` through every mapper, so **all** typed events (pairing + alarm) now expose it for correlation with `PersistentIdReceived`.

## ⚠️ Breaking changes
- `OnAlarmTriggered` payload: `EventHandler<AlarmEvent?>?` → `EventHandler<AlarmNotification?>?` (class + `IRustPlusFcm`).
- `AlarmEvent` record removed; use `AlarmNotification` (still has `Title`/`Message`, now also `ServerId` + `PersistentId`).
- `MessageDataToEventModel.ToAlarmEvent()` → `ToAlarmNotification(Guid serverId, string? persistentId)`.
- `Notification<T>` now derives `NotificationBase` and gains `PersistentId` (additive for existing consumers; `ServerId` is now inherited).

## Test plan
- [x] Full solution builds: 0 warnings / 0 errors (strict analyzers, TreatWarningsAsErrors).
- [x] Entire suite passes on **both** TFM hosts (net8.0 = netstandard2.0 build, net10.0); FCM 96/96.
- [x] Coverage gate PASS: line 97.26% / branch 93.71% (≥95/≥90); changed mappers/helpers at 100/100.
- [x] Critical invariant verified: `AlarmNotification` is built directly, never via `BuildGenericOutput` — an alarm's null `PlayerToken` can never reach the `int.Parse`.
- [x] Pre-push ReSharper format check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)