### PR TITLE
beta.4: full AppMarker surface, new marker types, no-throw dispatch

### DIFF
--- a/docs/articles/rustplus-client.md
+++ b/docs/articles/rustplus-client.md
@@ -75,7 +75,7 @@ else
 | `GetInfoAsync()` | `Response<ServerInfo?>` | Name, player counts, map size, wipe time, logo URL. |
 | `GetTimeAsync()` | `Response<TimeInfo?>` | In-game time, sunrise/sunset, day-length parameters. |
 | `GetMapAsync()` | `Response<ServerMap?>` | Map image bytes and monument list. Large response — cache it. |
-| `GetMapMarkersAsync()` | `Response<MapMarkers?>` | Players, cargo ship, patrol heli, vending machines, CH-47, events. |
+| `GetMapMarkersAsync()` | `Response<MapMarkers?>` | Players, cargo ship, patrol heli, vending machines, CH-47, events. Unrecognized marker types land in UnknownMarkers instead of failing. |
 
 ### Entities (smart devices)
 

--- a/src/RustPlusApi/Data/MapMarkers.cs
+++ b/src/RustPlusApi/Data/MapMarkers.cs
@@ -2,31 +2,37 @@ using RustPlusApi.Data.Markers;
 
 namespace RustPlusApi.Data;
 
-/// <summary>Collects all map markers returned by the Rust+ server, keyed by marker ID.</summary>
-/// <remarks>
-/// Marker type 2 (Explosions), type 6 (Crates) and type 7 (GenericRadius) are not emitted by the
-/// current Rust+ API and therefore have no corresponding dictionary here.
-/// </remarks>
+/// <summary>Collects all map markers returned by the Rust+ server, keyed by marker ID.
+/// Markers of a type this library does not recognize land in <see cref="UnknownMarkers"/>.</summary>
 public sealed record MapMarkers
 {
-    /// <summary>Markers of unknown or unrecognised type, keyed by marker ID.</summary>
-    public Dictionary<ulong, UnknownMarker> UnknownMarkers { get; init; } = [];
-
-    /// <summary>Player position markers, keyed by marker ID.</summary>
-    public Dictionary<ulong, PlayerMarker> PlayerMarkers { get; init; } = [];
-
-    /// <summary>Vending machine markers, keyed by marker ID.</summary>
-    public Dictionary<ulong, VendingMachineMarker> VendingMachineMarkers { get; init; } = [];
+    /// <summary>Cargo ship markers, keyed by marker ID.</summary>
+    public Dictionary<ulong, CargoShipMarker> CargoShipMarkers { get; init; } = [];
 
     /// <summary>CH-47 (Chinook helicopter) markers, keyed by marker ID.</summary>
     public Dictionary<ulong, Ch47Marker> Ch47Markers { get; init; } = [];
 
-    /// <summary>Cargo ship markers, keyed by marker ID.</summary>
-    public Dictionary<ulong, CargoShipMarker> CargoShipMarkers { get; init; } = [];
+    /// <summary>Locked crate markers, keyed by marker ID.</summary>
+    public Dictionary<ulong, CrateMarker> CrateMarkers { get; init; } = [];
+
+    /// <summary>Explosion markers, keyed by marker ID.</summary>
+    public Dictionary<ulong, ExplosionMarker> ExplosionMarkers { get; init; } = [];
+
+    /// <summary>Generic radius overlay markers, keyed by marker ID.</summary>
+    public Dictionary<ulong, GenericRadiusMarker> GenericRadiusMarkers { get; init; } = [];
 
     /// <summary>Patrol helicopter markers, keyed by marker ID.</summary>
     public Dictionary<ulong, PatrolHelicopterMarker> PatrolHelicopterMarkers { get; init; } = [];
 
+    /// <summary>Player position markers, keyed by marker ID.</summary>
+    public Dictionary<ulong, PlayerMarker> PlayerMarkers { get; init; } = [];
+
     /// <summary>Travelling vendor markers, keyed by marker ID.</summary>
     public Dictionary<ulong, TravellingVendorMarker> TravellingVendorMarkers { get; init; } = [];
+
+    /// <summary>Markers of unknown or unrecognised type (full raw surface), keyed by marker ID.</summary>
+    public Dictionary<ulong, UnknownMarker> UnknownMarkers { get; init; } = [];
+
+    /// <summary>Vending machine markers, keyed by marker ID.</summary>
+    public Dictionary<ulong, VendingMachineMarker> VendingMachineMarkers { get; init; } = [];
 }

--- a/src/RustPlusApi/Data/MarkerColor.cs
+++ b/src/RustPlusApi/Data/MarkerColor.cs
@@ -1,0 +1,17 @@
+namespace RustPlusApi.Data;
+
+/// <summary>Color carried by a map marker, mapped from the server's <c>Vector4</c> (RGBA components, 0–1).</summary>
+public sealed record MarkerColor
+{
+    /// <summary>Red component (0–1), or <see langword="null"/> when the server omitted it.</summary>
+    public float? R { get; init; }
+
+    /// <summary>Green component (0–1), or <see langword="null"/> when the server omitted it.</summary>
+    public float? G { get; init; }
+
+    /// <summary>Blue component (0–1), or <see langword="null"/> when the server omitted it.</summary>
+    public float? B { get; init; }
+
+    /// <summary>Alpha component (0–1), or <see langword="null"/> when the server omitted it.</summary>
+    public float? A { get; init; }
+}

--- a/src/RustPlusApi/Data/Markers/CargoShipMarker.cs
+++ b/src/RustPlusApi/Data/Markers/CargoShipMarker.cs
@@ -1,4 +1,9 @@
 namespace RustPlusApi.Data.Markers;
 
 /// <summary>Map marker for the Cargo Ship event.</summary>
-public sealed record CargoShipMarker : Marker;
+public sealed record CargoShipMarker : Marker
+{
+    /// <summary>Heading in degrees (0–360) as sent by the server, or <see langword="null"/> when omitted.
+    /// Consumers own the render transform (the official app draws icons rotated by <c>-Rotation</c> on a Y-down canvas).</summary>
+    public float? Rotation { get; init; }
+}

--- a/src/RustPlusApi/Data/Markers/Ch47Marker.cs
+++ b/src/RustPlusApi/Data/Markers/Ch47Marker.cs
@@ -1,4 +1,9 @@
 namespace RustPlusApi.Data.Markers;
 
 /// <summary>Map marker for the CH-47 Chinook helicopter.</summary>
-public sealed record Ch47Marker : Marker;
+public sealed record Ch47Marker : Marker
+{
+    /// <summary>Heading in degrees (0–360) as sent by the server, or <see langword="null"/> when omitted.
+    /// Consumers own the render transform (the official app draws icons rotated by <c>-Rotation</c> on a Y-down canvas).</summary>
+    public float? Rotation { get; init; }
+}

--- a/src/RustPlusApi/Data/Markers/CrateMarker.cs
+++ b/src/RustPlusApi/Data/Markers/CrateMarker.cs
@@ -1,0 +1,4 @@
+namespace RustPlusApi.Data.Markers;
+
+/// <summary>Map marker for a locked crate (Rust+ marker type 6).</summary>
+public sealed record CrateMarker : Marker;

--- a/src/RustPlusApi/Data/Markers/ExplosionMarker.cs
+++ b/src/RustPlusApi/Data/Markers/ExplosionMarker.cs
@@ -1,0 +1,4 @@
+namespace RustPlusApi.Data.Markers;
+
+/// <summary>Map marker for an explosion event (Rust+ marker type 2).</summary>
+public sealed record ExplosionMarker : Marker;

--- a/src/RustPlusApi/Data/Markers/GenericRadiusMarker.cs
+++ b/src/RustPlusApi/Data/Markers/GenericRadiusMarker.cs
@@ -1,0 +1,17 @@
+namespace RustPlusApi.Data.Markers;
+
+/// <summary>Map marker for a generic radius overlay (Rust+ marker type 7), carrying its styling.</summary>
+public sealed record GenericRadiusMarker : Marker
+{
+    /// <summary>Opacity of the overlay (0–1), or <see langword="null"/> when omitted.</summary>
+    public float? Alpha { get; init; }
+
+    /// <summary>Primary color of the overlay, or <see langword="null"/> when omitted.</summary>
+    public MarkerColor? Color1 { get; init; }
+
+    /// <summary>Secondary color of the overlay, or <see langword="null"/> when omitted.</summary>
+    public MarkerColor? Color2 { get; init; }
+
+    /// <summary>Radius of the overlay circle in world units, or <see langword="null"/> when omitted.</summary>
+    public float? Radius { get; init; }
+}

--- a/src/RustPlusApi/Data/Markers/PatrolHelicopterMarker.cs
+++ b/src/RustPlusApi/Data/Markers/PatrolHelicopterMarker.cs
@@ -1,4 +1,9 @@
 namespace RustPlusApi.Data.Markers;
 
 /// <summary>Map marker for the Patrol Helicopter event.</summary>
-public sealed record PatrolHelicopterMarker : Marker;
+public sealed record PatrolHelicopterMarker : Marker
+{
+    /// <summary>Heading in degrees (0–360) as sent by the server, or <see langword="null"/> when omitted.
+    /// Consumers own the render transform (the official app draws icons rotated by <c>-Rotation</c> on a Y-down canvas).</summary>
+    public float? Rotation { get; init; }
+}

--- a/src/RustPlusApi/Data/Markers/PlayerMarker.cs
+++ b/src/RustPlusApi/Data/Markers/PlayerMarker.cs
@@ -3,9 +3,9 @@ namespace RustPlusApi.Data.Markers;
 /// <summary>Map marker for a player's current position.</summary>
 public sealed record PlayerMarker : Marker
 {
-    /// <summary>In-game display name of the player.</summary>
+    /// <summary>In-game display name of the player, or <see langword="null"/> when omitted.</summary>
     public string? Name { get; init; }
 
-    /// <summary>Steam64 ID of the player.</summary>
+    /// <summary>Steam64 ID of the player, or <see langword="null"/> when omitted.</summary>
     public ulong? SteamId { get; init; }
 }

--- a/src/RustPlusApi/Data/Markers/PlayerMarker.cs
+++ b/src/RustPlusApi/Data/Markers/PlayerMarker.cs
@@ -6,10 +6,6 @@ public sealed record PlayerMarker : Marker
     /// <summary>In-game display name of the player.</summary>
     public string? Name { get; init; }
 
-    /// <summary>Heading in degrees (0–360) as sent by the server, or <see langword="null"/> when omitted.
-    /// Consumers own the render transform (the official app draws icons rotated by <c>-Rotation</c> on a Y-down canvas).</summary>
-    public float? Rotation { get; init; }
-
     /// <summary>Steam64 ID of the player.</summary>
     public ulong? SteamId { get; init; }
 }

--- a/src/RustPlusApi/Data/Markers/PlayerMarker.cs
+++ b/src/RustPlusApi/Data/Markers/PlayerMarker.cs
@@ -6,6 +6,10 @@ public sealed record PlayerMarker : Marker
     /// <summary>In-game display name of the player.</summary>
     public string? Name { get; init; }
 
+    /// <summary>Heading in degrees (0–360) as sent by the server, or <see langword="null"/> when omitted.
+    /// Consumers own the render transform (the official app draws icons rotated by <c>-Rotation</c> on a Y-down canvas).</summary>
+    public float? Rotation { get; init; }
+
     /// <summary>Steam64 ID of the player.</summary>
     public ulong? SteamId { get; init; }
 }

--- a/src/RustPlusApi/Data/Markers/TravellingVendorMarker.cs
+++ b/src/RustPlusApi/Data/Markers/TravellingVendorMarker.cs
@@ -1,4 +1,9 @@
 namespace RustPlusApi.Data.Markers;
 
 /// <summary>Map marker for the Travelling Vendor (Rust+ marker type 9).</summary>
-public sealed record TravellingVendorMarker : Marker;
+public sealed record TravellingVendorMarker : Marker
+{
+    /// <summary>Heading in degrees (0–360) as sent by the server, or <see langword="null"/> when omitted.
+    /// Consumers own the render transform (the official app draws icons rotated by <c>-Rotation</c> on a Y-down canvas).</summary>
+    public float? Rotation { get; init; }
+}

--- a/src/RustPlusApi/Data/Markers/UnknownMarker.cs
+++ b/src/RustPlusApi/Data/Markers/UnknownMarker.cs
@@ -1,4 +1,33 @@
 namespace RustPlusApi.Data.Markers;
 
-/// <summary>Marker with an unrecognised or unsupported type.</summary>
-public sealed record UnknownMarker : Marker;
+/// <summary>Marker with an unrecognised or unsupported type. Carries the full raw field surface of
+/// the protobuf marker so nothing the server sends for a new marker type is dropped.</summary>
+public sealed record UnknownMarker : Marker
+{
+    /// <summary>Opacity (0–1), or <see langword="null"/> when omitted.</summary>
+    public float? Alpha { get; init; }
+
+    /// <summary>Primary color, or <see langword="null"/> when omitted.</summary>
+    public MarkerColor? Color1 { get; init; }
+
+    /// <summary>Secondary color, or <see langword="null"/> when omitted.</summary>
+    public MarkerColor? Color2 { get; init; }
+
+    /// <summary><see langword="true"/> if the marker reports being out of stock, or <see langword="null"/> when omitted.</summary>
+    public bool? IsOutOfStock { get; init; }
+
+    /// <summary>Display name carried by the marker, or <see langword="null"/> when omitted.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Radius in world units, or <see langword="null"/> when omitted.</summary>
+    public float? Radius { get; init; }
+
+    /// <summary>Heading in degrees (0–360) as sent by the server, or <see langword="null"/> when omitted.</summary>
+    public float? Rotation { get; init; }
+
+    /// <summary>Steam64 ID carried by the marker, or <see langword="null"/> when omitted.</summary>
+    public ulong? SteamId { get; init; }
+
+    /// <summary>Sell orders carried by the marker; empty when none were sent.</summary>
+    public IEnumerable<VendingMachineItem>? VendingMachineItems { get; init; }
+}

--- a/src/RustPlusApi/Data/Markers/UnknownMarker.cs
+++ b/src/RustPlusApi/Data/Markers/UnknownMarker.cs
@@ -22,6 +22,10 @@ public sealed record UnknownMarker : Marker
     /// <summary>Radius in world units, or <see langword="null"/> when omitted.</summary>
     public float? Radius { get; init; }
 
+    /// <summary>Numeric marker type as sent by the server — a value this library version does not
+    /// recognize (or <c>Undefined</c> = 0), preserved so consumers can distinguish and log new types.</summary>
+    public int? RawType { get; init; }
+
     /// <summary>Heading in degrees (0–360) as sent by the server, or <see langword="null"/> when omitted.</summary>
     public float? Rotation { get; init; }
 

--- a/src/RustPlusApi/Data/Markers/VendingMachineMarker.cs
+++ b/src/RustPlusApi/Data/Markers/VendingMachineMarker.cs
@@ -3,10 +3,10 @@ namespace RustPlusApi.Data.Markers;
 /// <summary>Map marker for a vending machine, including its current sell orders.</summary>
 public sealed record VendingMachineMarker : Marker
 {
-    /// <summary>Name of the vending machine (set by its owner).</summary>
+    /// <summary>Name of the vending machine (set by its owner), or <see langword="null"/> when omitted.</summary>
     public string? Name { get; init; }
 
-    /// <summary><see langword="true"/> if the vending machine has no stock remaining.</summary>
+    /// <summary><see langword="true"/> if the vending machine has no stock remaining, or <see langword="null"/> when the server did not report it.</summary>
     public bool? IsOutOfStock { get; init; }
 
     /// <summary>Active sell orders in the vending machine.</summary>

--- a/src/RustPlusApi/Data/ServerMap.cs
+++ b/src/RustPlusApi/Data/ServerMap.cs
@@ -3,15 +3,25 @@ using System.Drawing;
 namespace RustPlusApi.Data;
 
 /// <summary>Server map image and monument list returned by <c>GetMapAsync</c>.</summary>
+/// <remarks>
+/// <para><see cref="Width"/>, <see cref="Height"/> and <see cref="OceanMargin"/> are pixel
+/// measurements of <see cref="JpgImage"/> — only marker/monument coordinates and
+/// <c>ServerInfo.MapSize</c> are world units. The canonical world→pixel transform (world origin
+/// bottom-left, image origin top-left — hence the Y flip):</para>
+/// <code>
+/// px = worldX * ((Width  - 2 * OceanMargin) / ServerInfo.MapSize) + OceanMargin
+/// py = Height - (worldY * ((Height - 2 * OceanMargin) / ServerInfo.MapSize) + OceanMargin)
+/// </code>
+/// </remarks>
 public sealed record ServerMap
 {
-    /// <summary>Height of the map in game units.</summary>
+    /// <summary>Height of <see cref="JpgImage"/> in pixels.</summary>
     public uint? Height { get; init; }
 
-    /// <summary>Width of the map in game units.</summary>
+    /// <summary>Width of <see cref="JpgImage"/> in pixels.</summary>
     public uint? Width { get; init; }
 
-    /// <summary>Width of the ocean margin around the playable area, in game units.</summary>
+    /// <summary>Width of the ocean border baked into <see cref="JpgImage"/>, in pixels.</summary>
     public int? OceanMargin { get; init; }
 
     /// <summary>Background colour of the map (ocean colour).</summary>

--- a/src/RustPlusApi/Extensions/AppMapMarkerToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMapMarkerToModel.cs
@@ -1,77 +1,57 @@
 using RustPlusApi.Data;
 using RustPlusApi.Data.Markers;
 using RustPlusContracts;
-using System.Diagnostics;
 
 namespace RustPlusApi.Extensions;
 
 /// <summary>Mapping extensions from protobuf map-marker messages to model types.</summary>
 public static class AppMapMarkerToModel
 {
-    /// <summary>Maps an <see cref="AppMapMarkers"/> response to a <see cref="MapMarkers"/> model, routing each marker to its typed dictionary.</summary>
+    /// <summary>Maps an <see cref="AppMapMarkers"/> response to a <see cref="MapMarkers"/> model, routing each
+    /// marker to its typed dictionary. Markers with an unrecognized type fall back to
+    /// <see cref="MapMarkers.UnknownMarkers"/> so a game update cannot break the read.</summary>
     /// <param name="appMapMarker">The protobuf map markers response.</param>
-    /// <exception cref="ArgumentException">Thrown when a marker has an unrecognized type.</exception>
     public static MapMarkers ToMapMarkers(this AppMapMarkers appMapMarker)
     {
-        Dictionary<ulong, UnknownMarker> unknownMarkers = [];
-        Dictionary<ulong, PlayerMarker> playerMarkers = [];
-        // 2. Explosions: doesn't appear anymore in the API
-        Dictionary<ulong, VendingMachineMarker> vendingMachineMarkers = [];
-        Dictionary<ulong, Ch47Marker> ch47Markers = [];
-        Dictionary<ulong, CargoShipMarker> cargoShipMarkers = [];
-        // 6. Crates: doesn't appear anymore in the API
-        // 7. GenericRadius: I don't know what is this
-        Dictionary<ulong, PatrolHelicopterMarker> patrolHelicopterMarkers = [];
-        Dictionary<ulong, TravellingVendorMarker> travellingVendorMarkers = [];
+        var result = new MapMarkers();
 
         foreach (var marker in appMapMarker.Markers)
         {
             switch (marker.Type)
             {
-                case AppMarkerType.Undefined:
-                    unknownMarkers.Add(marker.Id, marker.ToUnknownMarker());
-                    break;
                 case AppMarkerType.Player:
-                    playerMarkers.Add(marker.Id, marker.ToPlayerMarker());
+                    result.PlayerMarkers.Add(marker.Id, marker.ToPlayerMarker());
                     break;
                 case AppMarkerType.Explosion:
-                    Debug.WriteLine("WTF!! Facepunch acknowledge their mistake?");
+                    result.ExplosionMarkers.Add(marker.Id, marker.ToExplosionMarker());
                     break;
                 case AppMarkerType.VendingMachine:
-                    vendingMachineMarkers.Add(marker.Id, marker.ToVendingMachineMarker());
+                    result.VendingMachineMarkers.Add(marker.Id, marker.ToVendingMachineMarker());
                     break;
                 case AppMarkerType.Ch47:
-                    ch47Markers.Add(marker.Id, marker.ToCh47Marker());
+                    result.Ch47Markers.Add(marker.Id, marker.ToCh47Marker());
                     break;
                 case AppMarkerType.CargoShip:
-                    cargoShipMarkers.Add(marker.Id, marker.ToCargoShipMarker());
+                    result.CargoShipMarkers.Add(marker.Id, marker.ToCargoShipMarker());
                     break;
                 case AppMarkerType.Crate:
-                    Debug.WriteLine("WTF!! Facepunch acknowledge their mistake?");
+                    result.CrateMarkers.Add(marker.Id, marker.ToCrateMarker());
                     break;
                 case AppMarkerType.GenericRadius:
-                    Debug.WriteLine($"What the fuck is that?\n{marker}");
+                    result.GenericRadiusMarkers.Add(marker.Id, marker.ToGenericRadiusMarker());
                     break;
                 case AppMarkerType.PatrolHelicopter:
-                    patrolHelicopterMarkers.Add(marker.Id, marker.ToPatrolHelicopterMarker());
+                    result.PatrolHelicopterMarkers.Add(marker.Id, marker.ToPatrolHelicopterMarker());
                     break;
                 case AppMarkerType.TravellingVendor:
-                    travellingVendorMarkers.Add(marker.Id, marker.ToTravellingVendorMarker());
+                    result.TravellingVendorMarkers.Add(marker.Id, marker.ToTravellingVendorMarker());
                     break;
                 default:
-                    throw new ArgumentException($"Unknown marker type: {marker.Type}");
+                    result.UnknownMarkers.Add(marker.Id, marker.ToUnknownMarker());
+                    break;
             }
         }
 
-        return new MapMarkers
-        {
-            UnknownMarkers = unknownMarkers,
-            PlayerMarkers = playerMarkers,
-            VendingMachineMarkers = vendingMachineMarkers,
-            Ch47Markers = ch47Markers,
-            CargoShipMarkers = cargoShipMarkers,
-            PatrolHelicopterMarkers = patrolHelicopterMarkers,
-            TravellingVendorMarkers = travellingVendorMarkers,
-        };
+        return result;
     }
 }

--- a/src/RustPlusApi/Extensions/AppMapMarkerToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMapMarkerToModel.cs
@@ -46,6 +46,7 @@ public static class AppMapMarkerToModel
                 case AppMarkerType.TravellingVendor:
                     result.TravellingVendorMarkers.Add(marker.Id, marker.ToTravellingVendorMarker());
                     break;
+                // AppMarkerType.Undefined and unrecognized future types intentionally route here.
                 default:
                     result.UnknownMarkers.Add(marker.Id, marker.ToUnknownMarker());
                     break;

--- a/src/RustPlusApi/Extensions/AppMarkerToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMarkerToModel.cs
@@ -10,13 +10,24 @@ namespace RustPlusApi.Extensions;
 /// <summary>Mapping extensions from a protobuf <see cref="AppMarker"/> to typed marker model records.</summary>
 public static class AppMarkerToModel
 {
-    /// <summary>Maps a marker to an <see cref="UnknownMarker"/>.</summary>
+    /// <summary>Maps a marker to an <see cref="UnknownMarker"/>, passing through the full raw field surface.</summary>
     /// <param name="marker">The protobuf map marker.</param>
     public static UnknownMarker ToUnknownMarker(this AppMarker marker)
     {
         return new UnknownMarker
         {
-            Id = marker.Id, X = marker.X, Y = marker.Y
+            Id = marker.Id,
+            X = marker.X,
+            Y = marker.Y,
+            Name = marker.ShouldSerializeName() ? marker.Name : null,
+            SteamId = marker.ShouldSerializeSteamId() ? marker.SteamId : null,
+            Rotation = marker.ShouldSerializeRotation() ? marker.Rotation : null,
+            Radius = marker.ShouldSerializeRadius() ? marker.Radius : null,
+            Color1 = marker.Color1?.ToMarkerColor(),
+            Color2 = marker.Color2?.ToMarkerColor(),
+            Alpha = marker.ShouldSerializeAlpha() ? marker.Alpha : null,
+            IsOutOfStock = marker.ShouldSerializeOutOfStock() ? marker.OutOfStock : null,
+            VendingMachineItems = marker.SellOrders.ToVendingMachineItems()
         };
     }
 

--- a/src/RustPlusApi/Extensions/AppMarkerToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMarkerToModel.cs
@@ -128,6 +128,42 @@ public static class AppMarkerToModel
         };
     }
 
+    /// <summary>Maps a marker to an <see cref="ExplosionMarker"/>.</summary>
+    /// <param name="marker">The protobuf map marker.</param>
+    public static ExplosionMarker ToExplosionMarker(this AppMarker marker)
+    {
+        return new ExplosionMarker
+        {
+            Id = marker.Id, X = marker.X, Y = marker.Y
+        };
+    }
+
+    /// <summary>Maps a marker to a <see cref="CrateMarker"/>.</summary>
+    /// <param name="marker">The protobuf map marker.</param>
+    public static CrateMarker ToCrateMarker(this AppMarker marker)
+    {
+        return new CrateMarker
+        {
+            Id = marker.Id, X = marker.X, Y = marker.Y
+        };
+    }
+
+    /// <summary>Maps a marker to a <see cref="GenericRadiusMarker"/>, including its styling fields.</summary>
+    /// <param name="marker">The protobuf map marker.</param>
+    public static GenericRadiusMarker ToGenericRadiusMarker(this AppMarker marker)
+    {
+        return new GenericRadiusMarker
+        {
+            Id = marker.Id,
+            X = marker.X,
+            Y = marker.Y,
+            Radius = marker.ShouldSerializeRadius() ? marker.Radius : null,
+            Color1 = marker.Color1?.ToMarkerColor(),
+            Color2 = marker.Color2?.ToMarkerColor(),
+            Alpha = marker.ShouldSerializeAlpha() ? marker.Alpha : null
+        };
+    }
+
     /// <summary>Maps a protobuf <see cref="Vector4"/> marker color to a <see cref="MarkerColor"/>.</summary>
     /// <param name="color">The protobuf color vector (RGBA components).</param>
     public static MarkerColor ToMarkerColor(this Vector4 color)

--- a/src/RustPlusApi/Extensions/AppMarkerToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMarkerToModel.cs
@@ -29,8 +29,9 @@ public static class AppMarkerToModel
             Id = marker.Id,
             X = marker.X,
             Y = marker.Y,
-            Name = marker.Name,
-            SteamId = marker.SteamId
+            Name = marker.ShouldSerializeName() ? marker.Name : null,
+            Rotation = marker.ShouldSerializeRotation() ? marker.Rotation : null,
+            SteamId = marker.ShouldSerializeSteamId() ? marker.SteamId : null
         };
     }
 
@@ -43,8 +44,8 @@ public static class AppMarkerToModel
             Id = marker.Id,
             X = marker.X,
             Y = marker.Y,
-            Name = marker.Name,
-            IsOutOfStock = marker.OutOfStock,
+            Name = marker.ShouldSerializeName() ? marker.Name : null,
+            IsOutOfStock = marker.ShouldSerializeOutOfStock() ? marker.OutOfStock : null,
             VendingMachineItems = marker.SellOrders.ToVendingMachineItems()
         };
     }
@@ -81,7 +82,10 @@ public static class AppMarkerToModel
     {
         return new Ch47Marker
         {
-            Id = marker.Id, X = marker.X, Y = marker.Y
+            Id = marker.Id,
+            X = marker.X,
+            Y = marker.Y,
+            Rotation = marker.ShouldSerializeRotation() ? marker.Rotation : null
         };
     }
 
@@ -91,7 +95,10 @@ public static class AppMarkerToModel
     {
         return new CargoShipMarker
         {
-            Id = marker.Id, X = marker.X, Y = marker.Y
+            Id = marker.Id,
+            X = marker.X,
+            Y = marker.Y,
+            Rotation = marker.ShouldSerializeRotation() ? marker.Rotation : null
         };
     }
 
@@ -101,7 +108,10 @@ public static class AppMarkerToModel
     {
         return new PatrolHelicopterMarker
         {
-            Id = marker.Id, X = marker.X, Y = marker.Y
+            Id = marker.Id,
+            X = marker.X,
+            Y = marker.Y,
+            Rotation = marker.ShouldSerializeRotation() ? marker.Rotation : null
         };
     }
 
@@ -111,7 +121,10 @@ public static class AppMarkerToModel
     {
         return new TravellingVendorMarker
         {
-            Id = marker.Id, X = marker.X, Y = marker.Y
+            Id = marker.Id,
+            X = marker.X,
+            Y = marker.Y,
+            Rotation = marker.ShouldSerializeRotation() ? marker.Rotation : null
         };
     }
 

--- a/src/RustPlusApi/Extensions/AppMarkerToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMarkerToModel.cs
@@ -19,6 +19,7 @@ public static class AppMarkerToModel
             Id = marker.Id,
             X = marker.X,
             Y = marker.Y,
+            RawType = (int)marker.Type,
             Name = marker.ShouldSerializeName() ? marker.Name : null,
             SteamId = marker.ShouldSerializeSteamId() ? marker.SteamId : null,
             Rotation = marker.ShouldSerializeRotation() ? marker.Rotation : null,

--- a/src/RustPlusApi/Extensions/AppMarkerToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMarkerToModel.cs
@@ -41,7 +41,6 @@ public static class AppMarkerToModel
             X = marker.X,
             Y = marker.Y,
             Name = marker.ShouldSerializeName() ? marker.Name : null,
-            Rotation = marker.ShouldSerializeRotation() ? marker.Rotation : null,
             SteamId = marker.ShouldSerializeSteamId() ? marker.SteamId : null
         };
     }

--- a/src/RustPlusApi/Extensions/AppMarkerToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMarkerToModel.cs
@@ -114,4 +114,17 @@ public static class AppMarkerToModel
             Id = marker.Id, X = marker.X, Y = marker.Y
         };
     }
+
+    /// <summary>Maps a protobuf <see cref="Vector4"/> marker color to a <see cref="MarkerColor"/>.</summary>
+    /// <param name="color">The protobuf color vector (RGBA components).</param>
+    public static MarkerColor ToMarkerColor(this Vector4 color)
+    {
+        return new MarkerColor
+        {
+            R = color.ShouldSerializeX() ? color.X : null,
+            G = color.ShouldSerializeY() ? color.Y : null,
+            B = color.ShouldSerializeZ() ? color.Z : null,
+            A = color.ShouldSerializeW() ? color.W : null
+        };
+    }
 }

--- a/tests/RustPlusApi.IntegrationTests/EntityClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/EntityClientTests.cs
@@ -333,4 +333,68 @@ public class EntityClientTests
         var message = Assert.Single(response.Data!.Messages!);
         Assert.Equal("team chat fixture", message.Message);
     }
+
+    [Fact]
+    public async Task GetMapMarkersAsync_MixedAndUnrecognizedTypes_AllRoutedWithoutThrow()
+    {
+        await using var server = new MockRustPlusServer(req =>
+        {
+            var resp = new AppResponse
+            {
+                Seq = req.Seq
+            };
+            if (req.GetMapMarkers is not null)
+            {
+                var markers = new AppMapMarkers();
+                markers.Markers.Add(new AppMarker
+                {
+                    Id = 1, X = 1, Y = 1, Type = AppMarkerType.Explosion
+                });
+                markers.Markers.Add(new AppMarker
+                {
+                    Id = 2, X = 1, Y = 1, Type = AppMarkerType.Crate
+                });
+                markers.Markers.Add(new AppMarker
+                {
+                    Id = 3,
+                    X = 1,
+                    Y = 1,
+                    Type = AppMarkerType.GenericRadius,
+                    Radius = 25f,
+                    Alpha = 0.5f,
+                    Color1 = new Vector4
+                    {
+                        X = 1f, Y = 0.5f, Z = 0f, W = 1f
+                    }
+                });
+                markers.Markers.Add(new AppMarker
+                {
+                    Id = 4, X = 1, Y = 1, Type = (AppMarkerType)999
+                });
+                resp.MapMarkers = markers;
+            }
+            else
+            {
+                resp.Success = new AppSuccess();
+            }
+
+            return new AppMessage
+            {
+                Response = resp
+            };
+        });
+        server.Start();
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await client.ConnectAsync().WaitAsync(Timeout);
+
+        var response = await client.GetMapMarkersAsync().WaitAsync(Timeout);
+
+        Assert.True(response.IsSuccess);
+        Assert.True(response.Data!.ExplosionMarkers.ContainsKey(1));
+        Assert.True(response.Data.CrateMarkers.ContainsKey(2));
+        Assert.Equal(25f, response.Data.GenericRadiusMarkers[3].Radius);
+        Assert.Equal(1f, response.Data.GenericRadiusMarkers[3].Color1!.R);
+        Assert.True(response.Data.UnknownMarkers.ContainsKey(4));
+    }
 }

--- a/tests/RustPlusApi.UnitTests/MapMarkerDispatchTests.cs
+++ b/tests/RustPlusApi.UnitTests/MapMarkerDispatchTests.cs
@@ -5,8 +5,8 @@ using Xunit;
 namespace RustPlusApi.UnitTests;
 
 /// <summary>Locks the marker routing in <see cref="AppMapMarkerToModel.ToMapMarkers"/>:
-/// each type lands in the right dictionary, the no-op arms are skipped, and an unknown
-/// type throws.</summary>
+/// each type lands in the right dictionary and unrecognized types fall back to
+/// <c>UnknownMarkers</c> instead of throwing.</summary>
 public class MapMarkerDispatchTests
 {
     private static AppMapMarkers With(params (ulong id, AppMarkerType type)[] markers)
@@ -37,7 +37,10 @@ public class MapMarkerDispatchTests
             (4, AppMarkerType.Ch47),
             (5, AppMarkerType.CargoShip),
             (6, AppMarkerType.PatrolHelicopter),
-            (7, AppMarkerType.TravellingVendor)).ToMapMarkers();
+            (7, AppMarkerType.TravellingVendor),
+            (8, AppMarkerType.Explosion),
+            (9, AppMarkerType.Crate),
+            (10, AppMarkerType.GenericRadius)).ToMapMarkers();
 
         Assert.True(result.UnknownMarkers.ContainsKey(1));
         Assert.True(result.PlayerMarkers.ContainsKey(2));
@@ -46,25 +49,17 @@ public class MapMarkerDispatchTests
         Assert.True(result.CargoShipMarkers.ContainsKey(5));
         Assert.True(result.PatrolHelicopterMarkers.ContainsKey(6));
         Assert.True(result.TravellingVendorMarkers.ContainsKey(7));
-    }
-
-    [Theory]
-    [InlineData(AppMarkerType.Explosion)]
-    [InlineData(AppMarkerType.Crate)]
-    [InlineData(AppMarkerType.GenericRadius)]
-    public void ToMapMarkers_IgnoresNoOpMarkerTypes(AppMarkerType type)
-    {
-        var result = With((1, type)).ToMapMarkers();
-
-        Assert.Empty(result.UnknownMarkers);
-        Assert.Empty(result.PlayerMarkers);
-        Assert.Empty(result.VendingMachineMarkers);
+        Assert.True(result.ExplosionMarkers.ContainsKey(8));
+        Assert.True(result.CrateMarkers.ContainsKey(9));
+        Assert.True(result.GenericRadiusMarkers.ContainsKey(10));
     }
 
     [Fact]
-    public void ToMapMarkers_UnknownType_Throws()
+    public void ToMapMarkers_UnrecognizedType_FallsBackToUnknown()
     {
-        var markers = With((1, (AppMarkerType)999));
-        Assert.Throws<ArgumentException>(markers.ToMapMarkers);
+        var result = With((1, (AppMarkerType)999)).ToMapMarkers();
+
+        var marker = Assert.Single(result.UnknownMarkers).Value;
+        Assert.Equal(1u, marker.Id);
     }
 }

--- a/tests/RustPlusApi.UnitTests/MapMarkerDispatchTests.cs
+++ b/tests/RustPlusApi.UnitTests/MapMarkerDispatchTests.cs
@@ -61,5 +61,6 @@ public class MapMarkerDispatchTests
 
         var marker = Assert.Single(result.UnknownMarkers).Value;
         Assert.Equal(1u, marker.Id);
+        Assert.Equal(999, marker.RawType);
     }
 }

--- a/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
@@ -125,4 +125,61 @@ public class MarkerMapperTests
         Assert.Null(m.B);
         Assert.Null(m.A);
     }
+
+    private static float? MapRotation(AppMarker marker, AppMarkerType type) => type switch
+    {
+        AppMarkerType.Player => marker.ToPlayerMarker().Rotation,
+        AppMarkerType.Ch47 => marker.ToCh47Marker().Rotation,
+        AppMarkerType.CargoShip => marker.ToCargoShipMarker().Rotation,
+        AppMarkerType.PatrolHelicopter => marker.ToPatrolHelicopterMarker().Rotation,
+        _ => marker.ToTravellingVendorMarker().Rotation,
+    };
+
+    [Theory]
+    [InlineData(AppMarkerType.Player)]
+    [InlineData(AppMarkerType.Ch47)]
+    [InlineData(AppMarkerType.CargoShip)]
+    [InlineData(AppMarkerType.PatrolHelicopter)]
+    [InlineData(AppMarkerType.TravellingVendor)]
+    public void MovingMarkers_RotationPresent_MapsValue(AppMarkerType type)
+    {
+        var marker = Marker(type);
+        marker.Rotation = 123.5f;
+
+        Assert.Equal(123.5f, MapRotation(marker, type));
+    }
+
+    [Theory]
+    [InlineData(AppMarkerType.Player)]
+    [InlineData(AppMarkerType.Ch47)]
+    [InlineData(AppMarkerType.CargoShip)]
+    [InlineData(AppMarkerType.PatrolHelicopter)]
+    [InlineData(AppMarkerType.TravellingVendor)]
+    public void MovingMarkers_RotationAbsent_MapsNull(AppMarkerType type)
+        => Assert.Null(MapRotation(Marker(type), type));
+
+    [Fact]
+    public void ToPlayerMarker_UnsetOptionals_AreNull()
+    {
+        var m = new AppMarker
+        {
+            Id = 1, X = 0, Y = 0, Type = AppMarkerType.Player
+        }.ToPlayerMarker();
+
+        Assert.Null(m.SteamId);
+        Assert.Null(m.Name);
+        Assert.Null(m.Rotation);
+    }
+
+    [Fact]
+    public void ToVendingMachineMarker_UnsetOptionals_AreNull()
+    {
+        var m = new AppMarker
+        {
+            Id = 1, X = 0, Y = 0, Type = AppMarkerType.VendingMachine
+        }.ToVendingMachineMarker();
+
+        Assert.Null(m.Name);
+        Assert.Null(m.IsOutOfStock);
+    }
 }

--- a/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
@@ -182,4 +182,58 @@ public class MarkerMapperTests
         Assert.Null(m.Name);
         Assert.Null(m.IsOutOfStock);
     }
+
+    [Fact]
+    public void ToExplosionMarker_MapsIdAndCoords()
+    {
+        var m = Marker(AppMarkerType.Explosion).ToExplosionMarker();
+
+        Assert.Equal(7u, m.Id);
+        Assert.Equal(1.5f, m.X);
+        Assert.Equal(2.5f, m.Y);
+    }
+
+    [Fact]
+    public void ToCrateMarker_MapsIdAndCoords()
+    {
+        var m = Marker(AppMarkerType.Crate).ToCrateMarker();
+
+        Assert.Equal(7u, m.Id);
+        Assert.Equal(1.5f, m.X);
+        Assert.Equal(2.5f, m.Y);
+    }
+
+    [Fact]
+    public void ToGenericRadiusMarker_MapsStyling()
+    {
+        var marker = Marker(AppMarkerType.GenericRadius);
+        marker.Radius = 25f;
+        marker.Alpha = 0.75f;
+        marker.Color1 = new Vector4
+        {
+            X = 1f, Y = 0.5f, Z = 0.25f, W = 1f
+        };
+        marker.Color2 = new Vector4
+        {
+            X = 0f, Y = 0f, Z = 0f, W = 0.5f
+        };
+
+        var m = marker.ToGenericRadiusMarker();
+
+        Assert.Equal(25f, m.Radius);
+        Assert.Equal(0.75f, m.Alpha);
+        Assert.Equal(1f, m.Color1!.R);
+        Assert.Equal(0.5f, m.Color2!.A);
+    }
+
+    [Fact]
+    public void ToGenericRadiusMarker_UnsetStyling_IsNull()
+    {
+        var m = Marker(AppMarkerType.GenericRadius).ToGenericRadiusMarker();
+
+        Assert.Null(m.Radius);
+        Assert.Null(m.Alpha);
+        Assert.Null(m.Color1);
+        Assert.Null(m.Color2);
+    }
 }

--- a/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
@@ -98,4 +98,31 @@ public class MarkerMapperTests
         Assert.Equal(1.5f, x);
         Assert.Equal(2.5f, y);
     }
+
+    [Fact]
+    public void ToMarkerColor_MapsComponents()
+    {
+        var color = new Vector4
+        {
+            X = 0.1f, Y = 0.2f, Z = 0.3f, W = 0.4f
+        };
+
+        var m = color.ToMarkerColor();
+
+        Assert.Equal(0.1f, m.R);
+        Assert.Equal(0.2f, m.G);
+        Assert.Equal(0.3f, m.B);
+        Assert.Equal(0.4f, m.A);
+    }
+
+    [Fact]
+    public void ToMarkerColor_UnsetComponents_AreNull()
+    {
+        var m = new Vector4().ToMarkerColor();
+
+        Assert.Null(m.R);
+        Assert.Null(m.G);
+        Assert.Null(m.B);
+        Assert.Null(m.A);
+    }
 }

--- a/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
@@ -236,4 +236,52 @@ public class MarkerMapperTests
         Assert.Null(m.Color1);
         Assert.Null(m.Color2);
     }
+
+    [Fact]
+    public void ToUnknownMarker_PassesThroughFullSurface()
+    {
+        var marker = Marker(AppMarkerType.Undefined);
+        marker.Rotation = 90f;
+        marker.Radius = 10f;
+        marker.Alpha = 0.5f;
+        marker.Color1 = new Vector4
+        {
+            X = 1f
+        };
+        marker.SellOrders.Add(new SellOrder
+        {
+            ItemId = 1, Quantity = 1, CostPerItem = 1, AmountInStock = 1
+        });
+
+        var m = marker.ToUnknownMarker();
+
+        Assert.Equal("M", m.Name);
+        Assert.Equal(76561198000000001ul, m.SteamId);
+        Assert.True(m.IsOutOfStock);
+        Assert.Equal(90f, m.Rotation);
+        Assert.Equal(10f, m.Radius);
+        Assert.Equal(0.5f, m.Alpha);
+        Assert.Equal(1f, m.Color1!.R);
+        Assert.Null(m.Color2);
+        Assert.Single(m.VendingMachineItems!);
+    }
+
+    [Fact]
+    public void ToUnknownMarker_UnsetOptionals_AreNull()
+    {
+        var m = new AppMarker
+        {
+            Id = 1, X = 0, Y = 0, Type = AppMarkerType.Undefined
+        }.ToUnknownMarker();
+
+        Assert.Null(m.Name);
+        Assert.Null(m.SteamId);
+        Assert.Null(m.IsOutOfStock);
+        Assert.Null(m.Rotation);
+        Assert.Null(m.Radius);
+        Assert.Null(m.Alpha);
+        Assert.Null(m.Color1);
+        Assert.Null(m.Color2);
+        Assert.Empty(m.VendingMachineItems!);
+    }
 }

--- a/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
@@ -27,6 +27,7 @@ public class MarkerMapperTests
         Assert.Equal(7u, m.Id);
         Assert.Equal(1.5f, m.X);
         Assert.Equal(2.5f, m.Y);
+        Assert.Equal(0, m.RawType);
     }
 
     [Fact]

--- a/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
@@ -128,7 +128,6 @@ public class MarkerMapperTests
 
     private static float? MapRotation(AppMarker marker, AppMarkerType type) => type switch
     {
-        AppMarkerType.Player => marker.ToPlayerMarker().Rotation,
         AppMarkerType.Ch47 => marker.ToCh47Marker().Rotation,
         AppMarkerType.CargoShip => marker.ToCargoShipMarker().Rotation,
         AppMarkerType.PatrolHelicopter => marker.ToPatrolHelicopterMarker().Rotation,
@@ -136,7 +135,6 @@ public class MarkerMapperTests
     };
 
     [Theory]
-    [InlineData(AppMarkerType.Player)]
     [InlineData(AppMarkerType.Ch47)]
     [InlineData(AppMarkerType.CargoShip)]
     [InlineData(AppMarkerType.PatrolHelicopter)]
@@ -150,7 +148,6 @@ public class MarkerMapperTests
     }
 
     [Theory]
-    [InlineData(AppMarkerType.Player)]
     [InlineData(AppMarkerType.Ch47)]
     [InlineData(AppMarkerType.CargoShip)]
     [InlineData(AppMarkerType.PatrolHelicopter)]
@@ -168,7 +165,6 @@ public class MarkerMapperTests
 
         Assert.Null(m.SteamId);
         Assert.Null(m.Name);
-        Assert.Null(m.Rotation);
     }
 
     [Fact]

--- a/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
@@ -58,6 +58,7 @@ public class MarkerMapperTests
         var m = marker.ToVendingMachineMarker();
 
         Assert.True(m.IsOutOfStock);
+        Assert.Equal("M", m.Name);
         var item = Assert.Single(m.VendingMachineItems!);
         Assert.Equal(1, item.Id);
         Assert.Equal(1.25f, item.PriceMultiplier);
@@ -244,6 +245,10 @@ public class MarkerMapperTests
         {
             X = 1f
         };
+        marker.Color2 = new Vector4
+        {
+            W = 0.5f
+        };
         marker.SellOrders.Add(new SellOrder
         {
             ItemId = 1, Quantity = 1, CostPerItem = 1, AmountInStock = 1
@@ -258,7 +263,7 @@ public class MarkerMapperTests
         Assert.Equal(10f, m.Radius);
         Assert.Equal(0.5f, m.Alpha);
         Assert.Equal(1f, m.Color1!.R);
-        Assert.Null(m.Color2);
+        Assert.Equal(0.5f, m.Color2!.A);
         Assert.Single(m.VendingMachineItems!);
     }
 


### PR DESCRIPTION
## Summary
- Map `rotation` on CargoShip/CH47/PatrolHelicopter/TravellingVendor markers (absent → null). Not on Player: the server does not populate it for players — reference apps (rustplus-desktop, rustplusplus) derive player heading from consecutive position polls.
- New `ExplosionMarker`, `CrateMarker`, `GenericRadiusMarker` (+ `MarkerColor` RGBA record) and their `MapMarkers` dictionaries
- `UnknownMarker` now passes through the full raw `AppMarker` surface, including the numeric `RawType` discriminator
- Unrecognized marker types fall back to `UnknownMarkers` instead of throwing from `GetMapMarkersAsync`
- Uniform presence rule: absent optional proto fields map to `null` — including `PlayerMarker.SteamId` (was `0`), `IsOutOfStock` (was `false`), and `Name` (was `""`; generated string getters coalesce unset to empty)
- `ServerMap` docs: dimensions are pixels of `JpgImage`; canonical world→pixel transform documented on the class

## Test plan
- Unit: mapper present/absent cases for every optional field; dispatch routing for all 10 types incl. `(AppMarkerType)999` fallback
- Integration (MockServer): mixed marker payload with Explosion/Crate/GenericRadius/unknown-999 round-trips through `GetMapMarkersAsync` without throwing
- Full matrix green on net8.0 + net10.0 hosts; coverage gate passes with the marker mappers at 100/100

Spec: `docs/superpowers/specs/2026-07-06-beta4-markers-and-entity-info-design.md` (not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)