### PR TITLE
fix(proto): recover fields from if-dispatch, guard against silent field loss

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,7 +52,8 @@ jobs:
         "-reporttypes:Cobertura"
 
     - name: Enforce coverage threshold
-      # Merged aggregate across all 7 test projects and both TFMs (ReportGenerator union).
+      # Merged aggregate across all 8 test projects and both TFMs (ReportGenerator union).
+      # ProtoGen.UnitTests covers the build-time proto tool and is excluded from the metric.
       # Metric: ReportGenerator-merged Cobertura line-rate/branch-rate.
       # Achieved: ~96.7% line / ~91.4% branch. Gate floor: line 95 / branch 90 —
       # keep in sync with docs/development/testing.md ("Coverage gate").

--- a/.github/workflows/ProtoRefresh.yml
+++ b/.github/workflows/ProtoRefresh.yml
@@ -58,12 +58,32 @@ jobs:
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
           exit 0
 
+      # The decompiled contracts are the input ProtoGen parses. Keeping them lets a
+      # surprising diff be traced back to the exact decompiled shape without re-running the
+      # multi-GB fetch — the drift issue alone is not enough to debug a parser regression.
+      - name: Upload decompiled contracts artifact
+        if: always() && steps.gate.outputs.run == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: decompiled-contracts
+          path: tools/update-proto/decompiled/
+          if-no-files-found: warn
+
       - name: Upload diff artifact
         if: steps.gate.outputs.run == 'true' && steps.refresh.outputs.exit_code == '1'
         uses: actions/upload-artifact@v7
         with:
           name: proto-diff
           path: tools/update-proto/out/proto.diff
+
+      # 0 = clean, 1 = drift (handled below). Anything else is a pipeline/tool failure —
+      # notably ProtoGen's field-loss guard (exit 3) — and must go red rather than quietly
+      # producing no issue.
+      - name: Fail on pipeline error
+        if: steps.gate.outputs.run == 'true' && steps.refresh.outputs.exit_code != '0' && steps.refresh.outputs.exit_code != '1'
+        run: |
+          echo "::error::proto refresh failed with exit code ${{ steps.refresh.outputs.exit_code }} — see the 'Run proto refresh' step."
+          exit 1
 
       - name: Open or update drift issue
         if: steps.gate.outputs.run == 'true' && steps.refresh.outputs.exit_code == '1'
@@ -74,6 +94,7 @@ jobs:
           set -euo pipefail
           manifest="tools/update-proto/rds/steamapps/appmanifest_258550.acf"
           build_id="$(grep -o '"buildid"[^0-9]*[0-9]*' "$manifest" 2>/dev/null | grep -o '[0-9]*' || echo unknown)"
+          ilspy_version="$(cat tools/update-proto/decompiled/.ilspy-version 2>/dev/null || echo unknown)"
 
           {
             echo "The Rust dedicated server's Companion contracts have drifted from the committed"
@@ -81,6 +102,7 @@ jobs:
             echo
             echo "- **Server build id:** \`${build_id}\`"
             echo "- **Workflow run:** ${RUN_URL}"
+            echo "- **Decompiler:** \`ilspycmd ${ilspy_version}\`"
             echo
             echo "Review the diff and apply the genuine wire changes (plus any matching \`Data/*\` model"
             echo "and \`Extensions/*\` mapper updates), then open a PR. See \`tools/update-proto/README.md\`."

--- a/RustPlusApi.sln
+++ b/RustPlusApi.sln
@@ -62,6 +62,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RustPlus.Camera.ConsoleApp"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RustPlusApi.Camera.IntegrationTests", "tests\RustPlusApi.Camera.IntegrationTests\RustPlusApi.Camera.IntegrationTests.csproj", "{20A96556-CCED-4AF7-8CB9-F853CC8C77E3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProtoGen.UnitTests", "tests\ProtoGen.UnitTests\ProtoGen.UnitTests.csproj", "{E0728EA1-0D3D-4AA9-ADA3-397616716200}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "update-proto", "update-proto", "{AED36C42-C4F3-0BED-678E-0E89E3357887}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -324,6 +328,18 @@ Global
 		{20A96556-CCED-4AF7-8CB9-F853CC8C77E3}.Release|x64.Build.0 = Release|Any CPU
 		{20A96556-CCED-4AF7-8CB9-F853CC8C77E3}.Release|x86.ActiveCfg = Release|Any CPU
 		{20A96556-CCED-4AF7-8CB9-F853CC8C77E3}.Release|x86.Build.0 = Release|Any CPU
+		{E0728EA1-0D3D-4AA9-ADA3-397616716200}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E0728EA1-0D3D-4AA9-ADA3-397616716200}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E0728EA1-0D3D-4AA9-ADA3-397616716200}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E0728EA1-0D3D-4AA9-ADA3-397616716200}.Debug|x64.Build.0 = Debug|Any CPU
+		{E0728EA1-0D3D-4AA9-ADA3-397616716200}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E0728EA1-0D3D-4AA9-ADA3-397616716200}.Debug|x86.Build.0 = Debug|Any CPU
+		{E0728EA1-0D3D-4AA9-ADA3-397616716200}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E0728EA1-0D3D-4AA9-ADA3-397616716200}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E0728EA1-0D3D-4AA9-ADA3-397616716200}.Release|x64.ActiveCfg = Release|Any CPU
+		{E0728EA1-0D3D-4AA9-ADA3-397616716200}.Release|x64.Build.0 = Release|Any CPU
+		{E0728EA1-0D3D-4AA9-ADA3-397616716200}.Release|x86.ActiveCfg = Release|Any CPU
+		{E0728EA1-0D3D-4AA9-ADA3-397616716200}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -350,6 +366,8 @@ Global
 		{09FE4712-EC55-47C6-9780-4C3A33C30832} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{AE59D626-EC9F-490F-884B-E229D202B23A} = {0B23F464-4021-46B2-9AD7-04C16FA9B6F1}
 		{20A96556-CCED-4AF7-8CB9-F853CC8C77E3} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{E0728EA1-0D3D-4AA9-ADA3-397616716200} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{AED36C42-C4F3-0BED-678E-0E89E3357887} = {45DEC691-A832-41DE-A585-008B5C8BB4F2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A4B4251F-ADA4-418D-95B5-27BA99A307A3}

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -7,7 +7,8 @@ coverage, how to run mutation testing, and why certain members are excluded from
 
 ## Test projects
 
-The monolithic test project was split into **seven** focused projects under `tests/`:
+The monolithic test project was split into **seven** focused projects under `tests/`, plus one
+covering the build-time proto tool:
 
 | Source project | Unit tests | Integration tests |
 | --- | --- | --- |
@@ -17,6 +18,13 @@ The monolithic test project was split into **seven** focused projects under `tes
 | `RustPlusApi.Camera` | `RustPlusApi.Camera.UnitTests` | `RustPlusApi.Camera.IntegrationTests` |
 | `RustPlusApi.Extensions.DependencyInjection` | `RustPlusApi.Extensions.DependencyInjection.UnitTests` | — (none yet) |
 | `RustPlusApi.Fcm.Extensions.DependencyInjection` | `RustPlusApi.Fcm.Extensions.DependencyInjection.UnitTests` | — (none yet) |
+
+`ProtoGen.UnitTests` covers `tools/update-proto/ProtoGen`, the tool that regenerates
+`RustPlusContracts.proto` from the decompiled Rust server. It is the one test project that does
+**not** follow the multi-TFM parity rule below: ProtoGen is a `net10.0`-only build-time tool rather
+than a shipped library, so the project targets `net10.0` alone. It is likewise excluded from the
+coverage gate (`[ProtoGen]*` in `coverlet.runsettings`), matching Sonar's existing `**/tools/**`
+coverage exclusion — the tool must not move the shipped libraries' aggregate in either direction.
 
 `RustPlusApi.MockServer` is the shared in-process test server used by integration tests.
 Integration test projects for `RustPlusApi.Fcm` and `RustPlusApi.Fcm.Registration` will be added
@@ -68,7 +76,8 @@ below.
 
 ## Multi-TFM parity mechanism
 
-The test projects target `net8.0;net10.0`. The production libraries target `netstandard2.0;net10.0`.
+The test projects target `net8.0;net10.0` (except `ProtoGen.UnitTests`, see above). The production
+libraries target `netstandard2.0;net10.0`.
 
 When the test runner uses a `net8.0` host, it cannot load the `net10.0` asset of a multi-targeted
 library; the .NET SDK resolves the `netstandard2.0` build instead. When the runner uses a `net10.0`

--- a/tests/ProtoGen.UnitTests/FieldLossGuardTests.cs
+++ b/tests/ProtoGen.UnitTests/FieldLossGuardTests.cs
@@ -1,0 +1,213 @@
+using Xunit;
+
+namespace ProtoGen.UnitTests;
+
+/// <summary>
+/// The guard that turns silent field loss into a hard failure. ProtoGen recovers fields by parsing
+/// decompiled C#; when it fails to recognise a dispatch shape it produces a message with no fields
+/// and no error, which reads as a deliberate server-side removal. Losing a committed field is
+/// therefore treated as a tool failure until a human says otherwise.
+/// </summary>
+public class FieldLossGuardTests
+{
+    /// <summary>A message whose single field is recovered normally.</summary>
+    private const string IntactSendMessage = """
+                                             public class AppSendMessage : IProto<AppSendMessage>
+                                             {
+                                                 public string message;
+
+                                                 public static AppSendMessage Deserialize(Stream stream, AppSendMessage instance, long limit)
+                                                 {
+                                                     while (true)
+                                                     {
+                                                         int num = stream.ReadByte();
+                                                         switch (num)
+                                                         {
+                                                         case 10:
+                                                             instance.message = ProtocolParser.ReadString(stream);
+                                                             continue;
+                                                         }
+                                                         return instance;
+                                                     }
+                                                 }
+                                             }
+                                             """;
+
+    /// <summary>The same message with a dispatch the parser cannot read — yields zero fields.</summary>
+    private const string UnparsableSendMessage = """
+                                                 public class AppSendMessage : IProto<AppSendMessage>
+                                                 {
+                                                     public string message;
+
+                                                     public static AppSendMessage Deserialize(Stream stream, AppSendMessage instance, long limit)
+                                                     {
+                                                         return instance;
+                                                     }
+                                                 }
+                                                 """;
+
+    /// <summary>Builds a committed-proto baseline from literal proto lines.</summary>
+    /// <param name="lines">Proto source lines.</param>
+    private static CommittedProto Committed(params string[] lines) => CommittedProto.ParseLines(lines);
+
+    /// <summary>Parses decompiled message declarations into a server model.</summary>
+    /// <param name="body">Decompiled message declarations.</param>
+    private static ServerParser Server(string body) =>
+        ServerParser.ParseSource($$"""
+                                   using System.IO;
+
+                                   namespace ProtoBuf
+                                   {
+                                   {{body}}
+                                   }
+                                   """);
+
+    [Fact]
+    public void Check_ReportsNothing_WhenEveryCommittedFieldSurvives()
+    {
+        var losses = FieldLossGuard.Check(
+            Committed("message AppSendMessage {", "\trequired string message = 1;", "}"),
+            Server(IntactSendMessage),
+            new HashSet<string>(StringComparer.Ordinal)
+            {
+                "AppSendMessage"
+            });
+
+        Assert.Empty(losses);
+    }
+
+    [Fact]
+    public void Check_ReportsLoss_WhenMessageIsEmptiedOut()
+    {
+        // This is issue #120's exact signature: a committed single-field message emitted empty.
+        var losses = FieldLossGuard.Check(
+            Committed("message AppSendMessage {", "\trequired string message = 1;", "}"),
+            Server(UnparsableSendMessage),
+            new HashSet<string>(StringComparer.Ordinal)
+            {
+                "AppSendMessage"
+            });
+
+        var loss = Assert.Single(losses);
+        Assert.Equal("AppSendMessage", loss.Message);
+        Assert.Equal(1, loss.Number);
+    }
+
+    [Fact]
+    public void Check_ReportsLoss_WhenOnlySomeFieldsAreRecovered()
+    {
+        // A partial loss is the more dangerous case: the message still looks populated, so a
+        // reviewer skimming the diff sees a plausible single-field removal.
+        var losses = FieldLossGuard.Check(
+            Committed(
+                "message AppTeamInfo {",
+                "\trequired string name = 1;",
+                "\trequired uint64 steam_id = 2;",
+                "}"),
+            Server("""
+                   public class AppTeamInfo : IProto<AppTeamInfo>
+                   {
+                       public string name;
+                       public ulong steamId;
+
+                       public static AppTeamInfo Deserialize(Stream stream, AppTeamInfo instance, long limit)
+                       {
+                           while (true)
+                           {
+                               int num = stream.ReadByte();
+                               switch (num)
+                               {
+                               case 10:
+                                   instance.name = ProtocolParser.ReadString(stream);
+                                   continue;
+                               }
+                               return instance;
+                           }
+                       }
+                   }
+                   """),
+            new HashSet<string>(StringComparer.Ordinal)
+            {
+                "AppTeamInfo"
+            });
+
+        var loss = Assert.Single(losses);
+        Assert.Equal("AppTeamInfo", loss.Message);
+        Assert.Equal(2, loss.Number);
+    }
+
+    [Fact]
+    public void Check_IgnoresMessagesOutsideScope_TheyAreEmittedVerbatim()
+    {
+        // Out-of-scope committed types (e.g. ClanInvitations, Vector3) are copied from the committed
+        // proto rather than regenerated, so they cannot lose a field no matter what the parser did.
+        var losses = FieldLossGuard.Check(
+            Committed("message ClanInvitations {", "\trepeated ClanInvitations.Invitation invitations = 1;", "}"),
+            Server(UnparsableSendMessage),
+            new HashSet<string>(StringComparer.Ordinal));
+
+        Assert.Empty(losses);
+    }
+
+    [Fact]
+    public void Check_ReportsNothing_WhenServerAddsNewFields()
+    {
+        // Additions are the normal, expected outcome of a game update — never a guard failure.
+        var losses = FieldLossGuard.Check(
+            Committed("message AppSendMessage {", "\trequired string message = 1;", "}"),
+            Server("""
+                   public class AppSendMessage : IProto<AppSendMessage>
+                   {
+                       public string message;
+                       public bool urgent;
+
+                       public static AppSendMessage Deserialize(Stream stream, AppSendMessage instance, long limit)
+                       {
+                           while (true)
+                           {
+                               int num = stream.ReadByte();
+                               switch (num)
+                               {
+                               case 10:
+                                   instance.message = ProtocolParser.ReadString(stream);
+                                   continue;
+                               case 16:
+                                   instance.urgent = ProtocolParser.ReadBool(stream);
+                                   continue;
+                               }
+                               return instance;
+                           }
+                       }
+                   }
+                   """),
+            new HashSet<string>(StringComparer.Ordinal)
+            {
+                "AppSendMessage"
+            });
+
+        Assert.Empty(losses);
+    }
+
+    [Fact]
+    public void Check_ReportsEveryLoss_NotJustTheFirst()
+    {
+        // Issue #120 lost 13 fields at once; a guard that reports one of them wastes a CI round trip.
+        var losses = FieldLossGuard.Check(
+            Committed(
+                "message AppSendMessage {",
+                "\trequired string message = 1;",
+                "}",
+                "message AppFlag {",
+                "\trequired bool value = 1;",
+                "}"),
+            Server($"{UnparsableSendMessage}\n\npublic class AppFlag : IProto<AppFlag> {{ public bool value; }}"),
+            new HashSet<string>(StringComparer.Ordinal)
+            {
+                "AppSendMessage", "AppFlag"
+            });
+
+        Assert.Equal(2, losses.Count);
+        Assert.Contains(losses, l => l.Message == "AppSendMessage");
+        Assert.Contains(losses, l => l.Message == "AppFlag");
+    }
+}

--- a/tests/ProtoGen.UnitTests/ProtoGen.UnitTests.csproj
+++ b/tests/ProtoGen.UnitTests/ProtoGen.UnitTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <!-- net10.0 only: ProtoGen is a net10.0 build-time tool, not a shipped library, so the
+             netstandard2.0/net8.0 parity rule that governs the src/ test projects does not apply. -->
+        <TargetFramework>net10.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\tools\update-proto\ProtoGen\ProtoGen.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/ProtoGen.UnitTests/ServerParserTests.cs
+++ b/tests/ProtoGen.UnitTests/ServerParserTests.cs
@@ -227,4 +227,60 @@ public class ServerParserTests
         Assert.Equal(1, field.Number);
         Assert.Equal("bool", field.ProtoType);
     }
+
+    [Fact]
+    public void MissingRoots_ReportsRootsAbsentFromTheContracts()
+    {
+        // A missing root collapses the authoritative closure, which makes the regenerated proto a
+        // verbatim copy of the committed one — "no drift" reported for a total parse failure.
+        var parser = ServerParser.ParseSource(Source("""
+                                                     public class AppMessage : IProto<AppMessage>
+                                                     {
+                                                         public uint seq;
+                                                     }
+                                                     """));
+
+        Assert.Equal(["AppRequest"], parser.MissingRoots(["AppRequest", "AppMessage"]));
+        Assert.Empty(parser.MissingRoots(["AppMessage"]));
+    }
+
+    [Fact]
+    public void ParseSource_PrefersTheFirstArmClaimingAFieldNumber_InDocumentOrder()
+    {
+        // The generated code dispatches the same field from an optimized raw-key arm and again from
+        // a key.Field fallback. Arms are collected in document order and the first claim wins, so
+        // the optimized arm above must supply the field — not whichever shape is scanned first.
+        var parser = ServerParser.ParseSource(Source("""
+                                                     public class AppSendMessage : IProto<AppSendMessage>
+                                                     {
+                                                         public string message;
+                                                         public string decoy;
+
+                                                         public static AppSendMessage Deserialize(Stream stream, AppSendMessage instance, long limit)
+                                                         {
+                                                             while (true)
+                                                             {
+                                                                 int num = stream.ReadByte();
+                                                                 if (num == 10)
+                                                                 {
+                                                                     instance.message = ProtocolParser.ReadString(stream);
+                                                                     continue;
+                                                                 }
+                                                                 Key key = ProtocolParser.ReadKey((byte)num, stream);
+                                                                 switch (key.Field)
+                                                                 {
+                                                                 case 1:
+                                                                     instance.decoy = ProtocolParser.ReadString(stream);
+                                                                     continue;
+                                                                 }
+                                                                 return instance;
+                                                             }
+                                                         }
+                                                     }
+                                                     """));
+
+        var field = Assert.Single(parser.Messages["AppSendMessage"].Fields);
+        Assert.Equal(1, field.Number);
+        Assert.Equal("message", field.Name);
+    }
 }

--- a/tests/ProtoGen.UnitTests/ServerParserTests.cs
+++ b/tests/ProtoGen.UnitTests/ServerParserTests.cs
@@ -1,0 +1,230 @@
+using Xunit;
+
+namespace ProtoGen.UnitTests;
+
+/// <summary>
+/// Field recovery from the decompiled <c>Deserialize</c> method. The decompiler chooses how to
+/// render the field dispatch (switch vs if/else-if) and that choice is not under our control, so
+/// every shape it can emit must recover the same fields.
+/// </summary>
+public class ServerParserTests
+{
+    /// <summary>Wraps message bodies in the namespace the parser scopes to.</summary>
+    /// <param name="body">Decompiled message declarations.</param>
+    private static string Source(string body) =>
+        $$"""
+          using System.IO;
+
+          namespace ProtoBuf
+          {
+          {{body}}
+          }
+          """;
+
+    [Fact]
+    public void ParseSource_RecoversField_FromSwitchDispatch()
+    {
+        var parser = ServerParser.ParseSource(Source("""
+                                                     public class AppSendMessage : IProto<AppSendMessage>
+                                                     {
+                                                         public string message;
+
+                                                         public static AppSendMessage Deserialize(Stream stream, AppSendMessage instance, long limit)
+                                                         {
+                                                             while (true)
+                                                             {
+                                                                 int num = stream.ReadByte();
+                                                                 switch (num)
+                                                                 {
+                                                                 case 10:
+                                                                     instance.message = ProtocolParser.ReadString(stream);
+                                                                     continue;
+                                                                 }
+                                                                 return instance;
+                                                             }
+                                                         }
+                                                     }
+                                                     """));
+
+        var field = Assert.Single(parser.Messages["AppSendMessage"].Fields);
+        Assert.Equal("message", field.Name);
+        Assert.Equal(1, field.Number);
+        Assert.Equal("string", field.ProtoType);
+    }
+
+    [Fact]
+    public void ParseSource_RecoversField_FromIfDispatch()
+    {
+        var parser = ServerParser.ParseSource(Source("""
+                                                     public class AppSendMessage : IProto<AppSendMessage>
+                                                     {
+                                                         public string message;
+
+                                                         public static AppSendMessage Deserialize(Stream stream, AppSendMessage instance, long limit)
+                                                         {
+                                                             while (true)
+                                                             {
+                                                                 int num = stream.ReadByte();
+                                                                 if (num == 10)
+                                                                 {
+                                                                     instance.message = ProtocolParser.ReadString(stream);
+                                                                     continue;
+                                                                 }
+                                                                 return instance;
+                                                             }
+                                                         }
+                                                     }
+                                                     """));
+
+        var field = Assert.Single(parser.Messages["AppSendMessage"].Fields);
+        Assert.Equal("message", field.Name);
+        Assert.Equal(1, field.Number);
+        Assert.Equal("string", field.ProtoType);
+    }
+
+    [Fact]
+    public void ParseSource_RecoversAllFields_FromElseIfChain()
+    {
+        var parser = ServerParser.ParseSource(Source("""
+                                                     public class AppTeamInfo : IProto<AppTeamInfo>
+                                                     {
+                                                         public string name;
+                                                         public ulong steamId;
+
+                                                         public static AppTeamInfo Deserialize(Stream stream, AppTeamInfo instance, long limit)
+                                                         {
+                                                             while (true)
+                                                             {
+                                                                 int num = stream.ReadByte();
+                                                                 if (num == 10)
+                                                                 {
+                                                                     instance.name = ProtocolParser.ReadString(stream);
+                                                                     continue;
+                                                                 }
+                                                                 else if (num == 16)
+                                                                 {
+                                                                     instance.steamId = ProtocolParser.ReadUInt64(stream);
+                                                                     continue;
+                                                                 }
+                                                                 return instance;
+                                                             }
+                                                         }
+                                                     }
+                                                     """));
+
+        var fields = parser.Messages["AppTeamInfo"].Fields;
+        Assert.Equal(2, fields.Count);
+        Assert.Equal(("name", 1, "string"), (fields[0].Name, fields[0].Number, fields[0].ProtoType));
+        Assert.Equal(("steamId", 2, "uint64"), (fields[1].Name, fields[1].Number, fields[1].ProtoType));
+    }
+
+    [Fact]
+    public void ParseSource_TreatsKeyFieldComparison_AsFieldNumberNotWireKey()
+    {
+        // `key.Field == 33` is already a field number; `num == 10` is a wire key needing >> 3.
+        // Getting this backwards would silently renumber a field.
+        var parser = ServerParser.ParseSource(Source("""
+                                                     public class AppTeamKick : IProto<AppTeamKick>
+                                                     {
+                                                         public ulong steamId;
+
+                                                         public static AppTeamKick Deserialize(Stream stream, AppTeamKick instance, long limit)
+                                                         {
+                                                             while (true)
+                                                             {
+                                                                 int num = stream.ReadByte();
+                                                                 Key key = ProtocolParser.ReadKey((byte)num, stream);
+                                                                 if (key.Field == 33)
+                                                                 {
+                                                                     instance.steamId = ProtocolParser.ReadUInt64(stream);
+                                                                     continue;
+                                                                 }
+                                                                 return instance;
+                                                             }
+                                                         }
+                                                     }
+                                                     """));
+
+        var field = Assert.Single(parser.Messages["AppTeamKick"].Fields);
+        Assert.Equal(33, field.Number);
+    }
+
+    [Fact]
+    public void ParseSource_RecoversFields_FromMixedSwitchAndIfDispatch()
+    {
+        // The real generated shape dispatches low field numbers on the raw key byte and high ones
+        // on key.Field, so both forms can appear in one Deserialize.
+        var parser = ServerParser.ParseSource(Source("""
+                                                     public class AppRequest : IProto<AppRequest>
+                                                     {
+                                                         public uint seq;
+                                                         public ulong kicked;
+
+                                                         public static AppRequest Deserialize(Stream stream, AppRequest instance, long limit)
+                                                         {
+                                                             while (true)
+                                                             {
+                                                                 int num = stream.ReadByte();
+                                                                 switch (num)
+                                                                 {
+                                                                 case 8:
+                                                                     instance.seq = ProtocolParser.ReadUInt32(stream);
+                                                                     continue;
+                                                                 }
+                                                                 Key key = ProtocolParser.ReadKey((byte)num, stream);
+                                                                 if (key.Field == 33)
+                                                                 {
+                                                                     instance.kicked = ProtocolParser.ReadUInt64(stream);
+                                                                     continue;
+                                                                 }
+                                                                 return instance;
+                                                             }
+                                                         }
+                                                     }
+                                                     """));
+
+        var fields = parser.Messages["AppRequest"].Fields;
+        Assert.Equal(2, fields.Count);
+        Assert.Equal((1, "seq"), (fields[0].Number, fields[0].Name));
+        Assert.Equal((33, "kicked"), (fields[1].Number, fields[1].Name));
+    }
+
+    [Fact]
+    public void ParseSource_IgnoresNonPositiveLabels_SuchAsEndOfStreamAndInvalidFieldZero()
+    {
+        // ILSpy folds the `keyByte == -1` end-of-stream guard into the dispatch, and the generator
+        // emits a `case 0` that throws. Neither is a field.
+        var parser = ServerParser.ParseSource(Source("""
+                                                     public class AppFlag : IProto<AppFlag>
+                                                     {
+                                                         public bool value;
+
+                                                         public static AppFlag Deserialize(Stream stream, AppFlag instance, long limit)
+                                                         {
+                                                             while (true)
+                                                             {
+                                                                 int num = stream.ReadByte();
+                                                                 switch (num)
+                                                                 {
+                                                                 case -1:
+                                                                     throw new EndOfStreamException();
+                                                                 case 8:
+                                                                     instance.value = ProtocolParser.ReadBool(stream);
+                                                                     continue;
+                                                                 }
+                                                                 Key key = ProtocolParser.ReadKey((byte)num, stream);
+                                                                 if (key.Field == 0)
+                                                                 {
+                                                                     throw new InvalidDataException("Invalid field id: 0");
+                                                                 }
+                                                                 return instance;
+                                                             }
+                                                         }
+                                                     }
+                                                     """));
+
+        var field = Assert.Single(parser.Messages["AppFlag"].Fields);
+        Assert.Equal(1, field.Number);
+        Assert.Equal("bool", field.ProtoType);
+    }
+}

--- a/tests/RustPlusApi.UnitTests/coverlet.runsettings
+++ b/tests/RustPlusApi.UnitTests/coverlet.runsettings
@@ -6,7 +6,7 @@
         <Configuration>
           <Format>opencover,cobertura</Format>
           <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
-          <Exclude>[RustPlusApi.MockServer]*</Exclude>
+          <Exclude>[RustPlusApi.MockServer]*,[ProtoGen]*</Exclude>
           <ExcludeByFile>**/obj/**,**/ProtoBuf/Mcs.cs,**/Protobuf/CheckinContracts.cs</ExcludeByFile>
           <SkipAutoProps>true</SkipAutoProps>
           <UseSourceLink>true</UseSourceLink>

--- a/tools/update-proto/.gitignore
+++ b/tools/update-proto/.gitignore
@@ -3,3 +3,4 @@ steamcmd/
 rds/
 decompiled/
 out/
+.tools/

--- a/tools/update-proto/2-decompile.sh
+++ b/tools/update-proto/2-decompile.sh
@@ -9,7 +9,11 @@
 # Field numbers/types/names are recovered downstream by parsing those methods (Step 3), not
 # by reflection. See proto-refresh-plan.md and §6 notes.
 #
-# Self-installs ilspycmd as a dotnet global tool if missing.
+# Self-installs ilspycmd at a PINNED version into a script-local tool dir. The version is
+# pinned deliberately: the decompiled *shape* of Deserialize is what ProtoGen parses, so an
+# unpinned decompiler makes the whole pipeline non-reproducible — a silent decompiler upgrade
+# between runs can change field recovery without any server change. Bump ILSPY_VERSION
+# consciously, and re-run to confirm the proto is unchanged.
 #
 # Usage:
 #   ./2-decompile.sh --list   List candidate assemblies/types holding AppRequest/AppMessage.
@@ -18,6 +22,7 @@
 # Env:
 #   CONTRACT_DLL   Assembly to decompile (default: Rust.Data.dll). Override if a future Rust
 #                  update relocates the App* contracts.
+#   ILSPY_VERSION  ilspycmd version to use (default: the pinned version below).
 
 set -euo pipefail
 
@@ -27,19 +32,24 @@ OUT_DIR="${SCRIPT_DIR}/decompiled"
 MANAGED_DIR="${RDS_DIR}/RustDedicated_Data/Managed"
 CONTRACT_DLL="${CONTRACT_DLL:-${MANAGED_DIR}/Rust.Data.dll}"
 
+# Pinned decompiler — see the header note. Not "latest": reproducibility is the point.
+ILSPY_VERSION="${ILSPY_VERSION:-11.0.0.9375}"
+ILSPY_DIR="${SCRIPT_DIR}/.tools/ilspycmd-${ILSPY_VERSION}"
+
 if [[ ! -d "${MANAGED_DIR}" ]]; then
     echo "ERROR: ${MANAGED_DIR} not found. Run ./1-fetch-server.sh first." >&2
     exit 1
 fi
 
-# Ensure ilspycmd is available (global dotnet tool).
-ILSPY_BIN="$(command -v ilspycmd || true)"
-if [[ -z "${ILSPY_BIN}" ]]; then
-    echo ">> ilspycmd not found — installing as a dotnet global tool..."
-    dotnet tool install -g ilspycmd >/dev/null
-    export PATH="${PATH}:${HOME}/.dotnet/tools"
-    ILSPY_BIN="$(command -v ilspycmd)"
+# Ensure the *pinned* ilspycmd is available. Installed into a script-local tool dir rather
+# than -g so an ambient global ilspycmd of a different version cannot silently change the
+# decompiled output (and hence the regenerated proto).
+ILSPY_BIN="${ILSPY_DIR}/ilspycmd"
+if [[ ! -x "${ILSPY_BIN}" ]]; then
+    echo ">> installing pinned ilspycmd ${ILSPY_VERSION} into ${ILSPY_DIR}"
+    dotnet tool install ilspycmd --version "${ILSPY_VERSION}" --tool-path "${ILSPY_DIR}" >/dev/null
 fi
+echo ">> ilspycmd version: ${ILSPY_VERSION}"
 
 # --list: which managed assemblies *define* the companion contracts? (strings is enough to
 # spot the type names in metadata; Rust.Data.dll is the expected home.)
@@ -71,6 +81,10 @@ mkdir -p "${OUT_DIR}"
 # ilspycmd emits one Rust.Data.decompiled.cs for the whole assembly; Step 3 scopes to the
 # companion subset (App* roots + transitive closure within namespace ProtoBuf).
 "${ILSPY_BIN}" "${CONTRACT_DLL}" -o "${OUT_DIR}"
+
+# Stamp the decompiler version next to its output: the regenerated proto is only meaningful
+# relative to the decompiler that produced the input ProtoGen parses.
+echo "${ILSPY_VERSION}" > "${OUT_DIR}/.ilspy-version"
 
 # Sanity check: the SilentOrbit contract types are present (NOT protobuf-net attributes).
 if ! grep -rql 'IProto<AppMessage>\|class AppMessage' "${OUT_DIR}"; then

--- a/tools/update-proto/ProtoGen/CommittedProto.cs
+++ b/tools/update-proto/ProtoGen/CommittedProto.cs
@@ -1,6 +1,13 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace ProtoGen;
+
+/// <summary>A field as declared in the committed proto.</summary>
+/// <param name="Message">Qualified message name, e.g. "AppMap.Monument".</param>
+/// <param name="Number">Proto field number.</param>
+/// <param name="Label">The proto2 label: required, optional or repeated.</param>
+internal sealed record CommittedField(string Message, int Number, string Label);
 
 /// <summary>
 /// Light line-based reader of the committed <c>RustPlusContracts.proto</c>. We need the bits the
@@ -10,8 +17,14 @@ namespace ProtoGen;
 /// </summary>
 internal sealed partial class CommittedProto
 {
+    private readonly List<CommittedField> _fields = [];
+
     /// <summary>Maps "QualifiedName#FieldNumber" to the field label (required/optional/repeated).</summary>
     private readonly Dictionary<string, string> _labels = new(StringComparer.Ordinal);
+
+    /// <summary>Every field declared in the committed proto, in document order. This is the baseline
+    /// the field-loss guard compares the regenerated model against.</summary>
+    public IReadOnlyList<CommittedField> Fields => _fields;
 
     /// <summary>Qualified names of every message/enum declaration, in document order.</summary>
     public List<string> DeclOrder { get; } = [];
@@ -32,11 +45,17 @@ internal sealed partial class CommittedProto
         return repeated ? "repeated" : "optional";
     }
 
-    public static CommittedProto Parse(string protoPath)
+    /// <summary>Parses the committed proto from a file.</summary>
+    /// <param name="protoPath">Path to <c>RustPlusContracts.proto</c>.</param>
+    public static CommittedProto Parse(string protoPath) => ParseLines(File.ReadLines(protoPath));
+
+    /// <summary>Parses the committed proto from lines (the file-free seam used by tests).</summary>
+    /// <param name="lines">The proto source, line by line.</param>
+    public static CommittedProto ParseLines(IEnumerable<string> lines)
     {
         var result = new CommittedProto();
         var state = new ParseState();
-        foreach (var rawLine in File.ReadLines(protoPath))
+        foreach (var rawLine in lines)
         {
             result.ProcessLine(rawLine, state);
         }
@@ -128,7 +147,9 @@ internal sealed partial class CommittedProto
         if (field.Success && state.Stack.Count > 0)
         {
             var qualified = string.Join('.', state.Stack);
-            _labels[$"{qualified}#{field.Groups[2].Value}"] = field.Groups[1].Value;
+            var number = int.Parse(field.Groups[2].Value, CultureInfo.InvariantCulture);
+            _labels[$"{qualified}#{number}"] = field.Groups[1].Value;
+            _fields.Add(new CommittedField(qualified, number, field.Groups[1].Value));
         }
     }
 

--- a/tools/update-proto/ProtoGen/Emitter.cs
+++ b/tools/update-proto/ProtoGen/Emitter.cs
@@ -27,11 +27,20 @@ internal sealed partial class Emitter
         _committed = committed;
     }
 
-    public static string Emit(ServerParser server, CommittedProto committed, IEnumerable<string> roots)
+    /// <summary>Renders the proto and reports which messages were regenerated authoritatively.</summary>
+    /// <param name="server">The model recovered from the decompiled server.</param>
+    /// <param name="committed">The committed proto, for labels, ordering and preserved blocks.</param>
+    /// <param name="roots">Root message names to compute the authoritative closure from.</param>
+    /// <returns>The proto text and the set of authoritatively regenerated messages. The scope is
+    /// returned because only those messages can lose a field — see <see cref="FieldLossGuard" />.</returns>
+    public static (string Proto, IReadOnlySet<string> ScopeMessages) Emit(
+        ServerParser server,
+        CommittedProto committed,
+        IEnumerable<string> roots)
     {
         var e = new Emitter(server, committed);
         e.ComputeScope(roots);
-        return e.Render();
+        return (e.Render(), e._scopeMessages);
     }
 
     /// <summary>Authoritative scope = transitive closure of messages/enums reachable from the roots.

--- a/tools/update-proto/ProtoGen/FieldLossGuard.cs
+++ b/tools/update-proto/ProtoGen/FieldLossGuard.cs
@@ -1,0 +1,83 @@
+namespace ProtoGen;
+
+/// <summary>A committed field that the regenerated model no longer contains.</summary>
+/// <param name="Message">Qualified message name the field belongs to.</param>
+/// <param name="Number">Proto field number that went missing.</param>
+/// <param name="Label">The label the field carried in the committed proto.</param>
+internal sealed record FieldLoss(string Message, int Number, string Label);
+
+/// <summary>
+/// Guards against silent field loss.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ProtoGen recovers wire information by pattern-matching decompiled C#. When it meets a dispatch
+/// shape it does not recognise it produces a message with no fields and no error — which renders as
+/// a clean, plausible-looking field removal in the diff. Issue #120 is exactly that: 13 committed
+/// fields vanished at once and the drift report presented them as genuine server changes.
+/// </para>
+/// <para>
+/// Real removals do happen, so this is a stop rather than a ban: the operator confirms one with
+/// <c>--allow-field-removal</c>. The default is to refuse, because a wrong proto silently breaks
+/// serialization at runtime whereas a failed refresh only costs a re-run.
+/// </para>
+/// </remarks>
+internal static class FieldLossGuard
+{
+    /// <summary>Finds every committed field missing from the regenerated model.</summary>
+    /// <param name="committed">The committed proto, used as the baseline.</param>
+    /// <param name="server">The model recovered from the decompiled server.</param>
+    /// <param name="scopeMessages">Messages the emitter regenerated authoritatively. Anything outside
+    /// this set is copied verbatim from the committed proto and so cannot lose a field.</param>
+    /// <returns>The losses, in committed declaration order; empty when nothing was lost.</returns>
+    public static List<FieldLoss> Check(
+        CommittedProto committed,
+        ServerParser server,
+        IReadOnlySet<string> scopeMessages)
+    {
+        var losses = new List<FieldLoss>();
+
+        foreach (var field in committed.Fields)
+        {
+            // Out of scope -> emitted verbatim from the committed proto, nothing to lose.
+            if (!scopeMessages.Contains(field.Message))
+            {
+                continue;
+            }
+
+            // The message dropping out of the server model entirely is a different signal (a removed
+            // message), and the emitter falls back to the committed block for it.
+            if (!server.Messages.TryGetValue(field.Message, out var message))
+            {
+                continue;
+            }
+
+            if (!message.Fields.Exists(f => f.Number == field.Number))
+            {
+                losses.Add(new FieldLoss(field.Message, field.Number, field.Label));
+            }
+        }
+
+        return losses;
+    }
+
+    /// <summary>Renders the losses as an operator-facing error report.</summary>
+    /// <param name="losses">The losses reported by <see cref="Check" />.</param>
+    /// <returns>A multi-line message naming every lost field and how to proceed.</returns>
+    public static string Describe(IReadOnlyList<FieldLoss> losses)
+    {
+        var lines = new List<string>
+        {
+            $"error: {losses.Count} committed field(s) are missing from the regenerated proto:",
+        };
+        lines.AddRange(losses.Select(l => $"  - {l.Message} #{l.Number} ({l.Label})"));
+        lines.Add(string.Empty);
+        lines.Add("This usually means ProtoGen failed to recognise the decompiled dispatch shape");
+        lines.Add("rather than that the server dropped these fields — a whole message emptying out,");
+        lines.Add("or many messages losing a field at once, is the signature of a parser gap.");
+        lines.Add("Check the decompiled Deserialize for one of the messages above before believing it.");
+        lines.Add(string.Empty);
+        lines.Add("If the removal really is genuine, re-run with --allow-field-removal.");
+        return string.Join(Environment.NewLine, lines);
+    }
+}

--- a/tools/update-proto/ProtoGen/Program.cs
+++ b/tools/update-proto/ProtoGen/Program.cs
@@ -1,17 +1,27 @@
 using ProtoGen;
 
-// Usage: ProtoGen <decompiled.cs> <committed.proto> <output.proto>
+// Usage: ProtoGen <decompiled.cs> <committed.proto> <output.proto> [--allow-field-removal]
 // Regenerates RustPlusContracts.proto from the decompiled SilentOrbit server contracts,
 // preserving committed conventions (labels, nesting, snake_case, ordering).
+//
+// Exit codes: 0 = written; 2 = usage/input error; 3 = committed fields went missing (see
+// FieldLossGuard). Drift itself is not detected here — update-proto.sh diffs the output.
 
-if (args.Length != 3)
+const int exitUsage = 2;
+const int exitFieldLoss = 3;
+
+var allowFieldRemoval = args.Contains("--allow-field-removal", StringComparer.Ordinal);
+var positional = args.Where(a => !a.StartsWith("--", StringComparison.Ordinal)).ToArray();
+
+if (positional.Length != 3)
 {
-    await Console.Error.WriteLineAsync("usage: ProtoGen <decompiled.cs> <committed.proto> <output.proto>")
+    await Console.Error
+        .WriteLineAsync("usage: ProtoGen <decompiled.cs> <committed.proto> <output.proto> [--allow-field-removal]")
         .ConfigureAwait(false);
-    return 2;
+    return exitUsage;
 }
 
-var (decompiledPath, committedPath, outputPath) = (args[0], args[1], args[2]);
+var (decompiledPath, committedPath, outputPath) = (positional[0], positional[1], positional[2]);
 
 foreach (var (label, path) in new[]
          {
@@ -21,7 +31,7 @@ foreach (var (label, path) in new[]
     if (!File.Exists(path))
     {
         await Console.Error.WriteLineAsync($"error: {label} not found: {path}").ConfigureAwait(false);
-        return 2;
+        return exitUsage;
     }
 }
 
@@ -35,8 +45,26 @@ var committed = CommittedProto.Parse(committedPath);
 
 // Roots: everything the wire exposes hangs off the request and the message envelope.
 string[] roots = ["AppRequest", "AppMessage"];
-var proto = Emitter.Emit(server, committed, roots);
+var (proto, scopeMessages) = Emitter.Emit(server, committed, roots);
 
+// Write before guarding: when the guard trips, the output is the evidence a human needs to see
+// which messages came out empty. It goes to out/, never to the committed proto.
 await File.WriteAllTextAsync(outputPath, proto).ConfigureAwait(false);
 await Console.Error.WriteLineAsync($">> wrote {outputPath}").ConfigureAwait(false);
-return 0;
+
+var losses = FieldLossGuard.Check(committed, server, scopeMessages);
+if (losses.Count == 0)
+{
+    return 0;
+}
+
+if (allowFieldRemoval)
+{
+    await Console.Error
+        .WriteLineAsync($">> ⚠️  {losses.Count} committed field(s) removed, allowed by --allow-field-removal")
+        .ConfigureAwait(false);
+    return 0;
+}
+
+await Console.Error.WriteLineAsync(FieldLossGuard.Describe(losses)).ConfigureAwait(false);
+return exitFieldLoss;

--- a/tools/update-proto/ProtoGen/Program.cs
+++ b/tools/update-proto/ProtoGen/Program.cs
@@ -5,19 +5,41 @@ using ProtoGen;
 // preserving committed conventions (labels, nesting, snake_case, ordering).
 //
 // Exit codes: 0 = written; 2 = usage/input error; 3 = committed fields went missing (see
-// FieldLossGuard). Drift itself is not detected here — update-proto.sh diffs the output.
+// FieldLossGuard); 4 = a root message was not found in the decompiled contracts. Drift itself
+// is not detected here — update-proto.sh diffs the output. Anything other than 0 or 1 fails
+// the ProtoRefresh workflow, so every non-zero code here surfaces as a red run.
 
 const int exitUsage = 2;
 const int exitFieldLoss = 3;
+const int exitMissingRoot = 4;
 
-var allowFieldRemoval = args.Contains("--allow-field-removal", StringComparer.Ordinal);
-var positional = args.Where(a => !a.StartsWith("--", StringComparison.Ordinal)).ToArray();
+// Roots: everything the wire exposes hangs off the request and the message envelope.
+string[] roots = ["AppRequest", "AppMessage"];
+
+const string allowFieldRemovalFlag = "--allow-field-removal";
+const string usage =
+    $"usage: ProtoGen <decompiled.cs> <committed.proto> <output.proto> [{allowFieldRemovalFlag}]";
+
+// Reject unknown options rather than ignoring them: a typo such as "--allow-field-removals"
+// would otherwise be dropped silently and the operator would see the guard still firing with no
+// indication why their flag had no effect.
+var unknownFlags = args
+    .Where(a => a.StartsWith('-') && !string.Equals(a, allowFieldRemovalFlag, StringComparison.Ordinal))
+    .ToArray();
+if (unknownFlags.Length > 0)
+{
+    await Console.Error.WriteLineAsync($"error: unknown option(s): {string.Join(", ", unknownFlags)}")
+        .ConfigureAwait(false);
+    await Console.Error.WriteLineAsync(usage).ConfigureAwait(false);
+    return exitUsage;
+}
+
+var allowFieldRemoval = args.Contains(allowFieldRemovalFlag, StringComparer.Ordinal);
+var positional = args.Where(a => !a.StartsWith('-')).ToArray();
 
 if (positional.Length != 3)
 {
-    await Console.Error
-        .WriteLineAsync("usage: ProtoGen <decompiled.cs> <committed.proto> <output.proto> [--allow-field-removal]")
-        .ConfigureAwait(false);
+    await Console.Error.WriteLineAsync(usage).ConfigureAwait(false);
     return exitUsage;
 }
 
@@ -41,10 +63,31 @@ await Console.Error
     .WriteLineAsync($">> parsed {server.Messages.Count} messages, {server.Enums.Count} enums (namespace ProtoBuf)")
     .ConfigureAwait(false);
 
-var committed = CommittedProto.Parse(committedPath);
+// Without a root there is no authoritative closure: every committed type falls through to the
+// "preserved verbatim" path, the output reproduces the committed proto exactly, and both the
+// diff and the field-loss guard come up empty. A total parse failure would be reported as
+// "no changes — the committed proto matches the current server", which is the worst possible
+// lie this tool can tell. Refuse instead.
+var missingRoots = server.MissingRoots(roots);
+if (missingRoots.Count > 0)
+{
+    await Console.Error
+        .WriteLineAsync(
+            $"error: root message(s) not found in the decompiled contracts: {string.Join(", ", missingRoots)}")
+        .ConfigureAwait(false);
+    await Console.Error
+        .WriteLineAsync("The contracts may have been renamed or relocated, or the decompiled input may be")
+        .ConfigureAwait(false);
+    await Console.Error
+        .WriteLineAsync("the wrong assembly. Regenerating without a root would silently reproduce the")
+        .ConfigureAwait(false);
+    await Console.Error
+        .WriteLineAsync("committed proto and report no drift, so this is a hard failure.")
+        .ConfigureAwait(false);
+    return exitMissingRoot;
+}
 
-// Roots: everything the wire exposes hangs off the request and the message envelope.
-string[] roots = ["AppRequest", "AppMessage"];
+var committed = CommittedProto.Parse(committedPath);
 var (proto, scopeMessages) = Emitter.Emit(server, committed, roots);
 
 // Write before guarding: when the guard trips, the output is the evidence a human needs to see
@@ -61,7 +104,7 @@ if (losses.Count == 0)
 if (allowFieldRemoval)
 {
     await Console.Error
-        .WriteLineAsync($">> ⚠️  {losses.Count} committed field(s) removed, allowed by --allow-field-removal")
+        .WriteLineAsync($">> ⚠️  {losses.Count} committed field(s) removed, allowed by {allowFieldRemovalFlag}")
         .ConfigureAwait(false);
     return 0;
 }

--- a/tools/update-proto/ProtoGen/ProtoGen.csproj
+++ b/tools/update-proto/ProtoGen/ProtoGen.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="ProtoGen.UnitTests" />
+  </ItemGroup>
+
 </Project>

--- a/tools/update-proto/ProtoGen/ServerParser.cs
+++ b/tools/update-proto/ProtoGen/ServerParser.cs
@@ -67,6 +67,18 @@ internal sealed class ServerParser
         return parser;
     }
 
+    /// <summary>The requested root messages that the decompiled contracts do not define.</summary>
+    /// <remarks>
+    /// A missing root collapses the authoritative closure to nothing, so every committed type falls
+    /// through to the emitter's "preserved verbatim" path and the regenerated proto reproduces the
+    /// committed one exactly — no diff, and nothing for <see cref="FieldLossGuard" /> to compare.
+    /// Callers must treat a non-empty result as a failure rather than as "no drift".
+    /// </remarks>
+    /// <param name="roots">Qualified root message names, e.g. AppRequest.</param>
+    /// <returns>The roots absent from the parsed model, in the order given.</returns>
+    public IReadOnlyList<string> MissingRoots(IEnumerable<string> roots) =>
+        roots.Where(r => !_messages.ContainsKey(r)).ToList();
+
     /// <summary>First pass: register every message/enum and the parent/child structure.</summary>
     /// <param name="member">The syntax node to register.</param>
     /// <param name="parentQualified">Qualified name of the enclosing type, or null at file scope.</param>
@@ -248,31 +260,43 @@ internal sealed class ServerParser
     {
         var arms = new List<DispatchArm>();
 
-        foreach (var sw in deser.DescendantNodes().OfType<SwitchStatementSyntax>())
+        // One document-order walk, so switch and if arms interleave exactly as written. Ordering is
+        // behaviour, not presentation: the first arm to claim a field number wins (see the `seen`
+        // set in FillFields), and the generated code dispatches the same field from both an
+        // optimized raw-key arm and a key.Field fallback arm.
+        foreach (var node in deser.DescendantNodes())
         {
-            var fieldNumberMode = IsFieldNumberExpression(sw.Expression);
-            foreach (var section in sw.Sections)
+            switch (node)
             {
-                var constants = section.Labels.OfType<CaseSwitchLabelSyntax>()
-                    .Select(l => TryParseInt(l.Value, out var v) ? v : (int?)null)
-                    .OfType<int>()
-                    .ToList();
-                if (constants.Count > 0)
-                {
-                    arms.Add(new DispatchArm(constants, section, fieldNumberMode));
-                }
-            }
-        }
-
-        foreach (var ifStatement in deser.DescendantNodes().OfType<IfStatementSyntax>())
-        {
-            if (TryReadEqualityArm(ifStatement, out var arm))
-            {
-                arms.Add(arm);
+                case SwitchStatementSyntax sw:
+                    AddSwitchArms(sw, arms);
+                    break;
+                case IfStatementSyntax ifStatement when TryReadEqualityArm(ifStatement, out var arm):
+                    arms.Add(arm);
+                    break;
             }
         }
 
         return arms;
+    }
+
+    /// <summary>Appends one arm per <c>case</c> section carrying at least one integer label.</summary>
+    /// <param name="sw">The switch statement to read.</param>
+    /// <param name="arms">The list to append to.</param>
+    private static void AddSwitchArms(SwitchStatementSyntax sw, List<DispatchArm> arms)
+    {
+        var fieldNumberMode = IsFieldNumberExpression(sw.Expression);
+        foreach (var section in sw.Sections)
+        {
+            var constants = section.Labels.OfType<CaseSwitchLabelSyntax>()
+                .Select(l => TryParseInt(l.Value, out var v) ? v : (int?)null)
+                .OfType<int>()
+                .ToList();
+            if (constants.Count > 0)
+            {
+                arms.Add(new DispatchArm(constants, section, fieldNumberMode));
+            }
+        }
     }
 
     /// <summary>Reads an <c>if (num == 10)</c> / <c>if (key.Field == 33)</c> arm.</summary>

--- a/tools/update-proto/ProtoGen/ServerParser.cs
+++ b/tools/update-proto/ProtoGen/ServerParser.cs
@@ -21,10 +21,15 @@ internal sealed class ServerParser
     public IReadOnlyDictionary<string, Message> Messages => _messages;
     public IReadOnlyDictionary<string, EnumDef> Enums => _enums;
 
-    public static ServerParser Parse(string decompiledCsPath)
+    /// <summary>Parses the decompiled contracts from a file.</summary>
+    /// <param name="decompiledCsPath">Path to the ilspycmd output.</param>
+    public static ServerParser Parse(string decompiledCsPath) => ParseSource(File.ReadAllText(decompiledCsPath));
+
+    /// <summary>Parses decompiled contracts from source text (the file-free seam used by tests).</summary>
+    /// <param name="source">Decompiled C# source.</param>
+    public static ServerParser ParseSource(string source)
     {
-        var text = File.ReadAllText(decompiledCsPath);
-        var tree = CSharpSyntaxTree.ParseText(text);
+        var tree = CSharpSyntaxTree.ParseText(source);
         var root = tree.GetCompilationUnitRoot();
 
         var parser = new ServerParser();
@@ -152,13 +157,9 @@ internal sealed class ServerParser
         }
 
         var seen = new HashSet<int>();
-        foreach (var sw in deser.DescendantNodes().OfType<SwitchStatementSyntax>())
+        foreach (var arm in CollectDispatchArms(deser))
         {
-            var fieldNumberMode = IsKeyFieldSwitch(sw);
-            foreach (var section in sw.Sections)
-            {
-                AddFieldsFromSection(section, decls, fieldNumberMode, qualified, msg, seen);
-            }
+            AddFieldsFromArm(arm, decls, qualified, msg, seen);
         }
 
         msg.Fields.Sort((a, b) => a.Number.CompareTo(b.Number));
@@ -189,38 +190,38 @@ internal sealed class ServerParser
         return decls;
     }
 
-    /// <summary>Recovers every field assigned in one <c>Deserialize</c> switch section and appends it to
+    /// <summary>Recovers every field assigned in one dispatch arm and appends it to
     /// <paramref name="msg"/>, skipping field numbers already <paramref name="seen"/>.</summary>
-    /// <param name="section">The switch section to analyze.</param>
+    /// <param name="arm">The dispatch arm to analyze.</param>
     /// <param name="decls">Declared field types for the enclosing message.</param>
-    /// <param name="fieldNumberMode">True when case labels are field numbers rather than wire keys.</param>
     /// <param name="qualified">Qualified name of the message being filled (resolution scope).</param>
     /// <param name="msg">The message to append recovered fields to.</param>
     /// <param name="seen">Field numbers already recorded for this message.</param>
-    private void AddFieldsFromSection(
-        SwitchSectionSyntax section,
+    private void AddFieldsFromArm(
+        DispatchArm arm,
         Dictionary<string, (string CsType, bool Repeated, string Element)> decls,
-        bool fieldNumberMode,
         string qualified,
         Message msg,
         HashSet<int> seen)
     {
-        var fieldName = FindFieldName(section);
+        var fieldName = FindFieldName(arm.Body);
         if (fieldName is null || !decls.TryGetValue(fieldName, out var d))
         {
             return;
         }
 
-        var readMethod = FindReadMethod(section);
+        var readMethod = FindReadMethod(arm.Body);
 
-        foreach (var label in section.Labels.OfType<CaseSwitchLabelSyntax>())
+        foreach (var raw in arm.Constants)
         {
-            if (!TryParseInt(label.Value, out var raw) || raw <= 0)
+            // Non-positive labels are never fields: `case -1` is ILSpy's folded end-of-stream
+            // guard and `0` is the generator's "invalid field id" throw.
+            if (raw <= 0)
             {
                 continue;
             }
 
-            var number = fieldNumberMode ? raw : raw >> 3;
+            var number = arm.FieldNumberMode ? raw : raw >> 3;
             if (number <= 0 || !seen.Add(number))
             {
                 continue;
@@ -232,6 +233,72 @@ internal sealed class ServerParser
                 Name = fieldName, Number = number, ProtoType = protoType, Repeated = d.Repeated,
             });
         }
+    }
+
+    /// <summary>Every field-dispatch arm in a <c>Deserialize</c> body, in source order.</summary>
+    /// <remarks>
+    /// The decompiler decides whether to render the dispatch as a <c>switch</c> or as an
+    /// <c>if</c>/<c>else if</c> chain, and that choice is not stable across decompiler versions or
+    /// across the number of fields in a message. Both shapes are read here so field recovery does
+    /// not depend on it. A shape that is recognised by neither yields no fields, which
+    /// <see cref="FieldLossGuard" /> turns into a hard failure rather than a silent empty message.
+    /// </remarks>
+    /// <param name="deser">The <c>Deserialize</c> method to scan.</param>
+    private static List<DispatchArm> CollectDispatchArms(MethodDeclarationSyntax deser)
+    {
+        var arms = new List<DispatchArm>();
+
+        foreach (var sw in deser.DescendantNodes().OfType<SwitchStatementSyntax>())
+        {
+            var fieldNumberMode = IsFieldNumberExpression(sw.Expression);
+            foreach (var section in sw.Sections)
+            {
+                var constants = section.Labels.OfType<CaseSwitchLabelSyntax>()
+                    .Select(l => TryParseInt(l.Value, out var v) ? v : (int?)null)
+                    .OfType<int>()
+                    .ToList();
+                if (constants.Count > 0)
+                {
+                    arms.Add(new DispatchArm(constants, section, fieldNumberMode));
+                }
+            }
+        }
+
+        foreach (var ifStatement in deser.DescendantNodes().OfType<IfStatementSyntax>())
+        {
+            if (TryReadEqualityArm(ifStatement, out var arm))
+            {
+                arms.Add(arm);
+            }
+        }
+
+        return arms;
+    }
+
+    /// <summary>Reads an <c>if (num == 10)</c> / <c>if (key.Field == 33)</c> arm.</summary>
+    /// <param name="ifStatement">The if statement to inspect.</param>
+    /// <param name="arm">The recovered arm, when the condition is a constant equality test.</param>
+    /// <returns><c>true</c> when the condition is an equality comparison against an integer constant.</returns>
+    private static bool TryReadEqualityArm(IfStatementSyntax ifStatement, out DispatchArm arm)
+    {
+        arm = default!;
+        if (ifStatement.Condition is not BinaryExpressionSyntax bin ||
+            !bin.OperatorToken.IsKind(SyntaxKind.EqualsEqualsToken))
+        {
+            return false;
+        }
+
+        // Either operand may hold the constant (`num == 10` or `10 == num`).
+        var (dispatched, constantExpr) = TryParseInt(bin.Right, out _)
+            ? (bin.Left, bin.Right)
+            : (bin.Right, bin.Left);
+        if (!TryParseInt(constantExpr, out var constant))
+        {
+            return false;
+        }
+
+        arm = new DispatchArm([constant], ifStatement.Statement, IsFieldNumberExpression(dispatched));
+        return true;
     }
 
     // ---- helpers ----
@@ -265,14 +332,15 @@ internal sealed class ServerParser
         return _messages.ContainsKey(qualified) ? qualified : null;
     }
 
-    /// <summary>When the switch expression is <c>key.Field</c>, case labels are field numbers; otherwise they are wire keys.</summary>
-    /// <param name="sw">The switch statement to inspect.</param>
-    private static bool IsKeyFieldSwitch(SwitchStatementSyntax sw) =>
-        sw.Expression is MemberAccessExpressionSyntax { Name.Identifier.Text: "Field" };
+    /// <summary>When the dispatched expression is <c>key.Field</c> the constants are field numbers;
+    /// otherwise they are raw wire keys and need <c>&gt;&gt; 3</c> to yield the field number.</summary>
+    /// <param name="dispatched">The expression the constants are compared against.</param>
+    private static bool IsFieldNumberExpression(ExpressionSyntax dispatched) =>
+        dispatched is MemberAccessExpressionSyntax { Name.Identifier.Text: "Field" };
 
-    /// <summary>The field assigned in a switch section: prefer assignment / .Add / ref target.</summary>
-    /// <param name="section">The switch section to analyze.</param>
-    private static string? FindFieldName(SwitchSectionSyntax section)
+    /// <summary>The field assigned in a dispatch arm: prefer assignment / .Add / ref target.</summary>
+    /// <param name="section">The arm body to analyze.</param>
+    private static string? FindFieldName(SyntaxNode section)
     {
         // instance.X = ...
         foreach (var asg in section.DescendantNodes().OfType<AssignmentExpressionSyntax>())
@@ -319,7 +387,9 @@ internal sealed class ServerParser
             ? ma.Name.Identifier.Text
             : null;
 
-    private static string? FindReadMethod(SwitchSectionSyntax section)
+    /// <summary>The <c>ProtocolParser.Read*</c> call in a dispatch arm, which reveals the wire type.</summary>
+    /// <param name="section">The arm body to analyze.</param>
+    private static string? FindReadMethod(SyntaxNode section)
     {
         foreach (var inv in section.DescendantNodes().OfType<InvocationExpressionSyntax>())
         {
@@ -464,4 +534,11 @@ internal sealed class ServerParser
             }
         }
     }
+
+    /// <summary>One arm of a field dispatch: the constants that select it, its body, and whether
+    /// those constants are field numbers (<c>key.Field</c>) or raw wire keys.</summary>
+    /// <param name="Constants">The integer constants selecting this arm.</param>
+    /// <param name="Body">The arm body, scanned for the assigned field and the read method.</param>
+    /// <param name="FieldNumberMode">True when <paramref name="Constants" /> are already field numbers.</param>
+    private sealed record DispatchArm(IReadOnlyList<int> Constants, SyntaxNode Body, bool FieldNumberMode);
 }

--- a/tools/update-proto/README.md
+++ b/tools/update-proto/README.md
@@ -96,6 +96,13 @@ So ProtoGen now **fails with exit code 3** if any field in the committed proto i
 regenerated one, naming each loss. Messages outside the authoritative closure are exempt: they are
 copied verbatim from the committed proto and cannot lose anything.
 
+It likewise **fails with exit code 4** when a root message (`AppRequest`/`AppMessage`) is absent
+from the decompiled contracts. Without a root the closure is empty, every committed type falls
+through to the preserved-verbatim path, and the output reproduces the committed proto exactly — so
+a total parse failure would otherwise be reported as "no changes, the committed proto matches the
+current server". Unknown command-line options are rejected (exit 2) rather than ignored, so a
+mistyped `--allow-field-removal` cannot look like it took effect.
+
 Facepunch can of course genuinely remove a field. Confirm that deliberately:
 
 ```bash

--- a/tools/update-proto/README.md
+++ b/tools/update-proto/README.md
@@ -64,17 +64,56 @@ dotnet run --project ProtoGen -- \
 ### How ProtoGen works
 
 `ProtoGen` (Roslyn) parses the decompiled SilentOrbit classes and regenerates the proto:
-field **number** from each `Deserialize` `case` (`wirekey >> 3`, or the field number directly
-in the `switch (key.Field)` fallback), **type** from the field declaration + the
+field **number** from each `Deserialize` dispatch arm (`wirekey >> 3`, or the field number
+directly when the arm tests `key.Field`), **type** from the field declaration + the
 `ProtocolParser.Read*` call (incl. `ReadZInt32 → sint32`, `NetworkableId/ReadUInt64 → uint64`,
 `ArraySegment<byte> → bytes`), and **nesting** from the C# nested-class structure. It is
 authoritative for names/types/numbers/repeated and for new fields/messages/enums; it preserves
 the committed proto's conventions that the binary does not carry — `required`/`optional` labels,
 declaration order, and hand-maintained well-known types (`Vector2/3/4`, `Color`, `Ray`).
 
+The decompiler renders that dispatch as either a `switch` or an `if`/`else if` chain, and the
+choice is not ours: it varies with the decompiler version *and* with Facepunch's code generator.
+Build `25083359` moved single-field messages from `switch` to `if`, which is why both shapes are
+read. See **Field-loss guard** below for what happens when a future shape fits neither.
+
 > **Review, don't blindly overwrite.** A diff is the *server's* current truth; decide per change
 > whether to adopt it (e.g. a field rename) or keep a deliberate library convention. With the v2
 > refresh applied, the gate is currently empty.
+
+### Field-loss guard
+
+ProtoGen recovers wire information by pattern-matching decompiled C#. When it meets a dispatch
+shape it does not recognise, it has no way to tell "this message has no fields" from "I could not
+read this message" — so it used to emit an empty message and exit cleanly, and the drift report
+presented the result as a genuine server-side field removal.
+
+That is not hypothetical: it produced [#120](https://github.com/HandyS11/RustPlusApi/issues/120),
+where 13 committed fields (`AppSendMessage.message`, `AppCameraSubscribe.camera_id`,
+`AppError.error`, …) appeared to have been deleted by a game update. They had not been.
+
+So ProtoGen now **fails with exit code 3** if any field in the committed proto is missing from the
+regenerated one, naming each loss. Messages outside the authoritative closure are exempt: they are
+copied verbatim from the committed proto and cannot lose anything.
+
+Facepunch can of course genuinely remove a field. Confirm that deliberately:
+
+```bash
+dotnet run --project ProtoGen -- <decompiled.cs> <committed.proto> <out.proto> --allow-field-removal
+```
+
+Prefer reading the decompiled `Deserialize` of one named message first. A whole message emptying
+out, or many messages each losing exactly one field, is the signature of a parser gap — not of a
+game update.
+
+### Reproducibility
+
+`2-decompile.sh` pins `ilspycmd` (`ILSPY_VERSION`) and installs it into a script-local `.tools/`
+directory rather than `-g`. The decompiled *shape* is ProtoGen's input, so an unpinned or ambient
+decompiler makes the whole pipeline non-reproducible. Bump the pin consciously and re-run to
+confirm the proto is unchanged. The version is stamped into `decompiled/.ilspy-version`, reported
+in the drift issue, and the decompiled source is uploaded as a CI artifact so a surprising diff can
+be traced to the shape that produced it without repeating the multi-GB fetch.
 
 Working dirs (`steamcmd/`, `rds/`, `decompiled/`, `out/`, `ProtoGen/bin|obj`) are gitignored.
 


### PR DESCRIPTION
Closes #120.

## The deletions in #120 are not real

The drift report for game update `25083359` listed 13 committed fields as removed. They were not. Applying that diff would have broken team chat, smart-switch control, camera subscribe, clan/map/team responses and every error string — essentially the whole public API. (It would have failed the build rather than shipping, since `Extensions/*` references those members by name, but the report itself was wrong.)

The tell: the 13 are **exactly** the single-field messages inside the authoritative closure. `ClanInvitations`, the only other single-field message, survived — because it is out of scope and copied verbatim from the committed proto.

## Root cause

`ServerParser` recovered field numbers only from `switch` statements in the decompiled `Deserialize`. Facepunch's code generator changed in this build: generated methods now carry `ConsumeFieldOperation`/`ValidateFieldOrder` delta tracking, and single-field messages dispatch with a plain `if`:

```csharp
if (num == 10)
{
    stream.ValidateFieldOrder(ref lastFieldId, 1u, fieldIsRepeated: false, "ProtoBuf.AppSendMessage");
    instance.message = ProtocolParser.ReadString(stream);
    continue;
}
```

No `switch` → no fields recovered → empty message emitted, **silently**, so the diff read as a genuine server-side removal.

> Worth noting: my first hypothesis was that ILSpy 11 had changed the decompiled shape. A probe comparing `10.1.1.8388` against `11.0.0.9375` on a synthetic assembly refuted that — both decompile identically and parse correctly. The cause is Facepunch's generator, not the decompiler.

## Changes

**Parser** — read dispatch arms from `if`/`else if` chains as well as `switch`, keyed on whether the arm tests `key.Field` (already a field number) or the raw byte (wire key, needs `>> 3`).

**`FieldLossGuard`** — any committed field missing from the regenerated proto is now a hard failure (exit 3) naming every loss, overridable with `--allow-field-removal` for a genuine removal. The parser will meet an unrecognised shape again; this makes that loud instead of plausible.

**Reproducibility** — `ilspycmd` was unpinned (`dotnet tool install -g`), so the shape ProtoGen parses could change between runs with no server change, and an ambient global install would silently win. Now pinned, installed script-locally, and stamped into `decompiled/.ilspy-version`.

**Workflow** — upload the decompiled contracts as an artifact (they are ProtoGen's actual input; without them this diagnosis needed a repeat of the multi-GB fetch), report the decompiler version in the drift issue, and fail the job on exit codes outside `{0,1}` — an exit 3 previously passed green with no issue filed.

**Tests** — `tests/ProtoGen.UnitTests`, 12 tests over both dispatch shapes and the guard. `net10.0` only, since ProtoGen is a build-time tool rather than a shipped library, and excluded from the coverage gate to match Sonar's existing `**/tools/**` exclusion.

## Verification

Run against the **real** decompiled `Rust.Data.dll` from build `25083359` (workflow run [33816610057](https://github.com/HandyS11/RustPlusApi/actions/runs/33816610057)), the regenerated proto now contains zero deletions and exactly three genuine changes:

```diff
+	optional AppTeamKick kick_from_team = 33;
+	optional bool cameras_enabled = 16;
+message AppTeamKick {
+	optional uint64 steam_id = 1;
+}
```

Note `AppTeamKick` does carry a `steam_id` — the drift report showed it empty, for the same reason.

With the parser fix reverted but the guard in place, the same input reports all 13 losses and exits 3.

`dotnet test` — 501 passed. Coverage aggregate unaffected (ProtoGen excluded, verified absent from the merged report).

## Not in scope

Applying `cameras_enabled`, `kick_from_team`/`AppTeamKick` to the proto and the matching `Data/*` + `Extensions/*` work. That is a separate PR, now that the correct `AppTeamKick` body is known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)