### PR TITLE
fix: retarget the PBN2013 suppression to PBN3013

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -407,11 +407,13 @@ dotnet_diagnostic.CA1062.severity = none # Validate parameters — nullable refe
 dotnet_diagnostic.IDE0058.severity = none # Expression not used (boring with extension methods) _ = Foo()
 
 # protobuf-net.BuildTools (ships inside protobuf-net.Core 3.3+).
-# PBN2013 suggests [ProtoModel] to get compile-time serializers. That attribute is still experimental —
-# applying it raises PBN9001 ("for evaluation purposes only and is subject to change or removal") — and it
-# cascades PBN2010/PBN2011 onto every Serializer.Serialize / NonGeneric.Deserialize call site, i.e. a full
-# AOT rewrite. Not a trade worth making for a first-serialize perf hint; revisit once the attribute is stable.
-dotnet_diagnostic.PBN2013.severity = none # protobuf-net contracts without a [ProtoModel] compile-time serializer
+# PBN3013 (PBN2013 before protobuf-net 3.4, which renumbered the 2011-2013 family to 3011-3013 and reused the
+# PBN2010 slot for an unrelated error-level rule) suggests [ProtoModel] to get compile-time serializers. That
+# attribute is still experimental — applying it raises PBN9001 ("for evaluation purposes only and is subject to
+# change or removal") — and it cascades PBN3010/PBN3011 onto every Serializer.Serialize / NonGeneric.Deserialize
+# call site, i.e. a full AOT rewrite. Not a trade worth making for a first-serialize perf hint; revisit once the
+# attribute is stable.
+dotnet_diagnostic.PBN3013.severity = none # protobuf-net contracts without a [ProtoModel] compile-time serializer
 
 dotnet_diagnostic.Moq1203.severity = none # Method setup should specify a return value
 dotnet_diagnostic.Moq1400.severity = none # Choose a mock behaviour (strict, loose)


### PR DESCRIPTION
## Problem

The SonarQube quality gate on `develop` is failing on `new_violations = 2` (coverage 94.9% and duplication both pass). Both violations are `external_roslyn:PBN3013` — *"protobuf-net contracts and no `[ProtoModel]`"*:

- `src/RustPlusApi.Fcm/ProtoBuf/Mcs.cs:380`
- `src/RustPlusApi.Fcm.Registration/Protobuf/CheckinContracts.cs:67`

## Why it came back

This is the rule #113 already suppressed. It reappeared because 3aa4c12 bumped protobuf-net **3.3.21 → 3.4.19**, and 3.4 renumbered the analyzer's rule catalog:

| 3.3.x | 3.4.19 | Title |
|---|---|---|
| PBN2011 | PBN3011 | Call resolves its contract type at run time |
| PBN2012 | PBN3012 | Publishes AOT/trimmed but has no AOT model |
| **PBN2013** | **PBN3013** | Compile-time serializers are available |

`.editorconfig` therefore silences an ID that no longer exists in the analyzer, and PBN3013 fires unsuppressed at `note` severity — invisible in build output (0 warnings), but present in the SARIF error log, which is the channel the Sonar scanner imports.

## Why retarget rather than adopt `[ProtoModel]`

#113's rationale still holds in 3.4.19, so only the ID it was written against is stale:

- `ProtoModelAttribute` is still marked `[Experimental("PBN9001")]` in `protobuf-net.Core` 3.4.19.
- It still cascades onto every `Serializer.Serialize` / `NonGeneric.Deserialize` call site — those cascading rules were just renumbered too (PBN2010/PBN2011 → PBN3010/PBN3011), so the comment's cross-references are refreshed alongside the ID.

Still not a trade worth making for a first-serialize perf hint; the "revisit once the attribute is stable" note stands.

## Note on PBN2010

The updated comment also records that 3.4 **reused the PBN2010 slot** for an unrelated `error`-level rule (`ServiceContractAnalyzer.StreamingSyncMethod`). Nothing is broken today — that ID appeared in prose only, never in a suppression — but it is a trap for anyone copying these IDs into a suppression later.

## Verification

- PBN3013 gone from the SARIF for all three protobuf-using projects (`RustPlusApi`, `.Fcm`, `.Fcm.Registration`), both TFMs.
- Clean solution build: 0 warnings, 0 errors.
- 463 tests green on the net10.0 host.
- The net8.0 host could not be exercised locally (only the .NET 10 runtime is installed on this machine); CI covers it. The change is analyzer configuration only and compiles on both TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)