### PR TITLE
Fix clan timestamp parsing: wire values are Unix milliseconds

### DIFF
--- a/src/RustPlusApi/Extensions/AppClanChatToModel.cs
+++ b/src/RustPlusApi/Extensions/AppClanChatToModel.cs
@@ -28,7 +28,8 @@ public static class AppClanChatToModel
             SteamId = appClanMessage.SteamId,
             Name = appClanMessage.Name,
             Message = appClanMessage.Message,
-            Time = DateTimeOffset.FromUnixTimeSeconds(appClanMessage.Time).UtcDateTime
+            // Clan timestamps are Unix milliseconds on the wire, unlike team timestamps (seconds).
+            Time = DateTimeOffset.FromUnixTimeMilliseconds(appClanMessage.Time).UtcDateTime
         };
     }
 
@@ -49,7 +50,7 @@ public static class AppClanChatToModel
             SteamId = appNewClanMessage.Message.SteamId,
             Name = appNewClanMessage.Message.Name,
             Message = appNewClanMessage.Message.Message,
-            Time = DateTimeOffset.FromUnixTimeSeconds(appNewClanMessage.Message.Time).UtcDateTime
+            Time = DateTimeOffset.FromUnixTimeMilliseconds(appNewClanMessage.Message.Time).UtcDateTime
         };
     }
 }

--- a/src/RustPlusApi/Extensions/AppClanInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppClanInfoToModel.cs
@@ -31,11 +31,12 @@ public static class AppClanInfoToModel
         {
             ClanId = clanInfo.ClanId,
             Name = clanInfo.Name,
-            Created = DateTimeOffset.FromUnixTimeSeconds(clanInfo.Created).UtcDateTime,
+            // Clan timestamps are Unix milliseconds on the wire, unlike team timestamps (seconds).
+            Created = DateTimeOffset.FromUnixTimeMilliseconds(clanInfo.Created).UtcDateTime,
             Creator = clanInfo.Creator,
             Motd = clanInfo.ShouldSerializeMotd() ? clanInfo.Motd : null,
             MotdTimestamp = clanInfo.ShouldSerializeMotdTimestamp()
-                ? DateTimeOffset.FromUnixTimeSeconds(clanInfo.MotdTimestamp).UtcDateTime
+                ? DateTimeOffset.FromUnixTimeMilliseconds(clanInfo.MotdTimestamp).UtcDateTime
                 : null,
             MotdAuthor = clanInfo.ShouldSerializeMotdAuthor() ? clanInfo.MotdAuthor : null,
             Logo = clanInfo.ShouldSerializeLogo() ? clanInfo.Logo : null,
@@ -94,8 +95,8 @@ public static class AppClanInfoToModel
         {
             SteamId = member.SteamId,
             RoleId = member.RoleId,
-            Joined = DateTimeOffset.FromUnixTimeSeconds(member.Joined).UtcDateTime,
-            LastSeen = DateTimeOffset.FromUnixTimeSeconds(member.LastSeen).UtcDateTime,
+            Joined = DateTimeOffset.FromUnixTimeMilliseconds(member.Joined).UtcDateTime,
+            LastSeen = DateTimeOffset.FromUnixTimeMilliseconds(member.LastSeen).UtcDateTime,
             Notes = member.ShouldSerializeNotes() ? member.Notes : null,
             Online = member.ShouldSerializeOnline() ? member.Online : null
         };
@@ -116,7 +117,7 @@ public static class AppClanInfoToModel
         {
             SteamId = invite.SteamId,
             Recruiter = invite.Recruiter,
-            Timestamp = DateTimeOffset.FromUnixTimeSeconds(invite.Timestamp).UtcDateTime
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(invite.Timestamp).UtcDateTime
         };
     }
 

--- a/tests/RustPlusApi.MockServer/MockResponses.cs
+++ b/tests/RustPlusApi.MockServer/MockResponses.cs
@@ -167,7 +167,7 @@ public static class MockResponses
                 ClanId = clanId,
                 Message = new AppClanMessage
                 {
-                    SteamId = steamId, Name = name, Message = message, Time = 1_700_000_000
+                    SteamId = steamId, Name = name, Message = message, Time = 1_700_000_000_000
                 }
             }
         };
@@ -271,10 +271,10 @@ public static class MockResponses
     {
         ClanId = 4242,
         Name = "Mock Clan",
-        Created = 1_600_000_000,
+        Created = 1_600_000_000_000,
         Creator = 76561198000000001,
         Motd = "Welcome to the mock clan",
-        MotdTimestamp = 1_700_000_000,
+        MotdTimestamp = 1_700_000_000_000,
         MotdAuthor = 76561198000000001,
         Color = 16711680,
         MaxMemberCount = 50,
@@ -284,8 +284,8 @@ public static class MockResponses
             {
                 SteamId = 76561198000000001,
                 RoleId = 0,
-                Joined = 1_600_000_000,
-                LastSeen = 1_700_000_000,
+                Joined = 1_600_000_000_000,
+                LastSeen = 1_700_000_000_000,
                 Online = true
             }
         }
@@ -297,7 +297,7 @@ public static class MockResponses
         {
             new AppClanMessage
             {
-                SteamId = 76561198000000001, Name = "Tester", Message = "clan chat fixture", Time = 1_700_000_000
+                SteamId = 76561198000000001, Name = "Tester", Message = "clan chat fixture", Time = 1_700_000_000_000
             }
         }
     };

--- a/tests/RustPlusApi.UnitTests/ClanInfoPresenceTests.cs
+++ b/tests/RustPlusApi.UnitTests/ClanInfoPresenceTests.cs
@@ -31,7 +31,7 @@ public class ClanInfoPresenceTests
     {
         var proto = Minimal();
         proto.Motd = "m";
-        proto.MotdTimestamp = 1_700_000_000;
+        proto.MotdTimestamp = 1_700_000_000_000;
         proto.MotdAuthor = 5;
         proto.Logo = [1, 2];
         proto.Color = 42;
@@ -41,7 +41,7 @@ public class ClanInfoPresenceTests
         var model = proto.ToClanInfo()!;
 
         Assert.Equal("m", model.Motd);
-        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1_700_000_000).UtcDateTime, model.MotdTimestamp);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000).UtcDateTime, model.MotdTimestamp);
         Assert.Equal(5ul, model.MotdAuthor);
         Assert.Equal(42, model.Color);
         Assert.Equal(50, model.MaxMemberCount);
@@ -85,11 +85,11 @@ public class ClanInfoPresenceTests
     {
         var invite = new ProtoClanInfo.Invite
         {
-            SteamId = 1, Recruiter = 2, Timestamp = 1_700_000_000
+            SteamId = 1, Recruiter = 2, Timestamp = 1_700_000_000_000
         };
         var model = invite.ToClanInvite();
         Assert.Equal(1ul, model.SteamId);
-        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1_700_000_000).UtcDateTime, model.Timestamp);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000).UtcDateTime, model.Timestamp);
     }
 
     [Fact]

--- a/tests/RustPlusApi.UnitTests/ClanMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/ClanMapperTests.cs
@@ -22,9 +22,14 @@ public class ClanMapperTests
         Assert.Equal("Mock Clan", model.Name);
         Assert.Equal("Welcome to the mock clan", model.Motd);
         Assert.Equal(50, model.MaxMemberCount);
+        // Clan timestamps are Unix milliseconds on the wire (live-server verified), unlike
+        // team timestamps which are seconds.
         Assert.Equal(
-            DateTimeOffset.FromUnixTimeSeconds(1_600_000_000).UtcDateTime,
+            DateTimeOffset.FromUnixTimeMilliseconds(1_600_000_000_000).UtcDateTime,
             model.Created);
+        Assert.Equal(
+            DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000).UtcDateTime,
+            model.MotdTimestamp);
     }
 
     [Fact]
@@ -35,6 +40,8 @@ public class ClanMapperTests
         var member = Assert.Single(model!.Members!);
         Assert.Equal(76561198000000001ul, member.SteamId);
         Assert.True(member.Online);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1_600_000_000_000).UtcDateTime, member.Joined);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000).UtcDateTime, member.LastSeen);
     }
 
     [Fact]

--- a/tests/RustPlusApi.UnitTests/RemainingMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/RemainingMapperTests.cs
@@ -161,12 +161,12 @@ public class RemainingMapperTests
     {
         var proto = new AppClanMessage
         {
-            SteamId = 1, Name = "D", Message = "hey", Time = 1_700_000_000
+            SteamId = 1, Name = "D", Message = "hey", Time = 1_700_000_000_000
         };
         var msg = proto.ToClanMessage();
         Assert.Equal(1ul, msg.SteamId);
         Assert.Equal("D", msg.Name);
-        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1_700_000_000).UtcDateTime, msg.Time);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000).UtcDateTime, msg.Time);
     }
 
     [Fact]
@@ -177,7 +177,7 @@ public class RemainingMapperTests
             ClanId = 42,
             Message = new AppClanMessage
             {
-                SteamId = 7, Name = "Eve", Message = "sup", Time = 1_600_000_000
+                SteamId = 7, Name = "Eve", Message = "sup", Time = 1_600_000_000_000
             }
         };
 
@@ -187,7 +187,7 @@ public class RemainingMapperTests
         Assert.Equal(7ul, ev.SteamId);
         Assert.Equal("Eve", ev.Name);
         Assert.Equal("sup", ev.Message);
-        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1_600_000_000).UtcDateTime, ev.Time);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1_600_000_000_000).UtcDateTime, ev.Time);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

With the in-game clan feature now released, live testing showed only 2 of the 4 clan endpoints working. `GetClanInfoAsync` failed with `ArgumentOutOfRangeException: Valid values are between -62135596800 and 253402300799` and `GetClanChatAsync` blew up at enumeration time.

**Root cause:** the server sends every clan timestamp as Unix **milliseconds** (verified with a raw probe against a live server: `created`, `motd_timestamp`, member `joined`/`last_seen`, and message `time` all classify as ms), but the mappers converted with `FromUnixTimeSeconds`. Team timestamps remain seconds — clans are the outlier.

## Changes

- `AppClanInfoToModel`: `Created`, `MotdTimestamp`, member `Joined`/`LastSeen`, invite `Timestamp` now use `FromUnixTimeMilliseconds`
- `AppClanChatToModel`: message `Time` in `ToClanMessage` and `ToClanMessageEvent` (the latter also fixes the `OnClanChatReceived`/`OnClanChanged` broadcast path)
- Mock fixtures updated to realistic millisecond-scale values, so the suite would have caught this (pre-fix, 8 tests fail with the exact live exception)
- Added assertions pinning `MotdTimestamp` and member `Joined`/`LastSeen` conversions

## Test plan

- [x] Full suite green on both TFM hosts (net8.0 → netstandard2.0 build, net10.0)
- [x] Live-server verification via the console sample: `GetClanInfo` and `GetClanChat` both return `IsSuccess: true` with correct dates; `SendClanMessage` and `SetClanMotd` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)