### PR TITLE
feat: map received_quantity_multiplier and sample_rotation (proto drift 24587531)

### DIFF
--- a/docs/articles/cameras.md
+++ b/docs/articles/cameras.md
@@ -107,6 +107,7 @@ Each `CameraFrame` (delivered via `OnCameraRaysReceived`) contains:
 - `Entities` — list of `CameraEntity` objects visible in the frame (id, type, position/rotation/size, name).
 - `TimeOfDay` — in-game time of day when captured (`null` if not reported).
 - `CameraPosition` / `CameraRotation` — world-space position and rotation (`null` if not reported).
+- `SampleRotation` — world-space rotation the frame's rays were sampled with (`null` if not reported).
 
 ## CameraController
 

--- a/src/RustPlusApi/Data/Cameras/CameraFrame.cs
+++ b/src/RustPlusApi/Data/Cameras/CameraFrame.cs
@@ -31,4 +31,7 @@ public record CameraFrame
 
     /// <summary>World-space rotation of the camera, if reported.</summary>
     public Vector3? CameraRotation { get; init; }
+
+    /// <summary>World-space rotation the frame's rays were sampled with, if reported.</summary>
+    public Vector3? SampleRotation { get; init; }
 }

--- a/src/RustPlusApi/Data/VendingMachineItem.cs
+++ b/src/RustPlusApi/Data/VendingMachineItem.cs
@@ -32,4 +32,7 @@ public sealed record VendingMachineItem
 
     /// <summary>Price multiplier applied to the order, if reported.</summary>
     public float? PriceMultiplier { get; init; }
+
+    /// <summary>Multiplier applied to the quantity actually received per transaction, if reported.</summary>
+    public float? ReceivedQuantityMultiplier { get; init; }
 }

--- a/src/RustPlusApi/Extensions/AppCameraToModel.cs
+++ b/src/RustPlusApi/Extensions/AppCameraToModel.cs
@@ -39,7 +39,8 @@ public static class AppCameraToModel
             Entities = appCameraRays.Entities.ToCameraEntities(),
             TimeOfDay = appCameraRays.ShouldSerializeTimeOfDay() ? appCameraRays.TimeOfDay : null,
             CameraPosition = appCameraRays.CameraPosition?.ToVector3(),
-            CameraRotation = appCameraRays.CameraRotation?.ToVector3()
+            CameraRotation = appCameraRays.CameraRotation?.ToVector3(),
+            SampleRotation = appCameraRays.SampleRotation?.ToVector3()
         };
     }
 
@@ -56,7 +57,8 @@ public static class AppCameraToModel
             Entities = appCameraRays.Entities.ToCameraEntities(),
             TimeOfDay = appCameraRays.ShouldSerializeTimeOfDay() ? appCameraRays.TimeOfDay : null,
             CameraPosition = appCameraRays.CameraPosition?.ToVector3(),
-            CameraRotation = appCameraRays.CameraRotation?.ToVector3()
+            CameraRotation = appCameraRays.CameraRotation?.ToVector3(),
+            SampleRotation = appCameraRays.SampleRotation?.ToVector3()
         };
     }
 

--- a/src/RustPlusApi/Extensions/AppMarkerToModel.cs
+++ b/src/RustPlusApi/Extensions/AppMarkerToModel.cs
@@ -76,7 +76,10 @@ public static class AppMarkerToModel
             IsCurrencyBlueprint = sellOrder.CurrencyIsBlueprint,
             ItemLife = sellOrder.ItemCondition,
             ItemMaxLife = sellOrder.ItemConditionMax,
-            PriceMultiplier = sellOrder.ShouldSerializePriceMultiplier() ? sellOrder.PriceMultiplier : null
+            PriceMultiplier = sellOrder.ShouldSerializePriceMultiplier() ? sellOrder.PriceMultiplier : null,
+            ReceivedQuantityMultiplier = sellOrder.ShouldSerializeReceivedQuantityMultiplier()
+                ? sellOrder.ReceivedQuantityMultiplier
+                : null
         };
     }
 

--- a/src/RustPlusApi/Protobuf/RustPlusContracts.proto
+++ b/src/RustPlusApi/Protobuf/RustPlusContracts.proto
@@ -335,6 +335,7 @@ message AppMarker {
 		optional float item_condition = 8;
 		optional float item_condition_max = 9;
 		optional float price_multiplier = 10;
+		optional float received_quantity_multiplier = 11;
 	}
 }
 
@@ -424,6 +425,7 @@ message AppCameraRays {
 	optional float time_of_day = 6;
 	optional Vector3 camera_position = 7;
 	optional Vector3 camera_rotation = 8;
+	optional Vector3 sample_rotation = 9;
 
 	enum EntityType {
 		Tree = 1;

--- a/tests/RustPlusApi.UnitTests/CameraModelMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/CameraModelMapperTests.cs
@@ -32,6 +32,7 @@ public class CameraModelMapperTests
         Assert.Null(frame.TimeOfDay);
         Assert.Null(frame.CameraPosition);
         Assert.Null(frame.CameraRotation);
+        Assert.Null(frame.SampleRotation);
         Assert.Empty(frame.Entities);
     }
 
@@ -50,6 +51,10 @@ public class CameraModelMapperTests
             CameraRotation = new ProtoVector3
             {
                 X = 4, Y = 5, Z = 6
+            },
+            SampleRotation = new ProtoVector3
+            {
+                X = 7, Y = 8, Z = 9
             }
         };
 
@@ -58,6 +63,7 @@ public class CameraModelMapperTests
         Assert.Equal(0.5f, frame.TimeOfDay);
         Assert.Equal(1, frame.CameraPosition!.X);
         Assert.Equal(6, frame.CameraRotation!.Z);
+        Assert.Equal(9, frame.SampleRotation!.Z);
     }
 
     [Fact]
@@ -74,6 +80,7 @@ public class CameraModelMapperTests
         Assert.Null(frame.TimeOfDay);
         Assert.Null(frame.CameraPosition);
         Assert.Null(frame.CameraRotation);
+        Assert.Null(frame.SampleRotation);
     }
 
     [Fact]
@@ -91,6 +98,10 @@ public class CameraModelMapperTests
             CameraRotation = new ProtoVector3
             {
                 X = 1, Y = 2, Z = 3
+            },
+            SampleRotation = new ProtoVector3
+            {
+                X = 4, Y = 5, Z = 6
             }
         };
 
@@ -99,5 +110,6 @@ public class CameraModelMapperTests
         Assert.Equal(0.75f, frame.TimeOfDay);
         Assert.Equal(10, frame.CameraPosition!.X);
         Assert.Equal(3, frame.CameraRotation!.Z);
+        Assert.Equal(6, frame.SampleRotation!.Z);
     }
 }

--- a/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/MarkerMapperTests.cs
@@ -6,7 +6,7 @@ using static RustPlusContracts.AppMarker;
 namespace RustPlusApi.UnitTests;
 
 /// <summary>Locks every projection in <see cref="AppMarkerToModel"/>, including the sell-order
-/// presence fork on <c>PriceMultiplier</c>.</summary>
+/// presence forks on <c>PriceMultiplier</c> and <c>ReceivedQuantityMultiplier</c>.</summary>
 public class MarkerMapperTests
 {
     private static AppMarker Marker(AppMarkerType type) => new()
@@ -76,6 +76,36 @@ public class MarkerMapperTests
         };
         var item = order.ToVendingMachineItem();
         Assert.Null(item.PriceMultiplier);
+    }
+
+    [Fact]
+    public void ToVendingMachineItem_WhenReceivedQuantityMultiplierSet_MapsValue()
+    {
+        var order = new SellOrder
+        {
+            ItemId = 9,
+            Quantity = 1,
+            CostPerItem = 1,
+            AmountInStock = 1,
+            ReceivedQuantityMultiplier = 2.5f
+        };
+
+        var item = order.ToVendingMachineItem();
+
+        Assert.Equal(2.5f, item.ReceivedQuantityMultiplier);
+    }
+
+    [Fact]
+    public void ToVendingMachineItem_WhenReceivedQuantityMultiplierUnset_IsNull()
+    {
+        var order = new SellOrder
+        {
+            ItemId = 9, Quantity = 1, CostPerItem = 1, AmountInStock = 1
+        };
+
+        var item = order.ToVendingMachineItem();
+
+        Assert.Null(item.ReceivedQuantityMultiplier);
     }
 
     [Theory]


### PR DESCRIPTION
Closes #110.

The ProtoRefresh drift gate flagged two new optional fields on the August 2026 Rust dedicated server (build `24587531`). Both are purely additive — no renames or removals — so the wire format stays compatible; they were simply dropped before reaching the public DTOs.

| Proto | New field | Surfaced as |
| --- | --- | --- |
| `AppMarker.SellOrder` | `optional float received_quantity_multiplier = 11` | `VendingMachineItem.ReceivedQuantityMultiplier` |
| `AppCameraRays` | `optional Vector3 sample_rotation = 9` | `CameraFrame.SampleRotation` (inherited by `CameraRaysEventArg`) |

## Changes

- `RustPlusContracts.proto` — adopt both fields as reported by the diff.
- `VendingMachineItem` / `CameraFrame` — nullable properties following the existing `PriceMultiplier` / `CameraRotation` idiom (absent on the wire → `null`).
- `AppMarkerToModel.ToVendingMachineItem` — `ShouldSerializeReceivedQuantityMultiplier()` presence fork.
- `AppCameraToModel` — mapped in **both** `ToCameraFrame` and `ToCameraRaysEvent`.
- `docs/articles/cameras.md` — `CameraFrame` field list kept in sync.

## Not changed

`CameraRenderer` needs nothing: sample placement comes from the fixed 1337-seeded shuffle buffer indexed by `SampleOffset`, so `sample_rotation` (the orientation the rays were sampled with) is pass-through data for consumers, not a render input. The golden render fixture is unaffected.

## Tests

Written first, watched fail on the missing members, then implemented:

- `MarkerMapperTests` — set/unset pair for `ReceivedQuantityMultiplier`.
- `CameraModelMapperTests` — set/unset for `SampleRotation` across both mappers.

`dotnet test RustPlusApi.sln -f net10.0` → 463 passed. The net8.0 host (netstandard2.0 asset) wasn't runnable locally — that runtime isn't installed on this machine — so CI covers that half; the netstandard2.0 target compiles clean in the full solution build. Coverage on the net10.0 run keeps `AppMarkerToModel` and `AppCameraToModel` at 100% line/branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)