### PR TITLE
feat: raise OnTeamChanged for AppTeamChanged broadcasts

### DIFF
--- a/docs/articles/rustplus-client.md
+++ b/docs/articles/rustplus-client.md
@@ -163,6 +163,7 @@ The complete set of public events across `RustPlusSocket` and `RustPlus`:
 | `OnStorageMonitorTriggered` | `StorageMonitorEventArg` | An `EntityChanged` broadcast classified as a storage monitor: items, capacity or tool-cupboard protection present (TC broadcasts are sometimes partial — capacity may be absent). Item-less `value == true` storage broadcasts carry no contents snapshot and are **not** raised here (observe them via `OnEntityChanged`). |
 | `OnTeamChatReceived` | `TeamMessageEventArg` | A team chat message arrived. |
 | `OnClanChatReceived` | `ClanMessageEventArg` | A clan chat message arrived. |
+| `OnTeamChanged` | `TeamChangedEventArg` | The team snapshot changed (members, map notes, leader, …); carries the triggering `PlayerId`. |
 | `OnClanChanged` | `ClanChangedEventArg` | The clan snapshot changed (roles, members, MOTD, …). |
 | `OnCameraRaysReceived` | `CameraRaysEventArg` | A camera frame broadcast arrived for the subscribed camera. |
 

--- a/samples/RustPlus.ConsoleApp/Features/LiveEvents.cs
+++ b/samples/RustPlus.ConsoleApp/Features/LiveEvents.cs
@@ -16,23 +16,26 @@ internal sealed class LiveEvents(IRustPlus rustPlus)
 
         void OnTeamChat(object? _, TeamMessageEventArg e) => DisplayUtilities.DisplayEvent("TeamChatReceived", e);
         void OnClanChat(object? _, ClanMessageEventArg e) => DisplayUtilities.DisplayEvent("ClanChatReceived", e);
+        void OnTeamChanged(object? _, TeamChangedEventArg e) => DisplayUtilities.DisplayEvent("TeamChanged", e);
         void OnClanChanged(object? _, ClanChangedEventArg e) => DisplayUtilities.DisplayEvent("ClanChanged", e);
 
         rustPlus.OnSmartDeviceTriggered += OnSmartDevice;
         rustPlus.OnStorageMonitorTriggered += OnStorageMonitor;
         rustPlus.OnTeamChatReceived += OnTeamChat;
         rustPlus.OnClanChatReceived += OnClanChat;
+        rustPlus.OnTeamChanged += OnTeamChanged;
         rustPlus.OnClanChanged += OnClanChanged;
 
         Console.Clear();
         Console.WriteLine("Listening for live events (smart switch, storage monitor, team & clan chat,");
-        Console.WriteLine("clan changes). Press any key to stop...\n");
+        Console.WriteLine("team & clan changes). Press any key to stop...\n");
         Console.ReadKey(intercept: true);
 
         rustPlus.OnSmartDeviceTriggered -= OnSmartDevice;
         rustPlus.OnStorageMonitorTriggered -= OnStorageMonitor;
         rustPlus.OnTeamChatReceived -= OnTeamChat;
         rustPlus.OnClanChatReceived -= OnClanChat;
+        rustPlus.OnTeamChanged -= OnTeamChanged;
         rustPlus.OnClanChanged -= OnClanChanged;
 
         return Task.CompletedTask;

--- a/src/RustPlusApi/Data/Events/TeamChangedEventArg.cs
+++ b/src/RustPlusApi/Data/Events/TeamChangedEventArg.cs
@@ -1,0 +1,11 @@
+namespace RustPlusApi.Data.Events;
+
+/// <summary>Event argument raised when the team snapshot changes.</summary>
+public sealed record TeamChangedEventArg
+{
+    /// <summary>The Steam id of the player whose action triggered the change.</summary>
+    public ulong PlayerId { get; init; }
+
+    /// <summary>The updated team snapshot.</summary>
+    public TeamInfo? TeamInfo { get; init; }
+}

--- a/src/RustPlusApi/Extensions/AppTeamInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppTeamInfoToModel.cs
@@ -1,4 +1,5 @@
 using RustPlusApi.Data;
+using RustPlusApi.Data.Events;
 using RustPlusApi.Data.Notes;
 using RustPlusContracts;
 using static RustPlusContracts.AppTeamInfo;
@@ -40,6 +41,16 @@ public static class AppTeamInfoToModel
             DeathNote = deathNote,
             Notes = notes,
             LeaderNotes = appTeamInfo.LeaderMapNotes.ToPlayerNotes()
+        };
+    }
+
+    /// <summary>Maps an <see cref="AppTeamChanged"/> broadcast to a <see cref="TeamChangedEventArg"/>.</summary>
+    /// <param name="appTeamChanged">The protobuf team-changed broadcast.</param>
+    public static TeamChangedEventArg ToTeamChangedEvent(this AppTeamChanged appTeamChanged)
+    {
+        return new TeamChangedEventArg
+        {
+            PlayerId = appTeamChanged.PlayerId, TeamInfo = appTeamChanged.TeamInfo.ToTeamInfo()
         };
     }
 

--- a/src/RustPlusApi/Interfaces/IRustPlus.cs
+++ b/src/RustPlusApi/Interfaces/IRustPlus.cs
@@ -34,6 +34,9 @@ public interface IRustPlus : IRustPlusSocket
     /// <summary>Raised when a new clan chat message arrives.</summary>
     event EventHandler<ClanMessageEventArg>? OnClanChatReceived;
 
+    /// <summary>Raised when the team snapshot changes.</summary>
+    event EventHandler<TeamChangedEventArg>? OnTeamChanged;
+
     /// <summary>Raised when the clan snapshot changes.</summary>
     event EventHandler<ClanChangedEventArg>? OnClanChanged;
 

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -58,6 +58,11 @@ public class RustPlus(
     public event EventHandler<ClanMessageEventArg>? OnClanChatReceived;
 
     /// <summary>
+    /// Occurs when the team changes (members, map notes, leader, …), providing a <see cref="TeamChangedEventArg"/>.
+    /// </summary>
+    public event EventHandler<TeamChangedEventArg>? OnTeamChanged;
+
+    /// <summary>
     /// Occurs when the clan changes (roles, members, MOTD, …), providing a <see cref="ClanChangedEventArg"/>.
     /// </summary>
     public event EventHandler<ClanChangedEventArg>? OnClanChanged;
@@ -606,6 +611,12 @@ public class RustPlus(
         if (broadcast.TeamMessage is not null)
         {
             OnTeamChatReceived?.Invoke(this, broadcast.TeamMessage.Message.ToTeamMessageEvent());
+            return;
+        }
+
+        if (broadcast.TeamChanged is not null)
+        {
+            OnTeamChanged?.Invoke(this, broadcast.TeamChanged.ToTeamChangedEvent());
             return;
         }
 

--- a/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
+++ b/tests/RustPlusApi.UnitTests/RustPlusParseNotificationTests.cs
@@ -123,6 +123,63 @@ public class RustPlusParseNotificationTests
     }
 
     [Fact]
+    public void TeamChanged_WithSubscriber_InvokesHandler()
+    {
+        using var sut = new TestRustPlus();
+        RustPlusApi.Data.Events.TeamChangedEventArg? captured = null;
+        sut.OnTeamChanged += (_, e) => captured = e;
+
+        var broadcast = new AppBroadcast
+        {
+            TeamChanged = new AppTeamChanged
+            {
+                PlayerId = 76561198000000001,
+                TeamInfo = new AppTeamInfo
+                {
+                    LeaderSteamId = 76561198000000001,
+                    Members =
+                    {
+                        new AppTeamInfo.Member
+                        {
+                            SteamId = 76561198000000001, Name = "Leader"
+                        }
+                    }
+                }
+            }
+        };
+
+        sut.Feed(broadcast);
+
+        Assert.NotNull(captured);
+        Assert.Equal(76561198000000001ul, captured!.PlayerId);
+        Assert.NotNull(captured.TeamInfo);
+        Assert.Equal(76561198000000001ul, captured.TeamInfo!.LeaderSteamId);
+        Assert.Single(captured.TeamInfo.Members!);
+    }
+
+    [Fact]
+    public void TeamChanged_NoSubscriber_DoesNotThrow()
+    {
+        using var sut = new TestRustPlus();
+        // OnTeamChanged intentionally NOT subscribed
+
+        var broadcast = new AppBroadcast
+        {
+            TeamChanged = new AppTeamChanged
+            {
+                PlayerId = 76561198000000001,
+                TeamInfo = new AppTeamInfo
+                {
+                    LeaderSteamId = 76561198000000001
+                }
+            }
+        };
+
+        var ex = Record.Exception(() => sut.Feed(broadcast));
+        Assert.Null(ex);
+    }
+
+    [Fact]
     public void ClanMessage_NoSubscriber_DoesNotThrow()
     {
         using var sut = new TestRustPlus();

--- a/tests/RustPlusApi.UnitTests/TeamInfoMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/TeamInfoMapperTests.cs
@@ -75,6 +75,33 @@ public class TeamInfoMapperTests
     }
 
     [Fact]
+    public void ToTeamChangedEvent_MapsPlayerIdAndTeamInfo()
+    {
+        var broadcast = new AppTeamChanged
+        {
+            PlayerId = 76561198000000001,
+            TeamInfo = new AppTeamInfo
+            {
+                LeaderSteamId = 76561198000000002,
+                Members =
+                {
+                    new AppTeamInfo.Member
+                    {
+                        SteamId = 76561198000000002, Name = "Leader"
+                    }
+                }
+            }
+        };
+
+        var arg = broadcast.ToTeamChangedEvent();
+
+        Assert.Equal(76561198000000001ul, arg.PlayerId);
+        Assert.NotNull(arg.TeamInfo);
+        Assert.Equal(76561198000000002ul, arg.TeamInfo!.LeaderSteamId);
+        Assert.Single(arg.TeamInfo.Members!);
+    }
+
+    [Fact]
     public void ToTeamInfo_UnknownNoteType_Throws()
     {
         var info = new AppTeamInfo


### PR DESCRIPTION
## Problem

The `AppBroadcast.team_changed` variant (proto field 4, `AppTeamChanged`) was defined and code-generated, but `RustPlus.ParseNotification` had **no branch for it** — so every team-snapshot change broadcast fell straight through to `Logger.LogUnknownBroadcast(broadcast)` and was silently dropped. Unlike the five sibling broadcasts (`EntityChanged`, `TeamMessage`, `ClanMessage`, `ClanChanged`, `CameraRays`), the entire vertical slice was missing.

## Fix

Mirrors the existing `ClanChanged` pattern end-to-end:

| Area | Change |
|---|---|
| Model | New `TeamChangedEventArg` record — `PlayerId` (ulong) + `TeamInfo?` |
| Mapper | New `AppTeamChanged.ToTeamChangedEvent()` (reuses existing `ToTeamInfo()`) |
| Client | New `OnTeamChanged` event + dispatch branch in `ParseNotification` |
| Contract | `OnTeamChanged` declared on `IRustPlus` |
| Docs | Added to the events table in `rustplus-client.md` |
| Sample | `LiveEvents` console feature now subscribes to `OnTeamChanged` |

## Tests

- `TeamInfoMapperTests.ToTeamChangedEvent_MapsPlayerIdAndTeamInfo`
- `RustPlusParseNotificationTests.TeamChanged_WithSubscriber_InvokesHandler`
- `RustPlusParseNotificationTests.TeamChanged_NoSubscriber_DoesNotThrow`

Both dispatch branches (subscriber / no-subscriber) and the mapper are covered.

## Verification

- `dotnet build RustPlusApi.sln` — clean (TreatWarningsAsErrors)
- Unit tests pass on the **net10.0** host (132 passed). The net8.0 runtime (netstandard2.0 build) isn't installed locally; CI covers both TFMs. The touched code has no `#if` forks.
- ReSharper pre-push formatting check passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)