### PR TITLE
beta.4: entity-info reads never throw on success; raw OnEntityChanged + hardened routing

### DIFF
--- a/docs/articles/rustplus-client.md
+++ b/docs/articles/rustplus-client.md
@@ -66,6 +66,13 @@ else
     Console.WriteLine(time.Error!.Message);
 ```
 
+`Error.Code` is a machine-readable `RustPlusErrorCode` parsed from the raw server identifier, so you
+can branch on failure type without string comparisons. A successful server reply never surfaces as a
+thrown exception: when the server answered fine but the library could not map the payload (e.g.
+reading an alarm through the strict `GetSmartSwitchInfoAsync` — the server replies with the entity's
+*actual* type), the call returns a failed `Response` with `RustPlusErrorCode.ClientMappingFailed`
+and the mapper's message.
+
 ## Method reference
 
 ### Server & world
@@ -75,14 +82,15 @@ else
 | `GetInfoAsync()` | `Response<ServerInfo?>` | Name, player counts, map size, wipe time, logo URL. |
 | `GetTimeAsync()` | `Response<TimeInfo?>` | In-game time, sunrise/sunset, day-length parameters. |
 | `GetMapAsync()` | `Response<ServerMap?>` | Map image bytes and monument list. Large response — cache it. |
-| `GetMapMarkersAsync()` | `Response<MapMarkers?>` | Players, cargo ship, patrol heli, vending machines, CH-47, events. Unrecognized marker types land in UnknownMarkers instead of failing. |
+| `GetMapMarkersAsync()` | `Response<MapMarkers?>` | Typed marker dictionaries: players, cargo ship, patrol heli, CH-47, travelling vendor, vending machines, explosions, crates, generic-radius overlays. Event movers carry `Rotation` (degrees, `null` when omitted); unrecognized types land in `UnknownMarkers` (full raw surface incl. `RawType`) instead of failing. |
 
 ### Entities (smart devices)
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `GetSmartSwitchInfoAsync(entityId)` | `Response<SmartDeviceInfo?>` | Current on/off state. |
-| `GetAlarmInfoAsync(entityId)` | `Response<SmartDeviceInfo?>` | Current state (protocol-level identical to smart switch). |
+| `GetSmartDeviceInfoAsync(entityId)` | `Response<SmartDeviceInfo?>` | Type-agnostic read for any binary-state device (smart switch **or** smart alarm) — use this for mixed device sets. |
+| `GetSmartSwitchInfoAsync(entityId)` | `Response<SmartDeviceInfo?>` | Current on/off state. Strict: fails with `ClientMappingFailed` when the entity is not a switch. |
+| `GetAlarmInfoAsync(entityId)` | `Response<SmartDeviceInfo?>` | Current state (protocol-level identical to smart switch). Strict: fails with `ClientMappingFailed` when the entity is not an alarm. |
 | `GetStorageMonitorInfoAsync(entityId)` | `Response<StorageMonitorInfo?>` | Item list and protection state. |
 | `SetSmartSwitchValueAsync(entityId, value)` | `Response<SmartDeviceInfo?>` | `true` = on, `false` = off. Reply is the EntityChanged broadcast. |
 | `ToggleSmartSwitchAsync(entityId)` | `Response<SmartDeviceInfo?>` | Reads current state then flips it. |
@@ -150,17 +158,20 @@ The complete set of public events across `RustPlusSocket` and `RustPlus`:
 | `Disconnecting` | `EventArgs` | `DisconnectAsync` started the close handshake. |
 | `Disconnected` | `EventArgs` | The WebSocket close completed. |
 | `ErrorOccurred` | `Exception` | A transport or receive error occurred. Fires from Connecting or Connected state. |
-| `OnSmartDeviceTriggered` | `SmartDeviceEventArg` | A subscribed binary-state device changed state. The broadcast omits the entity type, so a smart switch and a smart alarm are indistinguishable here — query the entity to learn its type. |
-| `OnStorageMonitorTriggered` | `StorageMonitorEventArg` | A subscribed storage monitor reported a change. |
+| `OnEntityChanged` | `EntityChangedEventArg` | Every `EntityChanged` broadcast, raw and before any device-type heuristic (`Id`, `Value`, `Capacity`, `HasProtection`, `ProtectionExpiry`, `Items`). The broadcast carries no entity type — route on `Id` when you know your paired entities; this is the reliable channel. |
+| `OnSmartDeviceTriggered` | `SmartDeviceEventArg` | An `EntityChanged` broadcast classified as a binary-state device: no items, no capacity, no protection in the payload. A storage broadcast carrying *only* `value` is indistinguishable from a switch and lands here too. |
+| `OnStorageMonitorTriggered` | `StorageMonitorEventArg` | An `EntityChanged` broadcast classified as a storage monitor: items, capacity or tool-cupboard protection present (TC broadcasts are sometimes partial — capacity may be absent). Item-less `value == true` storage broadcasts carry no contents snapshot and are **not** raised here (observe them via `OnEntityChanged`). |
 | `OnTeamChatReceived` | `TeamMessageEventArg` | A team chat message arrived. |
 | `OnClanChatReceived` | `ClanMessageEventArg` | A clan chat message arrived. |
 | `OnClanChanged` | `ClanChangedEventArg` | The clan snapshot changed (roles, members, MOTD, …). |
 | `OnCameraRaysReceived` | `CameraRaysEventArg` | A camera frame broadcast arrived for the subscribed camera. |
 
 > [!NOTE]
-> To receive `OnSmartDeviceTriggered` or `OnStorageMonitorTriggered` broadcasts for a given
-> entity, you must first make at least one request on that entity (e.g. `GetSmartSwitchInfoAsync`),
-> which registers it with the server. Camera frame events start after `SubscribeToCameraAsync`.
+> To receive `OnEntityChanged`, `OnSmartDeviceTriggered` or `OnStorageMonitorTriggered` broadcasts
+> for a given entity, you must first make at least one request on that entity (e.g.
+> `GetSmartDeviceInfoAsync`), which registers it with the server — the registration happens even
+> when the read itself fails on a type mismatch. Camera frame events start after
+> `SubscribeToCameraAsync`.
 
 ## Disposal
 

--- a/docs/articles/troubleshooting.md
+++ b/docs/articles/troubleshooting.md
@@ -126,17 +126,45 @@ arriving.
 
 ```csharp
 // Register the entity with the server — broadcasts start after this call.
-await rustPlus.GetSmartSwitchInfoAsync(entityId);
+// GetSmartDeviceInfoAsync works for both smart switches and smart alarms.
+await rustPlus.GetSmartDeviceInfoAsync(entityId);
 
 rustPlus.OnSmartDeviceTriggered += (_, e) =>
     Console.WriteLine($"Device {e.Id}: {(e.IsActive ? "on" : "off")}");
 ```
+
+The registration happens server-side even when the read itself fails (e.g. a strict
+`GetSmartSwitchInfoAsync` on an alarm) — so an entity can broadcast while its reads fail. The
+broadcast carries no entity type, so the convenience events route by payload shape; when that
+heuristic can't work for you, subscribe to `OnEntityChanged` and route on the entity ID yourself.
 
 > [!NOTE]
 > Camera frames (`OnCameraRaysReceived`) work differently — they start automatically after
 > `SubscribeToCameraAsync`, no extra call needed.
 
 See [RustPlus Client — Events](rustplus-client.md#events) for the full broadcast list.
+
+## Reading a device fails with `ClientMappingFailed`
+
+**Symptom:** `GetSmartSwitchInfoAsync` (or `GetAlarmInfoAsync`) returns `IsSuccess = false` with
+`RustPlusErrorCode.ClientMappingFailed` for an entity that definitely exists — while its
+broadcasts keep arriving.
+
+**Cause:** The server answers `getEntityInfo` with the entity's *actual* type. Reading an alarm
+through the strict switch method (or vice versa) is a client-side type mismatch: the server reply
+was successful, the strict mapper refused it. Before 2.0.0-beta.4 this surfaced as a thrown
+`InvalidOperationException`, easily mistaken for "device unreachable".
+
+**Fix:** For mixed or unknown device sets, use the type-agnostic read — switch and alarm payloads
+are physically identical:
+
+```csharp
+var device = await rustPlus.GetSmartDeviceInfoAsync(entityId);
+if (device.IsSuccess)
+    Console.WriteLine($"Device {entityId} is {(device.Data!.IsActive ? "on" : "off")}");
+```
+
+Keep the strict methods when you *want* the type check (e.g. to detect a mis-paired entity).
 
 ## Camera subscribe fails with `no_player`
 

--- a/src/RustPlusApi/Data/Events/EntityChangedEventArg.cs
+++ b/src/RustPlusApi/Data/Events/EntityChangedEventArg.cs
@@ -1,0 +1,28 @@
+using RustPlusApi.Data.Entities;
+
+namespace RustPlusApi.Data.Events;
+
+/// <summary>Event argument raised for every <c>EntityChanged</c> broadcast, exposing the full raw
+/// payload before any device-type heuristic. The broadcast carries no entity type; consumers that
+/// know their paired entity ids should route on <see cref="Id"/>.</summary>
+public sealed record EntityChangedEventArg
+{
+    /// <summary>Container capacity, or <see langword="null"/> when omitted (storage payloads only).</summary>
+    public int? Capacity { get; init; }
+
+    /// <summary>Tool-cupboard protection flag, or <see langword="null"/> when omitted.</summary>
+    public bool? HasProtection { get; init; }
+
+    /// <summary>Entity ID of the entity that changed.</summary>
+    public ulong Id { get; init; }
+
+    /// <summary>Items in the container; empty for binary-state payloads and for storage broadcasts
+    /// that carry no contents snapshot.</summary>
+    public IEnumerable<StorageMonitorItemInfo> Items { get; init; } = [];
+
+    /// <summary>UTC time when the tool-cupboard protection expires, or <see langword="null"/> when omitted.</summary>
+    public DateTime? ProtectionExpiry { get; init; }
+
+    /// <summary>Binary state (on / triggered), or <see langword="null"/> when omitted.</summary>
+    public bool? Value { get; init; }
+}

--- a/src/RustPlusApi/Data/RustPlusErrorCode.cs
+++ b/src/RustPlusApi/Data/RustPlusErrorCode.cs
@@ -58,4 +58,10 @@ public enum RustPlusErrorCode
     /// on a non-PTZ camera) — the live server acknowledges unsupported camera inputs with
     /// success while silently ignoring them, so this is the only feedback available.</summary>
     NotSupported = 14,
+
+    /// <summary>Client-side: the server replied successfully but this library failed to map the
+    /// payload (e.g. reading an alarm through <c>GetSmartSwitchInfoAsync</c> — the server answers
+    /// with the entity's actual type). <see cref="ErrorMessage.Message"/> carries the mapper's
+    /// exception message.</summary>
+    ClientMappingFailed = 15,
 }

--- a/src/RustPlusApi/Extensions/AppEntityInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppEntityInfoToModel.cs
@@ -76,4 +76,22 @@ public static class AppEntityInfoToModel
     {
         return items.Select(ToStorageMonitorItemInfo);
     }
+
+    /// <summary>Maps an <see cref="AppEntityInfo"/> of a binary-state smart device (a smart switch or a
+    /// smart alarm) to a <see cref="SmartDeviceInfo"/>. The server replies with the entity's actual type
+    /// and switch/alarm payloads are physically identical, so both types are accepted.</summary>
+    /// <param name="entity">The protobuf entity info.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the entity type is neither <c>Switch</c> nor <c>Alarm</c>.</exception>
+    public static SmartDeviceInfo ToSmartDeviceInfo(this AppEntityInfo entity)
+    {
+        if (entity.Type is not (AppEntityType.Switch or AppEntityType.Alarm))
+        {
+            throw new InvalidOperationException("Entity type is not a binary-state smart device.");
+        }
+
+        return new SmartDeviceInfo
+        {
+            IsActive = entity.Payload.Value
+        };
+    }
 }

--- a/src/RustPlusApi/Extensions/EntityChangedToModel.cs
+++ b/src/RustPlusApi/Extensions/EntityChangedToModel.cs
@@ -31,4 +31,24 @@ public static class EntityChangedToModel
             Items = entityChanged.Payload.Items.ToStorageMonitorItemsInfo()
         };
     }
+
+    /// <summary>Maps an <see cref="AppEntityChanged"/> broadcast to the raw
+    /// <see cref="EntityChangedEventArg"/>, preserving field presence (absent optional fields map to
+    /// <see langword="null"/>).</summary>
+    /// <param name="entityChanged">The protobuf entity-changed broadcast.</param>
+    public static EntityChangedEventArg ToEntityChangedEvent(this AppEntityChanged entityChanged)
+    {
+        var payload = entityChanged.Payload;
+        return new EntityChangedEventArg
+        {
+            Id = entityChanged.EntityId,
+            Value = payload.ShouldSerializeValue() ? payload.Value : null,
+            Capacity = payload.ShouldSerializeCapacity() ? payload.Capacity : null,
+            HasProtection = payload.ShouldSerializeHasProtection() ? payload.HasProtection : null,
+            ProtectionExpiry = payload.ShouldSerializeProtectionExpiry()
+                ? DateTimeOffset.FromUnixTimeSeconds(payload.ProtectionExpiry).UtcDateTime
+                : null,
+            Items = payload.Items.ToStorageMonitorItemsInfo()
+        };
+    }
 }

--- a/src/RustPlusApi/Interfaces/IRustPlus.cs
+++ b/src/RustPlusApi/Interfaces/IRustPlus.cs
@@ -19,6 +19,11 @@ public interface IRustPlus : IRustPlusSocket
     /// (an <c>EntityChanged</c> broadcast whose payload carries item capacity).</summary>
     event EventHandler<StorageMonitorEventArg>? OnStorageMonitorTriggered;
 
+    /// <summary>Raised for every <c>EntityChanged</c> broadcast, before any device-type heuristic,
+    /// with the full raw payload. The broadcast carries no entity type; consumers that know their
+    /// paired entity ids should route on <see cref="EntityChangedEventArg.Id"/>.</summary>
+    event EventHandler<EntityChangedEventArg>? OnEntityChanged;
+
     /// <summary>Raised when a new team chat message arrives.</summary>
     event EventHandler<TeamMessageEventArg>? OnTeamChatReceived;
 

--- a/src/RustPlusApi/Interfaces/IRustPlus.cs
+++ b/src/RustPlusApi/Interfaces/IRustPlus.cs
@@ -96,6 +96,13 @@ public interface IRustPlus : IRustPlusSocket
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<MapMarkers?>> GetMapMarkersAsync(CancellationToken cancellationToken = default);
 
+    /// <summary>Returns the state of a binary-state smart device (a smart switch or a smart alarm),
+    /// whichever of the two types the entity actually is.</summary>
+    /// <param name="entityId">Entity ID of the smart device.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    Task<Response<SmartDeviceInfo?>> GetSmartDeviceInfoAsync(ulong entityId,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Returns the current state of a smart switch entity.</summary>
     /// <param name="entityId">Entity ID of the smart switch.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>

--- a/src/RustPlusApi/Interfaces/IRustPlus.cs
+++ b/src/RustPlusApi/Interfaces/IRustPlus.cs
@@ -9,14 +9,17 @@ namespace RustPlusApi.Interfaces;
 /// <summary>High-level Rust+ API contract — typed events and all supported server commands.</summary>
 public interface IRustPlus : IRustPlusSocket
 {
-    /// <summary>Raised when a subscribed binary-state smart device (a smart switch or a smart alarm)
-    /// changes state. The Rust+ <c>EntityChanged</c> broadcast omits the entity type, so a switch and
-    /// an alarm are indistinguishable here; query the entity explicitly (<c>GetSmartSwitchInfoAsync</c>
-    /// or <c>GetAlarmInfoAsync</c>) to learn its actual type.</summary>
+    /// <summary>Occurs when an <c>EntityChanged</c> broadcast is classified as a binary-state smart device
+    /// (a smart switch or a smart alarm): the payload carries no container state (no items, no
+    /// capacity, no protection). The broadcast omits the entity type, so a storage broadcast whose
+    /// payload is only <c>value</c> is indistinguishable from a switch and lands here too — route on
+    /// <see cref="OnEntityChanged"/> with your paired entity ids when that matters.</summary>
     event EventHandler<SmartDeviceEventArg>? OnSmartDeviceTriggered;
 
-    /// <summary>Raised when a subscribed storage monitor reports a change
-    /// (an <c>EntityChanged</c> broadcast whose payload carries item capacity).</summary>
+    /// <summary>Occurs when an <c>EntityChanged</c> broadcast is classified as a storage monitor: the payload
+    /// carries items, a capacity, or tool-cupboard protection. Storage broadcasts with
+    /// <c>value == true</c> and no items carry no contents snapshot and are NOT raised here (they
+    /// remain observable via <see cref="OnEntityChanged"/>).</summary>
     event EventHandler<StorageMonitorEventArg>? OnStorageMonitorTriggered;
 
     /// <summary>Raised for every <c>EntityChanged</c> broadcast, before any device-type heuristic,
@@ -45,6 +48,9 @@ public interface IRustPlus : IRustPlusSocket
     /// <summary>Returns the current state of a smart alarm entity.</summary>
     /// <param name="entityId">Entity ID of the alarm.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <remarks>The underlying <c>getEntityInfo</c> request also subscribes this connection to the
+    /// entity's <c>EntityChanged</c> broadcasts server-side — even when the read itself fails on a
+    /// type mismatch.</remarks>
     Task<Response<SmartDeviceInfo?>> GetAlarmInfoAsync(ulong entityId, CancellationToken cancellationToken = default);
 
     /// <summary>Returns the full clan snapshot for the authenticated player's clan.</summary>
@@ -111,12 +117,18 @@ public interface IRustPlus : IRustPlusSocket
     /// <summary>Returns the current state of a smart switch entity.</summary>
     /// <param name="entityId">Entity ID of the smart switch.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <remarks>The underlying <c>getEntityInfo</c> request also subscribes this connection to the
+    /// entity's <c>EntityChanged</c> broadcasts server-side — even when the read itself fails on a
+    /// type mismatch.</remarks>
     Task<Response<SmartDeviceInfo?>> GetSmartSwitchInfoAsync(ulong entityId,
         CancellationToken cancellationToken = default);
 
     /// <summary>Returns the current contents and protection state of a storage monitor.</summary>
     /// <param name="entityId">Entity ID of the storage monitor.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <remarks>The underlying <c>getEntityInfo</c> request also subscribes this connection to the
+    /// entity's <c>EntityChanged</c> broadcasts server-side — even when the read itself fails on a
+    /// type mismatch.</remarks>
     Task<Response<StorageMonitorInfo?>> GetStorageMonitorInfoAsync(ulong entityId,
         CancellationToken cancellationToken = default);
 

--- a/src/RustPlusApi/Interfaces/IRustPlus.cs
+++ b/src/RustPlusApi/Interfaces/IRustPlus.cs
@@ -19,7 +19,8 @@ public interface IRustPlus : IRustPlusSocket
     /// <summary>Occurs when an <c>EntityChanged</c> broadcast is classified as a storage monitor: the payload
     /// carries items, a capacity, or tool-cupboard protection. Storage broadcasts with
     /// <c>value == true</c> and no items carry no contents snapshot and are NOT raised here (they
-    /// remain observable via <see cref="OnEntityChanged"/>).</summary>
+    /// remain observable via <see cref="OnEntityChanged"/>). Tool-cupboard broadcasts are sometimes
+    /// partial — <c>capacity</c> may be absent and only the protection flag identifies them.</summary>
     event EventHandler<StorageMonitorEventArg>? OnStorageMonitorTriggered;
 
     /// <summary>Raised for every <c>EntityChanged</c> broadcast, before any device-type heuristic,
@@ -111,6 +112,9 @@ public interface IRustPlus : IRustPlusSocket
     /// whichever of the two types the entity actually is.</summary>
     /// <param name="entityId">Entity ID of the smart device.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <remarks>The underlying <c>getEntityInfo</c> request also subscribes this connection to the
+    /// entity's <c>EntityChanged</c> broadcasts server-side — even when the read itself fails on a
+    /// type mismatch.</remarks>
     Task<Response<SmartDeviceInfo?>> GetSmartDeviceInfoAsync(ulong entityId,
         CancellationToken cancellationToken = default);
 

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -42,7 +42,8 @@ public class RustPlus(
     /// Occurs when an <c>EntityChanged</c> broadcast is classified as a storage monitor: the payload
     /// carries items, a capacity, or tool-cupboard protection. Storage broadcasts with
     /// <c>value == true</c> and no items carry no contents snapshot and are NOT raised here (they
-    /// remain observable via <see cref="OnEntityChanged"/>).
+    /// remain observable via <see cref="OnEntityChanged"/>). Tool-cupboard broadcasts are sometimes
+    /// partial — <c>capacity</c> may be absent and only the protection flag identifies them.
     /// </summary>
     public event EventHandler<StorageMonitorEventArg>? OnStorageMonitorTriggered;
 
@@ -313,7 +314,8 @@ public class RustPlus(
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the smart device information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <remarks>The underlying <c>getEntityInfo</c> request also subscribes this connection to the
-    /// entity's <c>EntityChanged</c> broadcasts server-side.</remarks>
+    /// entity's <c>EntityChanged</c> broadcasts server-side — even when the read itself fails on a
+    /// type mismatch.</remarks>
     public async Task<Response<SmartDeviceInfo?>> GetSmartDeviceInfoAsync(ulong entityId,
         CancellationToken cancellationToken = default)
     {
@@ -666,7 +668,15 @@ public class RustPlus(
             // (e.g. reading an alarm through GetSmartSwitchInfoAsync — the server answers with the
             // entity's actual type) becomes a failed Response the consumer can tell apart from a
             // transport error.
-            return ResponseHelper.BuildGenericOutput<T>(false, default!, ex.Message);
+            Logger.LogSelectorFailed(ex);
+            return new Response<T?>
+            {
+                IsSuccess = false,
+                Error = new ErrorMessage
+                {
+                    Message = ex.Message, Code = RustPlusErrorCode.ClientMappingFailed
+                }
+            };
         }
     }
 
@@ -696,6 +706,8 @@ public class RustPlus(
     /// <param name="selector">The function to select the entity information from the response.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the entity information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <remarks>The underlying <c>getEntityInfo</c> request also subscribes this connection to the
+    /// entity's <c>EntityChanged</c> broadcasts server-side — even when the mapping of the reply fails.</remarks>
     protected async Task<Response<T?>> GetEntityInfoAsync<T>(ulong entityId,
         Func<AppMessage, T> selector,
         CancellationToken cancellationToken = default)

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -30,18 +30,19 @@ public class RustPlus(
     : RustPlusSocket(connection, options, loggerFactory), IRustPlus
 {
     /// <summary>
-    /// Occurs when a binary-state smart device (a smart switch or a smart alarm) changes state.
-    /// The Rust+ <c>EntityChanged</c> broadcast carries only the entity id and payload — it does
-    /// <b>not</b> include the entity type — so a switch and an alarm are indistinguishable here.
-    /// To learn an entity's actual type, query it explicitly with
-    /// <see cref="GetSmartSwitchInfoAsync"/> or <see cref="GetAlarmInfoAsync"/> (both read the
-    /// <c>type</c> field on <c>AppEntityInfo</c>, which the broadcast omits).
+    /// Occurs when an <c>EntityChanged</c> broadcast is classified as a binary-state smart device
+    /// (a smart switch or a smart alarm): the payload carries no container state (no items, no
+    /// capacity, no protection). The broadcast omits the entity type, so a storage broadcast whose
+    /// payload is only <c>value</c> is indistinguishable from a switch and lands here too — route on
+    /// <see cref="OnEntityChanged"/> with your paired entity ids when that matters.
     /// </summary>
     public event EventHandler<SmartDeviceEventArg>? OnSmartDeviceTriggered;
 
     /// <summary>
-    /// Occurs when a <see cref="StorageMonitorEventArg"/> is triggered by a storage monitor
-    /// (an <c>EntityChanged</c> broadcast whose payload carries item capacity).
+    /// Occurs when an <c>EntityChanged</c> broadcast is classified as a storage monitor: the payload
+    /// carries items, a capacity, or tool-cupboard protection. Storage broadcasts with
+    /// <c>value == true</c> and no items carry no contents snapshot and are NOT raised here (they
+    /// remain observable via <see cref="OnEntityChanged"/>).
     /// </summary>
     public event EventHandler<StorageMonitorEventArg>? OnStorageMonitorTriggered;
 
@@ -98,6 +99,9 @@ public class RustPlus(
     /// <param name="entityId">The ID of the alarm entity.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the alarm information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <remarks>The underlying <c>getEntityInfo</c> request also subscribes this connection to the
+    /// entity's <c>EntityChanged</c> broadcasts server-side — even when the read itself fails on a
+    /// type mismatch.</remarks>
     public async Task<Response<SmartDeviceInfo?>> GetAlarmInfoAsync(ulong entityId,
         CancellationToken cancellationToken = default)
     {
@@ -325,6 +329,9 @@ public class RustPlus(
     /// <param name="entityId">The ID of the smart switch entity.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the smart switch information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <remarks>The underlying <c>getEntityInfo</c> request also subscribes this connection to the
+    /// entity's <c>EntityChanged</c> broadcasts server-side — even when the read itself fails on a
+    /// type mismatch.</remarks>
     public async Task<Response<SmartDeviceInfo?>> GetSmartSwitchInfoAsync(ulong entityId,
         CancellationToken cancellationToken = default)
     {
@@ -339,6 +346,9 @@ public class RustPlus(
     /// <param name="entityId">The ID of the storage monitor entity.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the storage monitor information.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <remarks>The underlying <c>getEntityInfo</c> request also subscribes this connection to the
+    /// entity's <c>EntityChanged</c> broadcasts server-side — even when the read itself fails on a
+    /// type mismatch.</remarks>
     public async Task<Response<StorageMonitorInfo?>> GetStorageMonitorInfoAsync(ulong entityId,
         CancellationToken cancellationToken = default)
     {
@@ -567,17 +577,25 @@ public class RustPlus(
 
         if (broadcast.EntityChanged is not null)
         {
-            OnEntityChanged?.Invoke(this, broadcast.EntityChanged.ToEntityChangedEvent());
+            var entityChanged = broadcast.EntityChanged;
+            OnEntityChanged?.Invoke(this, entityChanged.ToEntityChangedEvent());
 
-            // There is no physical difference between a SmartSwitch and an Alarm
-            // If you check the status of an alarm, it will return the same as a smart switch
-            if (broadcast.EntityChanged.Payload.Capacity is 0)
+            // The broadcast carries no entity type. A payload is storage-shaped when it exposes any
+            // container state; a bare `value` is indistinguishable from a switch/alarm and routes to
+            // OnSmartDeviceTriggered. Consumers that know their paired ids use OnEntityChanged.
+            var payload = entityChanged.Payload;
+            if (payload.Items.Count > 0 || payload.Capacity > 0 || payload.HasProtection)
             {
-                OnSmartDeviceTriggered?.Invoke(this, broadcast.EntityChanged.ToSmartDeviceEvent());
+                // A storage broadcast with value == true carries no contents snapshot; surfacing it
+                // would wipe consumer-tracked contents.
+                if (!payload.Value || payload.Items.Count > 0)
+                {
+                    OnStorageMonitorTriggered?.Invoke(this, entityChanged.ToStorageMonitorEvent());
+                }
             }
             else
             {
-                OnStorageMonitorTriggered?.Invoke(this, broadcast.EntityChanged.ToStorageMonitorEvent());
+                OnSmartDeviceTriggered?.Invoke(this, entityChanged.ToSmartDeviceEvent());
             }
 
             return;

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -66,6 +66,15 @@ public class RustPlus(
     public event EventHandler<CameraRaysEventArg>? OnCameraRaysReceived;
 
     /// <summary>
+    /// Occurs for every <c>EntityChanged</c> broadcast, before any device-type heuristic, with the
+    /// full raw payload. The broadcast carries no entity type; consumers that know their paired
+    /// entity ids should route on <see cref="EntityChangedEventArg.Id"/> — this is the reliable
+    /// channel when the <see cref="OnSmartDeviceTriggered"/>/<see cref="OnStorageMonitorTriggered"/>
+    /// heuristics cannot classify a payload.
+    /// </summary>
+    public event EventHandler<EntityChangedEventArg>? OnEntityChanged;
+
+    /// <summary>
     /// Checks the subscription status of an alarm asynchronously.
     /// </summary>
     /// <param name="alarmId">The ID of the alarm entity.</param>
@@ -558,6 +567,8 @@ public class RustPlus(
 
         if (broadcast.EntityChanged is not null)
         {
+            OnEntityChanged?.Invoke(this, broadcast.EntityChanged.ToEntityChangedEvent());
+
             // There is no physical difference between a SmartSwitch and an Alarm
             // If you check the status of an alarm, it will return the same as a smart switch
             if (broadcast.EntityChanged.Payload.Capacity is 0)

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -611,6 +611,9 @@ public class RustPlus(
     /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the processed result.</returns>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     /// <exception cref="InvalidOperationException">Thrown when the client is not connected.</exception>
+    /// <remarks>A success-selector exception (other than <see cref="OperationCanceledException"/>) is
+    /// returned as a failed <see cref="Response{T}"/> carrying the exception message — a successful
+    /// server reply never surfaces as a thrown exception.</remarks>
     protected async Task<Response<T?>> ProcessRequestAsync<T>(AppRequest request,
         Func<AppMessage, T> successSelector,
         Func<AppBroadcast, bool>? broadcastReplyMatcher = null,
@@ -619,9 +622,23 @@ public class RustPlus(
         var response = await SendRequestAsync(request, broadcastReplyMatcher, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
-        return IsError(response)
-            ? ResponseHelper.BuildGenericOutput<T>(false, default!, GetErrorMessage(response))
-            : ResponseHelper.BuildGenericOutput(true, successSelector(response));
+        if (IsError(response))
+        {
+            return ResponseHelper.BuildGenericOutput<T>(false, default!, GetErrorMessage(response));
+        }
+
+        try
+        {
+            return ResponseHelper.BuildGenericOutput(true, successSelector(response));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A successful server reply must never escape as a thrown exception: a selector failure
+            // (e.g. reading an alarm through GetSmartSwitchInfoAsync — the server answers with the
+            // entity's actual type) becomes a failed Response the consumer can tell apart from a
+            // transport error.
+            return ResponseHelper.BuildGenericOutput<T>(false, default!, ex.Message);
+        }
     }
 
     /// <summary>

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -291,6 +291,26 @@ public class RustPlus(
     }
 
     /// <summary>
+    /// Retrieves the state of a binary-state smart device (a smart switch or a smart alarm)
+    /// asynchronously, whichever of the two types the entity actually is. The server replies with the
+    /// entity's actual type and switch/alarm payloads are identical, so this method reads mixed device
+    /// sets without tracking each entity's type.
+    /// </summary>
+    /// <param name="entityId">The ID of the smart device entity.</param>
+    /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a <see cref="Response{T}"/> with the smart device information.</returns>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    /// <remarks>The underlying <c>getEntityInfo</c> request also subscribes this connection to the
+    /// entity's <c>EntityChanged</c> broadcasts server-side.</remarks>
+    public async Task<Response<SmartDeviceInfo?>> GetSmartDeviceInfoAsync(ulong entityId,
+        CancellationToken cancellationToken = default)
+    {
+        return await GetEntityInfoAsync<SmartDeviceInfo?>(
+            entityId,
+            r => r.Response.EntityInfo.ToSmartDeviceInfo(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Retrieves the information of a smart switch asynchronously.
     /// </summary>
     /// <param name="entityId">The ID of the smart switch entity.</param>

--- a/src/RustPlusApi/RustPlusSocketLog.cs
+++ b/src/RustPlusApi/RustPlusSocketLog.cs
@@ -49,4 +49,8 @@ internal static partial class RustPlusSocketLog
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Broadcast-reply matcher threw; treating as no match.")]
     public static partial void LogMatcherThrew(this ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "A success selector failed to map a successful server reply; returning a failed response.")]
+    public static partial void LogSelectorFailed(this ILogger logger, Exception exception);
 }

--- a/tests/RustPlusApi.IntegrationTests/EntityClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/EntityClientTests.cs
@@ -333,4 +333,51 @@ public class EntityClientTests
         var message = Assert.Single(response.Data!.Messages!);
         Assert.Equal("team chat fixture", message.Message);
     }
+
+    [Fact]
+    public async Task GetSmartDeviceInfoAsync_SwitchTypedReply_Succeeds()
+    {
+        var (server, client) = await ConnectEntityAsync();
+        await using var _ = server;
+        await using var __ = client;
+
+        var response = await client.GetSmartDeviceInfoAsync(1).WaitAsync(Timeout);
+
+        Assert.True(response.IsSuccess);
+        Assert.True(response.Data!.IsActive);
+    }
+
+    [Fact]
+    public async Task GetSmartDeviceInfoAsync_AlarmTypedReply_Succeeds()
+    {
+        await using var server = new MockRustPlusServer(req =>
+        {
+            var resp = new AppResponse
+            {
+                Seq = req.Seq
+            };
+            if (req.GetEntityInfo is not null)
+            {
+                resp.EntityInfo = MockResponses.SampleAlarm(value: true);
+            }
+            else
+            {
+                resp.Success = new AppSuccess();
+            }
+
+            return new AppMessage
+            {
+                Response = resp
+            };
+        });
+        server.Start();
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await client.ConnectAsync().WaitAsync(Timeout);
+
+        var response = await client.GetSmartDeviceInfoAsync(1).WaitAsync(Timeout);
+
+        Assert.True(response.IsSuccess);
+        Assert.True(response.Data!.IsActive);
+    }
 }

--- a/tests/RustPlusApi.IntegrationTests/EntityClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/EntityClientTests.cs
@@ -417,6 +417,7 @@ public class EntityClientTests
         Assert.False(response.IsSuccess);
         Assert.Null(response.Data);
         Assert.Equal("Entity type is not a SmartSwitch.", response.Error!.Message);
+        Assert.Equal(RustPlusErrorCode.ClientMappingFailed, response.Error.Code);
     }
 
     [Fact]

--- a/tests/RustPlusApi.IntegrationTests/EntityClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/EntityClientTests.cs
@@ -1,3 +1,4 @@
+using RustPlusApi.Data;
 using RustPlusApi.MockServer;
 using RustPlusContracts;
 using Xunit;
@@ -379,5 +380,68 @@ public class EntityClientTests
 
         Assert.True(response.IsSuccess);
         Assert.True(response.Data!.IsActive);
+    }
+
+    [Fact]
+    public async Task GetSmartSwitchInfoAsync_AlarmTypedReply_ReturnsFailedResponse()
+    {
+        await using var server = new MockRustPlusServer(req =>
+        {
+            var resp = new AppResponse
+            {
+                Seq = req.Seq
+            };
+            if (req.GetEntityInfo is not null)
+            {
+                resp.EntityInfo = MockResponses.SampleAlarm(value: false);
+            }
+            else
+            {
+                resp.Success = new AppSuccess();
+            }
+
+            return new AppMessage
+            {
+                Response = resp
+            };
+        });
+        server.Start();
+        await using var client =
+            new RustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId, PlayerToken));
+        await client.ConnectAsync().WaitAsync(Timeout);
+
+        // The server answered successfully with the entity's actual type (Alarm); the strict
+        // mapper's type check must surface as a failed Response, not a thrown exception.
+        var response = await client.GetSmartSwitchInfoAsync(1).WaitAsync(Timeout);
+
+        Assert.False(response.IsSuccess);
+        Assert.Null(response.Data);
+        Assert.Equal("Entity type is not a SmartSwitch.", response.Error!.Message);
+    }
+
+    [Fact]
+    public async Task ProcessRequestAsync_SelectorThrowsOperationCanceled_Propagates()
+    {
+        await using var server = new MockRustPlusServer();
+        server.Start();
+        await using var client =
+            new SelectorProbeRustPlus(new RustPlusConnection(MockRustPlusServer.Host, server.Port, PlayerId,
+                PlayerToken));
+        await client.ConnectAsync().WaitAsync(Timeout);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => client.ProbeAsync<object>(
+            new AppRequest
+            {
+                GetTime = new AppEmpty()
+            },
+            _ => throw new OperationCanceledException()).WaitAsync(Timeout));
+    }
+
+    /// <summary>Exposes the protected <c>ProcessRequestAsync</c> to pin its selector exception handling.</summary>
+    /// <param name="connection">The server endpoint and player credentials to connect as.</param>
+    private sealed class SelectorProbeRustPlus(RustPlusConnection connection) : RustPlus(connection)
+    {
+        public Task<Response<T?>> ProbeAsync<T>(AppRequest request, Func<AppMessage, T> selector) =>
+            ProcessRequestAsync(request, selector);
     }
 }

--- a/tests/RustPlusApi.UnitTests/EntityChangedMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/EntityChangedMapperTests.cs
@@ -1,0 +1,59 @@
+using RustPlusApi.Extensions;
+using RustPlusContracts;
+using Xunit;
+
+namespace RustPlusApi.UnitTests;
+
+/// <summary>Locks <see cref="EntityChangedToModel.ToEntityChangedEvent"/>: full payload passthrough
+/// with absent optional fields mapping to <see langword="null"/>.</summary>
+public class EntityChangedMapperTests
+{
+    [Fact]
+    public void ToEntityChangedEvent_MapsFullPayload()
+    {
+        var changed = new AppEntityChanged
+        {
+            EntityId = 42,
+            Payload = new AppEntityPayload
+            {
+                Value = true,
+                Capacity = 24,
+                HasProtection = true,
+                ProtectionExpiry = 1_700_000_000,
+                Items =
+                {
+                    new AppEntityPayload.Item
+                    {
+                        ItemId = 1, Quantity = 5, ItemIsBlueprint = false
+                    }
+                }
+            }
+        };
+
+        var arg = changed.ToEntityChangedEvent();
+
+        Assert.Equal(42u, arg.Id);
+        Assert.True(arg.Value);
+        Assert.Equal(24, arg.Capacity);
+        Assert.True(arg.HasProtection);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1_700_000_000).UtcDateTime, arg.ProtectionExpiry);
+        var item = Assert.Single(arg.Items);
+        Assert.Equal(1, item.Id);
+    }
+
+    [Fact]
+    public void ToEntityChangedEvent_UnsetOptionals_AreNull()
+    {
+        var arg = new AppEntityChanged
+        {
+            EntityId = 7, Payload = new AppEntityPayload()
+        }.ToEntityChangedEvent();
+
+        Assert.Equal(7u, arg.Id);
+        Assert.Null(arg.Value);
+        Assert.Null(arg.Capacity);
+        Assert.Null(arg.HasProtection);
+        Assert.Null(arg.ProtectionExpiry);
+        Assert.Empty(arg.Items);
+    }
+}

--- a/tests/RustPlusApi.UnitTests/EntityInfoMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/EntityInfoMapperTests.cs
@@ -76,4 +76,22 @@ public class EntityInfoMapperTests
     public void ToStorageMonitorInfo_WrongType_Throws() =>
         Assert.Throws<InvalidOperationException>(() =>
             Entity(AppEntityType.Switch, new AppEntityPayload()).ToStorageMonitorInfo());
+
+    [Theory]
+    [InlineData(AppEntityType.Switch)]
+    [InlineData(AppEntityType.Alarm)]
+    public void ToSmartDeviceInfo_AcceptsBinaryStateDevices(AppEntityType type)
+    {
+        var info = Entity(type, new AppEntityPayload
+        {
+            Value = true
+        }).ToSmartDeviceInfo();
+
+        Assert.True(info.IsActive);
+    }
+
+    [Fact]
+    public void ToSmartDeviceInfo_StorageMonitor_Throws() =>
+        Assert.Throws<InvalidOperationException>(() =>
+            Entity(AppEntityType.StorageMonitor, new AppEntityPayload()).ToSmartDeviceInfo());
 }

--- a/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
@@ -258,6 +258,125 @@ public class RustPlusParseNotificationTests
         Assert.Null(ex);
     }
 
+    // ── routing matrix: storage vs smart device classification ─────────────
+
+    private sealed record RoutingCapture
+    {
+        public RustPlusApi.Data.Events.EntityChangedEventArg? Raw { get; set; }
+        public RustPlusApi.Data.Events.SmartDeviceEventArg? Smart { get; set; }
+        public RustPlusApi.Data.Events.StorageMonitorEventArg? Storage { get; set; }
+    }
+
+    private static RoutingCapture Route(AppEntityPayload payload)
+    {
+        using var sut = new TestRustPlus();
+        var capture = new RoutingCapture();
+        sut.OnEntityChanged += (_, e) => capture.Raw = e;
+        sut.OnSmartDeviceTriggered += (_, e) => capture.Smart = e;
+        sut.OnStorageMonitorTriggered += (_, e) => capture.Storage = e;
+
+        sut.Feed(new AppBroadcast
+        {
+            EntityChanged = new AppEntityChanged
+            {
+                EntityId = 42, Payload = payload
+            }
+        });
+
+        return capture;
+    }
+
+    [Fact]
+    public void EntityChanged_ItemsOnly_RoutesToStorageMonitor()
+    {
+        var capture = Route(new AppEntityPayload
+        {
+            Items =
+            {
+                new AppEntityPayload.Item
+                {
+                    ItemId = 1, Quantity = 1, ItemIsBlueprint = false
+                }
+            }
+        });
+
+        Assert.NotNull(capture.Storage);
+        Assert.Null(capture.Smart);
+        Assert.NotNull(capture.Raw);
+    }
+
+    [Fact]
+    public void EntityChanged_CapacityOnly_RoutesToStorageMonitor()
+    {
+        var capture = Route(new AppEntityPayload
+        {
+            Capacity = 48
+        });
+
+        Assert.NotNull(capture.Storage);
+        Assert.Null(capture.Smart);
+    }
+
+    [Fact]
+    public void EntityChanged_ProtectionOnly_RoutesToStorageMonitor()
+    {
+        var capture = Route(new AppEntityPayload
+        {
+            HasProtection = true
+        });
+
+        Assert.NotNull(capture.Storage);
+        Assert.Null(capture.Smart);
+    }
+
+    [Fact]
+    public void EntityChanged_ValueOnly_RoutesToSmartDevice()
+    {
+        var capture = Route(new AppEntityPayload
+        {
+            Value = true
+        });
+
+        Assert.NotNull(capture.Smart);
+        Assert.Null(capture.Storage);
+        Assert.NotNull(capture.Raw);
+    }
+
+    [Fact]
+    public void EntityChanged_StorageShapedValueTrueWithoutItems_SuppressedFromConvenienceEvents()
+    {
+        // A storage broadcast with value == true carries no contents snapshot; surfacing it through
+        // OnStorageMonitorTriggered would wipe consumer-tracked contents (rustplusplus skips these).
+        var capture = Route(new AppEntityPayload
+        {
+            Value = true, Capacity = 48
+        });
+
+        Assert.Null(capture.Storage);
+        Assert.Null(capture.Smart);
+        Assert.NotNull(capture.Raw);
+    }
+
+    [Fact]
+    public void EntityChanged_StorageShapedValueTrueWithItems_RoutesToStorageMonitor()
+    {
+        var capture = Route(new AppEntityPayload
+        {
+            Value = true,
+            Capacity = 48,
+            Items =
+            {
+                new AppEntityPayload.Item
+                {
+                    ItemId = 1, Quantity = 1, ItemIsBlueprint = false
+                }
+            }
+        });
+
+        Assert.NotNull(capture.Storage);
+        Assert.Null(capture.Smart);
+    }
+
     /// <summary>Exposes the protected members of <see cref="RustPlus"/> for direct unit testing.</summary>
     private sealed class TestRustPlus() : RustPlus(new RustPlusConnection("127.0.0.1", 1, 1, 1))
     {

--- a/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
@@ -258,15 +258,6 @@ public class RustPlusParseNotificationTests
         Assert.Null(ex);
     }
 
-    // ── routing matrix: storage vs smart device classification ─────────────
-
-    private sealed record RoutingCapture
-    {
-        public RustPlusApi.Data.Events.EntityChangedEventArg? Raw { get; set; }
-        public RustPlusApi.Data.Events.SmartDeviceEventArg? Smart { get; set; }
-        public RustPlusApi.Data.Events.StorageMonitorEventArg? Storage { get; set; }
-    }
-
     private static RoutingCapture Route(AppEntityPayload payload)
     {
         using var sut = new TestRustPlus();
@@ -375,6 +366,15 @@ public class RustPlusParseNotificationTests
 
         Assert.NotNull(capture.Storage);
         Assert.Null(capture.Smart);
+    }
+
+    // ── routing matrix: storage vs smart device classification ─────────────
+
+    private sealed record RoutingCapture
+    {
+        public RustPlusApi.Data.Events.EntityChangedEventArg? Raw { get; set; }
+        public RustPlusApi.Data.Events.SmartDeviceEventArg? Smart { get; set; }
+        public RustPlusApi.Data.Events.StorageMonitorEventArg? Storage { get; set; }
     }
 
     /// <summary>Exposes the protected members of <see cref="RustPlus"/> for direct unit testing.</summary>

--- a/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
@@ -306,6 +306,7 @@ public class RustPlusParseNotificationTests
 
         Assert.NotNull(capture.Storage);
         Assert.Null(capture.Smart);
+        Assert.NotNull(capture.Raw);
     }
 
     [Fact]
@@ -318,6 +319,7 @@ public class RustPlusParseNotificationTests
 
         Assert.NotNull(capture.Storage);
         Assert.Null(capture.Smart);
+        Assert.NotNull(capture.Raw);
     }
 
     [Fact]
@@ -366,9 +368,8 @@ public class RustPlusParseNotificationTests
 
         Assert.NotNull(capture.Storage);
         Assert.Null(capture.Smart);
+        Assert.NotNull(capture.Raw);
     }
-
-    // ── routing matrix: storage vs smart device classification ─────────────
 
     private sealed record RoutingCapture
     {

--- a/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
@@ -183,6 +183,30 @@ public class RustPlusParseNotificationTests
         Assert.Null(ex);
     }
 
+    [Fact]
+    public void EntityChanged_WithRawSubscriber_InvokesOnEntityChanged()
+    {
+        using var sut = new TestRustPlus();
+        RustPlusApi.Data.Events.EntityChangedEventArg? captured = null;
+        sut.OnEntityChanged += (_, e) => captured = e;
+
+        sut.Feed(new AppBroadcast
+        {
+            EntityChanged = new AppEntityChanged
+            {
+                EntityId = 42,
+                Payload = new AppEntityPayload
+                {
+                    Value = true
+                }
+            }
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal(42u, captured!.Id);
+        Assert.True(captured.Value);
+    }
+
     // ── IsError: message with Broadcast set → returns false ──────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary
- **`GetSmartDeviceInfoAsync`** (new): type-tolerant read for binary-state devices — the server answers `getEntityInfo` with the entity's *actual* type, and switch/alarm payloads are identical, so mixed device sets can be read without tracking each entity's type. Strict `GetSmartSwitchInfoAsync`/`GetAlarmInfoAsync` remain.
- **A successful server reply can never escape as a thrown exception**: `ProcessRequestAsync` returns success-selector exceptions as a failed `Response` with the new `RustPlusErrorCode.ClientMappingFailed` and the mapper's message (`GetSmartSwitchInfoAsync(alarmId)` previously threw a raw `InvalidOperationException`, indistinguishable from a transport failure). Selector failures are logged (`LogSelectorFailed`, Warning). `OperationCanceledException` still propagates.
- **`OnEntityChanged`** (new): raised for *every* `EntityChanged` broadcast, before any heuristic, with the full raw payload (`Id`, `Value`, `Capacity`, `HasProtection`, `ProtectionExpiry`, `Items`; absent optional fields → `null`). The reliable routing channel for consumers that know their paired ids.
- **Hardened convenience-event routing**: storage-shaped iff items non-empty OR capacity > 0 OR protection set (tool-cupboard broadcasts are sometimes partial — capacity may be absent); item-less `value == true` storage broadcasts are suppressed from `OnStorageMonitorTriggered` (they carry no contents snapshot and would wipe consumer-tracked state — rustplusplus reference behavior); everything else → `OnSmartDeviceTriggered`.
- Docs: `getEntityInfo` subscribes the connection to the entity's broadcasts server-side (even when the read fails on a type mismatch) — now documented on all entity getters.

## Behavior changes (beta channel)
- Strict entity getters on a mismatched type now return a failed `Response` (`ClientMappingFailed`) instead of throwing.
- Protection-only / items-only broadcasts now route to `OnStorageMonitorTriggered` (previously `OnSmartDeviceTriggered` when capacity was absent).
- Item-less `value == true` storage broadcasts no longer raise `OnStorageMonitorTriggered` (still visible via `OnEntityChanged`).
- Documented residual: a storage broadcast whose payload is *only* `value` is indistinguishable from a switch and still lands on `OnSmartDeviceTriggered`.

## Test plan
- Routing matrix (6 cases incl. suppression) via the `ParseNotification` seam; raw event asserted in every case
- Failed-Response contract pinned end-to-end (exact message + `ClientMappingFailed` code); OCE propagation pinned via probe subclass
- `GetSmartDeviceInfoAsync` integration-tested against switch-typed and alarm-typed replies
- Full matrix green on net8.0 + net10.0; coverage gate passes with all touched classes at 100/100

Spec: `docs/superpowers/specs/2026-07-06-beta4-markers-and-entity-info-design.md` (not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)