### PR TITLE
fix: resolve open SonarQube issues (S8969, PBN2013)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -406,6 +406,13 @@ dotnet_diagnostic.CA1062.severity = none # Validate parameters — nullable refe
 
 dotnet_diagnostic.IDE0058.severity = none # Expression not used (boring with extension methods) _ = Foo()
 
+# protobuf-net.BuildTools (ships inside protobuf-net.Core 3.3+).
+# PBN2013 suggests [ProtoModel] to get compile-time serializers. That attribute is still experimental —
+# applying it raises PBN9001 ("for evaluation purposes only and is subject to change or removal") — and it
+# cascades PBN2010/PBN2011 onto every Serializer.Serialize / NonGeneric.Deserialize call site, i.e. a full
+# AOT rewrite. Not a trade worth making for a first-serialize perf hint; revisit once the attribute is stable.
+dotnet_diagnostic.PBN2013.severity = none # protobuf-net contracts without a [ProtoModel] compile-time serializer
+
 dotnet_diagnostic.Moq1203.severity = none # Method setup should specify a return value
 dotnet_diagnostic.Moq1400.severity = none # Choose a mock behaviour (strict, loose)
 dotnet_diagnostic.Moq1410.severity = none # Set behaviour to Strict

--- a/src/RustPlusApi.Fcm.Registration/FcmRegistration.cs
+++ b/src/RustPlusApi.Fcm.Registration/FcmRegistration.cs
@@ -55,7 +55,10 @@ public sealed class FcmRegistration(HttpClient? httpClient = null, int steamLogi
     public async Task<string> RegisterWithRustPlusAsync(Credentials credentials,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrEmpty(credentials.ExpoPushToken))
+        // Narrow with a pattern rather than string.IsNullOrEmpty: netstandard2.0's reference assembly lacks the
+        // [NotNullWhen(false)] annotation, so only the pattern proves non-nullness to the compiler on both TFMs.
+        var expoPushToken = credentials.ExpoPushToken;
+        if (expoPushToken is not { Length: > 0 })
         {
             throw new InvalidOperationException(
                 "Credentials are missing the Expo push token; call AcquireCredentialsAsync first.");
@@ -63,7 +66,7 @@ public sealed class FcmRegistration(HttpClient? httpClient = null, int steamLogi
 
         var steamToken = await _steamLoginService.LoginAsync(cancellationToken).ConfigureAwait(false);
         await _rustCompanionClient
-            .RegisterAsync(steamToken, credentials.ExpoPushToken!, cancellationToken: cancellationToken)
+            .RegisterAsync(steamToken, expoPushToken, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
         return steamToken;
     }

--- a/src/RustPlusApi.Fcm.Registration/Steps/SteamLoginService.cs
+++ b/src/RustPlusApi.Fcm.Registration/Steps/SteamLoginService.cs
@@ -83,9 +83,11 @@ public sealed class SteamLoginService(int port = 3000)
 
                 var token = await ReadTokenAsync(context.Request).ConfigureAwait(false);
                 await RespondAsync(context, "<h1>Done. You can close this window.</h1>").ConfigureAwait(false);
-                if (!string.IsNullOrEmpty(token))
+                // Narrow with a pattern rather than string.IsNullOrEmpty: netstandard2.0's reference assembly lacks
+                // the [NotNullWhen(false)] annotation, so only the pattern proves non-nullness on both TFMs.
+                if (token is { Length: > 0 })
                 {
-                    return token!;
+                    return token;
                 }
             }
         }
@@ -339,7 +341,7 @@ public sealed class SteamLoginService(int port = 3000)
             return null;
         }
 
-        foreach (var directory in pathVariable!.Split(Path.PathSeparator))
+        foreach (var directory in pathVariable.Split(Path.PathSeparator))
         {
             var candidate = Path.Combine(directory, executable);
             if (File.Exists(candidate))

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -91,6 +91,10 @@ public abstract class RustPlusFcmSocket(
     /// <summary>The transport stream used for reading and writing MCS frames.
     /// In production this is set to the authenticated <see cref="SslStream"/> immediately after
     /// TLS handshake; tests supply an in-memory stream via <see cref="RunReceiveLoopOverStreamAsync"/>.</summary>
+    /// <remarks>Read/write helpers dereference this as <c>_transport!</c>: they only ever run once the transport is
+    /// established, but no guard is in scope for the compiler to see, so dropping the null-forgiving operator fails
+    /// the build with CS8602 on both target frameworks. Sonar's S8969 ("the compiler already knows this expression is
+    /// not null here") is therefore a false positive at those call sites and is suppressed there.</remarks>
     private Stream? _transport;
 
     /// <summary>Tear-free accessor over <see cref="_lastTrafficTicks"/>.</summary>
@@ -599,10 +603,11 @@ public abstract class RustPlusFcmSocket(
         while (bytesRead < size)
         {
             // byte[] overload is intentional: the Memory<byte> overload (preferred by CA1835) is unavailable on netstandard2.0.
-#pragma warning disable CA1835
+            // S8969 is a false positive on _transport! — see the field's remarks.
+#pragma warning disable CA1835, S8969
             var read = await _transport!.ReadAsync(buffer, bytesRead, size - bytesRead, CancellationToken)
                 .ConfigureAwait(false);
-#pragma warning restore CA1835
+#pragma warning restore CA1835, S8969
             if (read == 0)
             {
                 throw new EndOfStreamException(); // stream closed before the full frame arrived
@@ -622,9 +627,10 @@ public abstract class RustPlusFcmSocket(
     {
         var one = new byte[1];
         // byte[] overload is intentional: the Memory<byte> overload (preferred by CA1835) is unavailable on netstandard2.0.
-#pragma warning disable CA1835
+        // S8969 is a false positive on _transport! — see the field's remarks.
+#pragma warning disable CA1835, S8969
         var read = await _transport!.ReadAsync(one, 0, 1, CancellationToken).ConfigureAwait(false);
-#pragma warning restore CA1835
+#pragma warning restore CA1835, S8969
         return read == 0 ? -1 : one[0];
     }
 
@@ -678,9 +684,10 @@ public abstract class RustPlusFcmSocket(
         try
         {
             // byte[] overload is intentional: the Memory<byte> overload (preferred by CA1835) is unavailable on netstandard2.0.
-#pragma warning disable CA1835
+            // S8969 is a false positive on _transport! — see the field's remarks.
+#pragma warning disable CA1835, S8969
             await _transport!.WriteAsync(frame, 0, frame.Length, CancellationToken).ConfigureAwait(false);
-#pragma warning restore CA1835
+#pragma warning restore CA1835, S8969
         }
         finally
         {

--- a/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
+++ b/src/RustPlusApi.Fcm/RustPlusFcmSocket.cs
@@ -91,10 +91,12 @@ public abstract class RustPlusFcmSocket(
     /// <summary>The transport stream used for reading and writing MCS frames.
     /// In production this is set to the authenticated <see cref="SslStream"/> immediately after
     /// TLS handshake; tests supply an in-memory stream via <see cref="RunReceiveLoopOverStreamAsync"/>.</summary>
-    /// <remarks>Read/write helpers dereference this as <c>_transport!</c>: they only ever run once the transport is
-    /// established, but no guard is in scope for the compiler to see, so dropping the null-forgiving operator fails
-    /// the build with CS8602 on both target frameworks. Sonar's S8969 ("the compiler already knows this expression is
-    /// not null here") is therefore a false positive at those call sites and is suppressed there.</remarks>
+    /// <remarks>The read/write helpers dereference this as <c>_transport!</c>: they are only reachable once the
+    /// transport has been assigned, and the success path never clears it again — teardown disposes the stream rather
+    /// than nulling the field, so a read racing teardown surfaces <see cref="ObjectDisposedException"/> rather than a
+    /// null. No guard is in scope for the compiler to see, though, so dropping the null-forgiving operator fails the
+    /// build with CS8602 on both target frameworks; Sonar's S8969 ("the compiler already knows this expression is not
+    /// null here") is wrong at those call sites and is suppressed there.</remarks>
     private Stream? _transport;
 
     /// <summary>Tear-free accessor over <see cref="_lastTrafficTicks"/>.</summary>

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -69,11 +69,18 @@ public abstract class RustPlusSocket(
     /// <summary>int (not uint) so Interlocked.Increment works on netstandard2.0, which lacks the uint overload.</summary>
     private int _seq;
 
-    /// <summary>The underlying socket; <see langword="null"/> until connected and again after disposal.</summary>
-    /// <remarks>The close and send paths dereference this as <c>_webSocket!</c>: they only ever run on a connected
-    /// socket, but no guard is in scope for the compiler to see, so dropping the null-forgiving operator fails the
-    /// build with CS8602 on both target frameworks. Sonar's S8969 ("the compiler already knows this expression is not
-    /// null here") is therefore a false positive at those call sites and is suppressed there.</remarks>
+    /// <summary>The underlying socket; <see langword="null"/> until connected, again after disposal, and
+    /// transiently during a reconnect (<see cref="ConnectAsync"/> disposes and clears it before rebuilding).</summary>
+    /// <remarks>Two paths dereference this as <c>_webSocket!</c>, for different reasons.
+    /// <see cref="DisconnectAsync"/> runs under the lifecycle lock and has already returned unless
+    /// <see cref="IsConnected"/>, so the field really is non-null there — but the guard is a property, so the
+    /// compiler cannot narrow the field through it. <see cref="ProcessSendQueueAsync"/> has no such guard and makes
+    /// no such promise: a concurrent reconnect can clear the field while that loop is still draining, so the
+    /// dereference genuinely can throw. That is handled rather than prevented — the loop's catch-all surfaces the
+    /// fault and fails the pending requests instead of letting them time out. Either way the operator is
+    /// load-bearing: dropping it fails the build with CS8602 on both target frameworks, so Sonar's S8969 ("the
+    /// compiler already knows this expression is not null here") is wrong at both sites and is suppressed there.
+    /// </remarks>
     private ClientWebSocket? _webSocket;
 
     /// <summary>Test seam: the number of in-flight requests awaiting a seq-bearing response.</summary>
@@ -306,7 +313,8 @@ public abstract class RustPlusSocket(
                 using var closeTimeout = new CancellationTokenSource(_options.TeardownTimeout);
                 using var linked =
                     CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, closeTimeout.Token);
-                // S8969 is a false positive on _webSocket! — see the field's remarks.
+                // Non-null via the IsConnected check above, which the compiler cannot narrow through.
+                // S8969 (claims the operator is redundant) is wrong — see the field's remarks.
 #pragma warning disable S8969
                 await _webSocket!.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, linked.Token)
                     .ConfigureAwait(false);
@@ -662,7 +670,8 @@ public abstract class RustPlusSocket(
 #pragma warning restore RCS1261
                     Serializer.Serialize(ms, request);
                     var buffer = ms.ToArray();
-                    // S8969 is a false positive on _webSocket! — see the field's remarks.
+                    // A concurrent reconnect can clear _webSocket here; the catch-all below handles that.
+                    // S8969 (claims the operator is redundant) is wrong — see the field's remarks.
 #pragma warning disable S8969
                     await _webSocket!.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Binary, true,
                         CancellationToken).ConfigureAwait(false);

--- a/src/RustPlusApi/RustPlusSocket.cs
+++ b/src/RustPlusApi/RustPlusSocket.cs
@@ -69,6 +69,11 @@ public abstract class RustPlusSocket(
     /// <summary>int (not uint) so Interlocked.Increment works on netstandard2.0, which lacks the uint overload.</summary>
     private int _seq;
 
+    /// <summary>The underlying socket; <see langword="null"/> until connected and again after disposal.</summary>
+    /// <remarks>The close and send paths dereference this as <c>_webSocket!</c>: they only ever run on a connected
+    /// socket, but no guard is in scope for the compiler to see, so dropping the null-forgiving operator fails the
+    /// build with CS8602 on both target frameworks. Sonar's S8969 ("the compiler already knows this expression is not
+    /// null here") is therefore a false positive at those call sites and is suppressed there.</remarks>
     private ClientWebSocket? _webSocket;
 
     /// <summary>Test seam: the number of in-flight requests awaiting a seq-bearing response.</summary>
@@ -301,8 +306,11 @@ public abstract class RustPlusSocket(
                 using var closeTimeout = new CancellationTokenSource(_options.TeardownTimeout);
                 using var linked =
                     CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, closeTimeout.Token);
+                // S8969 is a false positive on _webSocket! — see the field's remarks.
+#pragma warning disable S8969
                 await _webSocket!.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, linked.Token)
                     .ConfigureAwait(false);
+#pragma warning restore S8969
             }
             catch (OperationCanceledException)
             {
@@ -654,8 +662,11 @@ public abstract class RustPlusSocket(
 #pragma warning restore RCS1261
                     Serializer.Serialize(ms, request);
                     var buffer = ms.ToArray();
+                    // S8969 is a false positive on _webSocket! — see the field's remarks.
+#pragma warning disable S8969
                     await _webSocket!.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Binary, true,
                         CancellationToken).ConfigureAwait(false);
+#pragma warning restore S8969
                 }
             }
         }


### PR DESCRIPTION
Clears the 10 open SonarQube issues that are failing the quality gate. The gate's other conditions already pass (`new_coverage` 94.9% ≥ 80, `new_duplicated_lines_density` 0.0 ≤ 3); `new_violations` was the only `ERROR`, at 10 against a threshold of 0.

## S8969 — "Remove this null-forgiving operator" (8 issues)

These looked uniform but split into three genuinely different cases, so they get three different treatments.

**1. Actually redundant — operator removed (1)**

`SteamLoginService.ResolveOnPath` — `pathVariable!` was dead weight on both TFMs. Removed, no other change needed.

**2. Redundant on net10.0 only — fixed by narrowing differently (2)**

`FcmRegistration.RegisterWithRustPlusAsync` and `SteamLoginService.LoginAsync`. Sonar analyses the net10.0 compilation, where `string.IsNullOrEmpty` carries `[NotNullWhen(false)]`. netstandard2.0's reference assembly does not, so the operator was load-bearing there — removing it outright fails that TFM with `CS8604` / `CS8603`.

Rather than suppress, the guards now narrow with a pattern (`is { Length: > 0 }` / `is not { Length: > 0 }`), which is compiler-intrinsic and so proves non-nullness identically on both TFMs. That lets the operator go for real and removes a silent behavioural difference between the two builds.

**3. False positives — suppressed with justification (5)**

`RustPlusSocket._webSocket` (2 sites) and `RustPlusFcmSocket._transport` (3 sites). Both are plain nullable fields with no guard in scope at those call sites. Removing the operator fails the build with `CS8602` on **both** TFMs — directly contradicting the rule message, "the compiler already knows this expression is not null here".

Suppressed at each call site with a one-line pointer, and the full reasoning recorded once in each field's `<remarks>` so the next reader doesn't have to re-derive it.

## PBN2013 — "protobuf-net contracts and no [ProtoModel]" (2 issues)

Suppressed in `.editorconfig`, with the rationale inline.

I tried the suggested fix first. Adding `[ProtoModel]` raises **PBN9001** — the attribute is *"for evaluation purposes only and is subject to change or removal in future updates"* — and it cascades **PBN2010/PBN2011** onto every existing `Serializer.Serialize` / `NonGeneric.Deserialize` call site, because those go through the runtime model. Adopting it properly means a full AOT rewrite of the serialization paths, gated behind an experimental API, in exchange for an INFO-severity first-serialize perf hint. Not a trade worth making here; the suppression comment says to revisit once the attribute stabilises.

## Verification

- Clean solution build: **0 warnings, 0 errors** (`TreatWarningsAsErrors` + `latest-all` analysers).
- Both TFMs compile — each of the three projects was also built per-TFM to pin down which failures were netstandard2.0-specific.
- **463 tests pass** on the net10.0 host.
- Confirmed via the SARIF error log — the same channel the Sonar scanner imports from — that neither rule emits an unsuppressed diagnostic. The intentional suppressions show up as `"suppressionStates": ["suppressedInSource"]`, which the scanner ignores.
- ReSharper `ReformatAndReorder` clean; pre-push hook passed.

**One gap:** the net8.0 test host (which exercises the netstandard2.0 build) could not run locally — only the .NET 10 runtime is installed in this environment, so `dotnet test` aborts on that host. The netstandard2.0 build itself is verified to compile; CI runs both hosts and will cover the parity assertion.

No behavioural change is intended: 3 operators removed as genuinely redundant, 2 guards re-expressed with equivalent semantics, 5 suppressions with no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)