### PR TITLE
feat(web): credential-acquisition website

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**/bin/
+**/obj/
+**/TestResults/
+**/.git/
+**/.idea/
+**/.vs/
+docs/_site/
+rustplus.config.json

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -138,10 +138,15 @@ jobs:
 
     - name: Compute image tags
       run: |
-        TAGS="ghcr.io/${{ github.repository_owner }}/rustplusapi-credentials:$VERSION"
+        # Docker repository names must be lowercase; github.repository_owner expands to the
+        # capitalized "HandyS11" and buildx rejects that outright. Hardcoded rather than
+        # lowercased dynamically, to match the image reference documented throughout the app
+        # (README, Caddyfile.example, SessionEndpoints' self-host pointer).
+        OWNER="handys11"
+        TAGS="ghcr.io/$OWNER/rustplusapi-credentials:$VERSION"
         # 'latest' only follows stable releases, so a prerelease never becomes the default pull.
         if [[ "$IS_PRERELEASE" == "false" ]]; then
-          TAGS="$TAGS,ghcr.io/${{ github.repository_owner }}/rustplusapi-credentials:latest"
+          TAGS="$TAGS,ghcr.io/$OWNER/rustplusapi-credentials:latest"
         fi
         echo "TAGS=$TAGS" >> "$GITHUB_ENV"
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -141,7 +141,8 @@ jobs:
         # Docker repository names must be lowercase; github.repository_owner expands to the
         # capitalized "HandyS11" and buildx rejects that outright. Hardcoded rather than
         # lowercased dynamically, to match the image reference documented throughout the app
-        # (README, Caddyfile.example, SessionEndpoints' self-host pointer).
+        # (both READMEs, docker-compose.yml, docs/articles/credentials.md, SessionEndpoints'
+        # self-host pointer).
         OWNER="handys11"
         TAGS="ghcr.io/$OWNER/rustplusapi-credentials:$VERSION"
         # 'latest' only follows stable releases, so a prerelease never becomes the default pull.

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -101,3 +101,55 @@ jobs:
           PRERELEASE_FLAG="--prerelease"
         fi
         gh release create "$GITHUB_REF_NAME" ./**/*.nupkg ./**/*.snupkg --generate-notes $PRERELEASE_FLAG
+
+  publish-image:
+    runs-on: ubuntu-latest
+    needs: build-and-deploy
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v7
+
+    - name: Resolve Version from Tag
+      run: |
+        VERSION="${GITHUB_REF_NAME#v}"
+        echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+        if [[ "$VERSION" == *-* ]]; then
+          echo "IS_PRERELEASE=true" >> "$GITHUB_ENV"
+        else
+          echo "IS_PRERELEASE=false" >> "$GITHUB_ENV"
+        fi
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Compute image tags
+      run: |
+        TAGS="ghcr.io/${{ github.repository_owner }}/rustplusapi-credentials:$VERSION"
+        # 'latest' only follows stable releases, so a prerelease never becomes the default pull.
+        if [[ "$IS_PRERELEASE" == "false" ]]; then
+          TAGS="$TAGS,ghcr.io/${{ github.repository_owner }}/rustplusapi-credentials:latest"
+        fi
+        echo "TAGS=$TAGS" >> "$GITHUB_ENV"
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: apps/RustPlusApi.CredentialsWeb/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ env.TAGS }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,17 +44,32 @@ jobs:
     - name: Restore .NET tools
       run: dotnet tool restore
 
-    - name: Merge coverage reports
+    - name: Merge coverage reports (libraries)
       run: >
         dotnet tool run reportgenerator --
         "-reports:${{ github.workspace }}/TestResults/**/coverage.opencover.xml"
         "-targetdir:${{ github.workspace }}/TestResults/merged"
+        "-assemblyfilters:-RustPlusApi.CredentialsWeb"
         "-reporttypes:Cobertura"
 
-    - name: Enforce coverage threshold
-      # Merged aggregate across all 7 test projects and both TFMs (ReportGenerator union).
+    - name: Merge coverage reports (web app)
+      run: >
+        dotnet tool run reportgenerator --
+        "-reports:${{ github.workspace }}/TestResults/**/coverage.opencover.xml"
+        "-targetdir:${{ github.workspace }}/TestResults/merged-web"
+        "-assemblyfilters:+RustPlusApi.CredentialsWeb"
+        "-reporttypes:Cobertura"
+
+    - name: Enforce coverage threshold (libraries)
+      # Merged aggregate across every library test project and both TFMs (ReportGenerator union).
+      # The web app is filtered out so it cannot dilute the libraries' number.
       # Metric: ReportGenerator-merged Cobertura line-rate/branch-rate.
-      # Achieved: ~96.7% line / ~91.4% branch. Gate floor: line 95 / branch 90 —
-      # keep in sync with docs/development/testing.md ("Coverage gate").
+      # Gate floor: line 95 / branch 90 — keep in sync with docs/development/testing.md.
       working-directory: ${{ github.workspace }}
       run: python3 tools/coverage/check_threshold.py 95 90
+
+    - name: Enforce coverage threshold (web app)
+      # Same floor. The app can meet it because its two untestable regions — host wiring and the
+      # live-network adapter — are [ExcludeFromCodeCoverage] with justifications.
+      working-directory: ${{ github.workspace }}
+      run: python3 tools/coverage/check_threshold.py 95 90 TestResults/merged-web/Cobertura.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ dotnet test RustPlusApi.sln -f net8.0
 dotnet test RustPlusApi.sln -f net10.0
 
 # Coverage with per-class gap report + CI gate (line 95 / branch 90):
+# Runs two gates: the libraries (unchanged since before apps/RustPlusApi.CredentialsWeb existed)
+# and the net10.0-only web app, merged and checked separately so the app can't move the library bar.
 tools/coverage/report.sh
 
 # Formatting + member reordering (ReSharper CLI; whitespace rules from .editorconfig, the
@@ -62,6 +64,12 @@ A committed **pre-push hook** (`.githooks/pre-push`, wired up automatically by t
   to a loopback callback (`SteamLoginService`), Rust Companion registration, `CredentialsStore`
   persistence.
 - **Two `*.Extensions.DependencyInjection`** packages — `AddRustPlus`/`AddRustPlusFcm` + factories.
+- **`apps/RustPlusApi.CredentialsWeb`** — a **net10.0-only** ASP.NET Core app (not a NuGet package)
+  that consumes `RustPlusApi.Fcm.Registration`'s public API to walk a browser visitor through the
+  same registration chain as the console app, but reordered to `4 → 1,2,3 → 5`: the Steam login
+  runs first so an anonymous visitor can't trigger a Google device registration without first
+  authenticating. Being net10.0-only, it sits outside the netstandard2.0 multi-TFM parity story
+  that governs `src/`; see `docs/development/testing.md`.
 
 ### Protobuf contracts
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,6 +32,8 @@
     <!-- Test stack -->
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ dotnet run --project samples/RustPlus.Register.ConsoleApp
 See [`samples/`](samples/README.md) for the full walkthrough. (You can still use
 `npx @liamcottle/rustplus.js fcm-register` as a fallback.)
 
+Prefer a browser to a terminal? The [Rust+ credentials website](apps/RustPlusApi.CredentialsWeb/README.md)
+is the same registration flow behind a single-page app — no .NET SDK needed. It's both a self-host
+starter and the code behind the public instance: `docker run -p 8080:8080 -e CredentialsWeb__PublicBaseUrl=https://creds.example.org ghcr.io/handys11/rustplusapi-credentials`.
+
 **2. Talk to the server:**
 
 ```csharp

--- a/RustPlusApi.sln
+++ b/RustPlusApi.sln
@@ -62,6 +62,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RustPlus.Camera.ConsoleApp"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RustPlusApi.Camera.IntegrationTests", "tests\RustPlusApi.Camera.IntegrationTests\RustPlusApi.Camera.IntegrationTests.csproj", "{20A96556-CCED-4AF7-8CB9-F853CC8C77E3}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "apps", "apps", "{1787FE1D-075E-9E68-7218-25F1BD1BBEAB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RustPlusApi.CredentialsWeb", "apps\RustPlusApi.CredentialsWeb\RustPlusApi.CredentialsWeb.csproj", "{2A9FBB1E-A489-4899-90A6-AA4CF605BA05}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RustPlusApi.CredentialsWeb.UnitTests", "tests\RustPlusApi.CredentialsWeb.UnitTests\RustPlusApi.CredentialsWeb.UnitTests.csproj", "{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -324,6 +330,30 @@ Global
 		{20A96556-CCED-4AF7-8CB9-F853CC8C77E3}.Release|x64.Build.0 = Release|Any CPU
 		{20A96556-CCED-4AF7-8CB9-F853CC8C77E3}.Release|x86.ActiveCfg = Release|Any CPU
 		{20A96556-CCED-4AF7-8CB9-F853CC8C77E3}.Release|x86.Build.0 = Release|Any CPU
+		{2A9FBB1E-A489-4899-90A6-AA4CF605BA05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A9FBB1E-A489-4899-90A6-AA4CF605BA05}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A9FBB1E-A489-4899-90A6-AA4CF605BA05}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2A9FBB1E-A489-4899-90A6-AA4CF605BA05}.Debug|x64.Build.0 = Debug|Any CPU
+		{2A9FBB1E-A489-4899-90A6-AA4CF605BA05}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2A9FBB1E-A489-4899-90A6-AA4CF605BA05}.Debug|x86.Build.0 = Debug|Any CPU
+		{2A9FBB1E-A489-4899-90A6-AA4CF605BA05}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A9FBB1E-A489-4899-90A6-AA4CF605BA05}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A9FBB1E-A489-4899-90A6-AA4CF605BA05}.Release|x64.ActiveCfg = Release|Any CPU
+		{2A9FBB1E-A489-4899-90A6-AA4CF605BA05}.Release|x64.Build.0 = Release|Any CPU
+		{2A9FBB1E-A489-4899-90A6-AA4CF605BA05}.Release|x86.ActiveCfg = Release|Any CPU
+		{2A9FBB1E-A489-4899-90A6-AA4CF605BA05}.Release|x86.Build.0 = Release|Any CPU
+		{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB}.Debug|x64.Build.0 = Debug|Any CPU
+		{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB}.Debug|x86.Build.0 = Debug|Any CPU
+		{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB}.Release|x64.ActiveCfg = Release|Any CPU
+		{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB}.Release|x64.Build.0 = Release|Any CPU
+		{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB}.Release|x86.ActiveCfg = Release|Any CPU
+		{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -350,6 +380,8 @@ Global
 		{09FE4712-EC55-47C6-9780-4C3A33C30832} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{AE59D626-EC9F-490F-884B-E229D202B23A} = {0B23F464-4021-46B2-9AD7-04C16FA9B6F1}
 		{20A96556-CCED-4AF7-8CB9-F853CC8C77E3} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{2A9FBB1E-A489-4899-90A6-AA4CF605BA05} = {1787FE1D-075E-9E68-7218-25F1BD1BBEAB}
+		{02446C8C-88FC-45FC-BFD7-BFEDFEF007BB} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A4B4251F-ADA4-418D-95B5-27BA99A307A3}

--- a/apps/RustPlusApi.CredentialsWeb/AppOptions.cs
+++ b/apps/RustPlusApi.CredentialsWeb/AppOptions.cs
@@ -52,13 +52,13 @@ internal static class AppOptionsValidator
         if (string.IsNullOrWhiteSpace(options.PublicBaseUrl))
         {
             return $"{AppOptions.SectionName}:PublicBaseUrl is required. Set it to the externally "
-                + "reachable origin of this instance, for example https://creds.example.org.";
+                   + "reachable origin of this instance, for example https://creds.example.org.";
         }
 
         if (!Uri.TryCreate(options.PublicBaseUrl, UriKind.Absolute, out var baseUri))
         {
             return $"{AppOptions.SectionName}:PublicBaseUrl must be an absolute URL, "
-                + $"but was '{options.PublicBaseUrl}'.";
+                   + $"but was '{options.PublicBaseUrl}'.";
         }
 
         if (options.PublicBaseUrl.EndsWith('/'))
@@ -70,8 +70,8 @@ internal static class AppOptionsValidator
             && !options.AllowInsecureBaseUrl)
         {
             return $"{AppOptions.SectionName}:PublicBaseUrl must use https, because it carries the "
-                + "Steam auth token back from Facepunch. Set "
-                + $"{AppOptions.SectionName}:AllowInsecureBaseUrl=true only for local development.";
+                   + "Steam auth token back from Facepunch. Set "
+                   + $"{AppOptions.SectionName}:AllowInsecureBaseUrl=true only for local development.";
         }
 
         foreach (var proxy in options.KnownProxies)
@@ -79,7 +79,7 @@ internal static class AppOptionsValidator
             if (!IPAddress.TryParse(proxy, out _))
             {
                 return $"{AppOptions.SectionName}:KnownProxies contains '{proxy}', which is not an "
-                    + "IP address.";
+                       + "IP address.";
             }
         }
 

--- a/apps/RustPlusApi.CredentialsWeb/AppOptions.cs
+++ b/apps/RustPlusApi.CredentialsWeb/AppOptions.cs
@@ -1,0 +1,115 @@
+using System.Net;
+
+namespace RustPlusApi.CredentialsWeb;
+
+/// <summary>Every knob the app exposes. Bound from the "CredentialsWeb" configuration section.</summary>
+internal sealed class AppOptions
+{
+    /// <summary>Configuration section these options bind from.</summary>
+    internal const string SectionName = "CredentialsWeb";
+
+    /// <summary>The externally reachable origin, with no trailing slash. Required: behind a reverse
+    /// proxy this is not what Kestrel sees, and the Facepunch returnUrl must be the external one.</summary>
+    internal string PublicBaseUrl { get; set; } = string.Empty;
+
+    /// <summary>Development escape hatch permitting a non-https <see cref="PublicBaseUrl"/>.</summary>
+    internal bool AllowInsecureBaseUrl { get; set; }
+
+    /// <summary>Addresses of reverse proxies whose <c>X-Forwarded-For</c> is trusted. Empty means
+    /// forwarded headers are ignored, which is the safe default: trusting them from anyone lets a
+    /// caller spoof their address past every per-IP cap.</summary>
+    internal IList<string> KnownProxies { get; } = [];
+
+    /// <summary>Global cap on live sessions in any state.</summary>
+    internal int MaxConcurrentSessions { get; set; } = 200;
+
+    /// <summary>Global cap on concurrent MCS sockets — the genuinely scarce resource.</summary>
+    internal int MaxConcurrentPairings { get; set; } = 50;
+
+    /// <summary>Per-IP cap on completed flows in a rolling hour. Bounds Google device registrations.</summary>
+    internal int MaxCompletionsPerIpPerHour { get; set; } = 5;
+
+    /// <summary>Lifetime of a session that has not yet completed the Steam login. Shortest leash:
+    /// this is the cheapest state to create and therefore the cheapest to spam.</summary>
+    internal TimeSpan CreatedTtl { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>Lifetime of a session once the Steam login has completed.</summary>
+    internal TimeSpan SessionTtl { get; set; } = TimeSpan.FromMinutes(15);
+
+    /// <summary>Maximum time an MCS socket is held waiting for a pairing push.</summary>
+    internal TimeSpan PairingTtl { get; set; } = TimeSpan.FromMinutes(10);
+}
+
+/// <summary>Pure validation for <see cref="AppOptions"/>, kept separate from host wiring so it is
+/// unit-testable without building a web host.</summary>
+internal static class AppOptionsValidator
+{
+    /// <summary>Returns <see langword="null"/> when the options are usable, or a message naming the
+    /// offending setting.</summary>
+    /// <param name="options">The options to validate.</param>
+    internal static string? Validate(AppOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.PublicBaseUrl))
+        {
+            return $"{AppOptions.SectionName}:PublicBaseUrl is required. Set it to the externally "
+                + "reachable origin of this instance, for example https://creds.example.org.";
+        }
+
+        if (!Uri.TryCreate(options.PublicBaseUrl, UriKind.Absolute, out var baseUri))
+        {
+            return $"{AppOptions.SectionName}:PublicBaseUrl must be an absolute URL, "
+                + $"but was '{options.PublicBaseUrl}'.";
+        }
+
+        if (options.PublicBaseUrl.EndsWith('/'))
+        {
+            return $"{AppOptions.SectionName}:PublicBaseUrl must not have a trailing slash.";
+        }
+
+        if (!baseUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.Ordinal)
+            && !options.AllowInsecureBaseUrl)
+        {
+            return $"{AppOptions.SectionName}:PublicBaseUrl must use https, because it carries the "
+                + "Steam auth token back from Facepunch. Set "
+                + $"{AppOptions.SectionName}:AllowInsecureBaseUrl=true only for local development.";
+        }
+
+        foreach (var proxy in options.KnownProxies)
+        {
+            if (!IPAddress.TryParse(proxy, out _))
+            {
+                return $"{AppOptions.SectionName}:KnownProxies contains '{proxy}', which is not an "
+                    + "IP address.";
+            }
+        }
+
+        if (options.MaxConcurrentSessions <= 0)
+        {
+            return $"{AppOptions.SectionName}:MaxConcurrentSessions must be greater than zero.";
+        }
+
+        if (options.MaxConcurrentPairings <= 0)
+        {
+            return $"{AppOptions.SectionName}:MaxConcurrentPairings must be greater than zero.";
+        }
+
+        if (options.MaxCompletionsPerIpPerHour <= 0)
+        {
+            return $"{AppOptions.SectionName}:MaxCompletionsPerIpPerHour must be greater than zero.";
+        }
+
+        if (options.CreatedTtl <= TimeSpan.Zero)
+        {
+            return $"{AppOptions.SectionName}:CreatedTtl must be greater than zero.";
+        }
+
+        if (options.SessionTtl <= TimeSpan.Zero)
+        {
+            return $"{AppOptions.SectionName}:SessionTtl must be greater than zero.";
+        }
+
+        return options.PairingTtl <= TimeSpan.Zero
+            ? $"{AppOptions.SectionName}:PairingTtl must be greater than zero."
+            : null;
+    }
+}

--- a/apps/RustPlusApi.CredentialsWeb/Caddyfile.example
+++ b/apps/RustPlusApi.CredentialsWeb/Caddyfile.example
@@ -7,19 +7,33 @@ creds.example.org {
 	log {
 		output file /var/log/caddy/creds.log
 		format filter {
-			request>uri query {
-				# Drop the query string entirely. Without this filter the Steam auth token is
-				# written to disk on every successful login.
-				delete steamId
-				delete token
-			}
-			# The session id travels in a URL fragment on the post-login redirect, which keeps it
-			# out of *that* log line — but the browser then opens
-			# GET /api/sessions/{sessionId}/events, putting the same id in the request path of
-			# every such request. That id is the sole authenticator for a stream that replays the
-			# full credentials payload once acquired, so redact it here too, not just the query
-			# string above.
-			request>uri regexp (sessions/)[0-9a-f]{32} ${1}REDACTED
+			# One filter per field: Caddy's format-filter config is keyed by field path
+			# (`request>uri` here), and a second directive for the same field silently replaces
+			# the first rather than combining with it — on older Caddy releases it refuses to
+			# start instead. A separate `request>uri query { delete steamId; delete token }`
+			# block used to sit here alongside this regexp; it was folded in below so there is
+			# only ever one `request>uri` entry. Do not re-split it.
+			#
+			# Redacts, in the full request URI:
+			#   - ?steamId=... and &token=... — the Steam identity and Rust+ auth token
+			#     Facepunch appends to the login callback.
+			#   - the session id in GET /api/sessions/{sessionId}/events — the sole
+			#     authenticator for a stream that replays the full credentials payload once
+			#     acquired. (It never appears in the callback URI itself: that id travels in a
+			#     URL fragment on the post-login redirect, which browsers never send to a
+			#     server.)
+			#
+			# The two query keys are matched as `[?&](steamId|token)=` followed by everything up
+			# to the next `&` (or end of string) — *not* stopped at `/`, because a token value is
+			# free to contain an unencoded `/` (it's a legal, unreserved-adjacent character in a
+			# URI query component per RFC 3986) and stopping there would leave the remainder of
+			# the token in the log. The session id instead is matched by its known fixed shape,
+			# exactly 32 lowercase hex characters (see Sessions/SessionIds.cs), which lets it stop
+			# precisely at the id without consuming the following /events. `regexp` here is Go's
+			# regexp.ReplaceAllString with no Caddy placeholder expansion, so ${1}/${2} are plain
+			# regexp capture references: exactly one of the two groups matches per hit, and Go
+			# expands an unmatched group to the empty string, so concatenating both is safe.
+			request>uri regexp ([?&](steamId|token)=)[^&]*|(sessions/)[0-9a-f]{32} ${1}${3}REDACTED
 		}
 	}
 }

--- a/apps/RustPlusApi.CredentialsWeb/Caddyfile.example
+++ b/apps/RustPlusApi.CredentialsWeb/Caddyfile.example
@@ -1,17 +1,25 @@
 # Example only. The important part is the log format: the default one records the full URI,
-# including the ?steamId=…&token=… that Facepunch appends to the callback.
+# including the ?steamId=…&token=… that Facepunch appends to the callback, and the session id in
+# the path of every /api/sessions/{sessionId}/... request.
 creds.example.org {
 	reverse_proxy 127.0.0.1:8080
 
 	log {
 		output file /var/log/caddy/creds.log
-		# Drop the query string entirely. Without this filter the Steam auth token is written
-		# to disk on every successful login.
 		format filter {
 			request>uri query {
+				# Drop the query string entirely. Without this filter the Steam auth token is
+				# written to disk on every successful login.
 				delete steamId
 				delete token
 			}
+			# The session id travels in a URL fragment on the post-login redirect, which keeps it
+			# out of *that* log line — but the browser then opens
+			# GET /api/sessions/{sessionId}/events, putting the same id in the request path of
+			# every such request. That id is the sole authenticator for a stream that replays the
+			# full credentials payload once acquired, so redact it here too, not just the query
+			# string above.
+			request>uri regexp (sessions/)[0-9a-f]{32} ${1}REDACTED
 		}
 	}
 }

--- a/apps/RustPlusApi.CredentialsWeb/Caddyfile.example
+++ b/apps/RustPlusApi.CredentialsWeb/Caddyfile.example
@@ -1,0 +1,17 @@
+# Example only. The important part is the log format: the default one records the full URI,
+# including the ?steamId=…&token=… that Facepunch appends to the callback.
+creds.example.org {
+	reverse_proxy 127.0.0.1:8080
+
+	log {
+		output file /var/log/caddy/creds.log
+		# Drop the query string entirely. Without this filter the Steam auth token is written
+		# to disk on every successful login.
+		format filter {
+			request>uri query {
+				delete steamId
+				delete token
+			}
+		}
+	}
+}

--- a/apps/RustPlusApi.CredentialsWeb/Dockerfile
+++ b/apps/RustPlusApi.CredentialsWeb/Dockerfile
@@ -1,0 +1,27 @@
+# Build context is the repository root:
+#   docker build -f apps/RustPlusApi.CredentialsWeb/Dockerfile -t rustplusapi-credentials .
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# .editorconfig carries the dotnet_diagnostic.* severities that pare the strict analyzer set
+# down to what CLAUDE.md documents as "clean" — without it, this publish fails on rules that are
+# deliberately silenced (see .editorconfig) rather than absent from the codebase.
+COPY Directory.Build.props Directory.Packages.props NuGet.config .editorconfig ./
+COPY src/ src/
+COPY apps/ apps/
+
+RUN dotnet publish apps/RustPlusApi.CredentialsWeb/RustPlusApi.CredentialsWeb.csproj \
+    --configuration Release \
+    --output /app
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+
+# The aspnet image ships a non-root user; APP_UID is its id.
+USER $APP_UID
+
+ENV ASPNETCORE_HTTP_PORTS=8080
+EXPOSE 8080
+
+COPY --from=build /app .
+ENTRYPOINT ["dotnet", "RustPlusApi.CredentialsWeb.dll"]

--- a/apps/RustPlusApi.CredentialsWeb/Endpoints/CallbackEndpoints.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Endpoints/CallbackEndpoints.cs
@@ -1,6 +1,8 @@
 using RustPlusApi.CredentialsWeb.Flow;
 using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.Fcm.Registration;
 using RustPlusApi.Fcm.Registration.Steps;
+using System.Diagnostics.CodeAnalysis;
 
 namespace RustPlusApi.CredentialsWeb.Endpoints;
 
@@ -15,7 +17,8 @@ internal static class CallbackEndpoints
             HttpContext context,
             SessionStore store,
             CredentialFlow flow,
-            AppOptions options) =>
+            AppOptions options,
+            TimeProvider timeProvider) =>
         {
             // Single-use: a callback URL replayed from browser history finds nothing, and an
             // unknown token is indistinguishable from a consumed one.
@@ -29,29 +32,61 @@ internal static class CallbackEndpoints
             // to a server and which therefore cannot reach an access log or a Referer header.
             var redirect = Results.Redirect($"/#session={session.SessionId}");
 
-            try
+            if (TryParseSteamLogin(
+                    options.PublicBaseUrl, context.Request.Path, context.Request.QueryString, out var login))
             {
-                var callbackUri = new Uri(
-                    options.PublicBaseUrl + context.Request.Path + context.Request.QueryString);
-                var login = SteamLoginService.ParseCallback(callbackUri);
-
                 session.BackgroundWork = flow.CompleteRegistrationAsync(
                     session,
                     login,
                     session.Lifetime.Token);
             }
-            catch (Exception ex) when (ex is InvalidOperationException or UriFormatException)
+            else
             {
                 // ParseCallback rejects a callback with no usable token or steamId, and a malformed
-                // request (e.g. an unparsable query string) can make the Uri construction above throw
+                // request can make the URI construction inside TryParseSteamLogin throw
                 // UriFormatException instead. Both must land the session in Failed rather than crash
                 // the host with a 500. The message is not surfaced: the page says the login did not
                 // complete and offers a restart.
-                session.Advance(SessionState.Failed, session.ExpiresAt);
+                //
+                // The deadline uses SessionTtl, not the session's original (short) CreatedTtl expiry:
+                // every other Failed transition in CredentialFlow does the same. A real Steam
+                // round-trip — two-factor authentication included — can consume most of CreatedTtl, so
+                // reusing it here would risk the sweeper removing the session, and its error, before
+                // the visitor's browser ever reads it back.
+                session.Advance(SessionState.Failed, timeProvider.GetUtcNow().Add(options.SessionTtl));
                 session.Events.Publish(new SessionEvent("error", new ErrorPayload(
                     "The Steam login didn't complete. Start over — nothing was saved.")));
             }
 
             return redirect;
         });
+
+    /// <summary>Builds the callback URI from the request and parses the Steam identity out of it.
+    /// Extracted from the route handler so <see cref="UriFormatException"/> — essentially
+    /// unreachable through a real request, since <see cref="AppOptions.PublicBaseUrl"/> is validated
+    /// absolute at startup and Kestrel has already rejected anything that would leave the path or
+    /// query URI-illegal — can still be forced directly in a unit test with a deliberately malformed
+    /// <paramref name="publicBaseUrl"/>, with no <c>TestServer</c> involved.</summary>
+    /// <param name="publicBaseUrl">The externally reachable origin, from <see cref="AppOptions.PublicBaseUrl"/>.</param>
+    /// <param name="path">The request path.</param>
+    /// <param name="queryString">The request query string.</param>
+    /// <param name="login">The parsed Steam identity on success.</param>
+    internal static bool TryParseSteamLogin(
+        string publicBaseUrl,
+        PathString path,
+        QueryString queryString,
+        [NotNullWhen(true)] out SteamLoginResult? login)
+    {
+        try
+        {
+            var callbackUri = new Uri(publicBaseUrl + path + queryString);
+            login = SteamLoginService.ParseCallback(callbackUri);
+            return true;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or UriFormatException)
+        {
+            login = null;
+            return false;
+        }
+    }
 }

--- a/apps/RustPlusApi.CredentialsWeb/Endpoints/CallbackEndpoints.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Endpoints/CallbackEndpoints.cs
@@ -1,0 +1,57 @@
+using RustPlusApi.CredentialsWeb.Flow;
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.Fcm.Registration.Steps;
+
+namespace RustPlusApi.CredentialsWeb.Endpoints;
+
+/// <summary>The Facepunch redirect target.</summary>
+internal static class CallbackEndpoints
+{
+    /// <summary>Maps <c>GET /callback/{returnToken}</c>.</summary>
+    /// <param name="app">The route builder.</param>
+    internal static void MapCallbackEndpoints(this IEndpointRouteBuilder app) =>
+        app.MapGet("/callback/{returnToken}", (
+            string returnToken,
+            HttpContext context,
+            SessionStore store,
+            CredentialFlow flow,
+            AppOptions options) =>
+        {
+            // Single-use: a callback URL replayed from browser history finds nothing, and an
+            // unknown token is indistinguishable from a consumed one.
+            if (!store.TryConsumeReturnToken(returnToken, out var session))
+            {
+                return Results.NotFound();
+            }
+
+            // 302 rather than 200: a redirect leaves no back-button entry, so the token-bearing URL
+            // never becomes one. The session handle rides in the fragment, which browsers never send
+            // to a server and which therefore cannot reach an access log or a Referer header.
+            var redirect = Results.Redirect($"/#session={session.SessionId}");
+
+            try
+            {
+                var callbackUri = new Uri(
+                    options.PublicBaseUrl + context.Request.Path + context.Request.QueryString);
+                var login = SteamLoginService.ParseCallback(callbackUri);
+
+                session.BackgroundWork = flow.CompleteRegistrationAsync(
+                    session,
+                    login,
+                    session.Lifetime.Token);
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or UriFormatException)
+            {
+                // ParseCallback rejects a callback with no usable token or steamId, and a malformed
+                // request (e.g. an unparsable query string) can make the Uri construction above throw
+                // UriFormatException instead. Both must land the session in Failed rather than crash
+                // the host with a 500. The message is not surfaced: the page says the login did not
+                // complete and offers a restart.
+                session.Advance(SessionState.Failed, session.ExpiresAt);
+                session.Events.Publish(new SessionEvent("error", new ErrorPayload(
+                    "The Steam login didn't complete. Start over — nothing was saved.")));
+            }
+
+            return redirect;
+        });
+}

--- a/apps/RustPlusApi.CredentialsWeb/Endpoints/ClientAddress.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Endpoints/ClientAddress.cs
@@ -1,0 +1,12 @@
+namespace RustPlusApi.CredentialsWeb.Endpoints;
+
+/// <summary>Resolves the caller's address for per-IP accounting.</summary>
+internal static class ClientAddress
+{
+    /// <summary>The remote address, already rewritten by the forwarded-headers middleware when the
+    /// instance is configured with known proxies. Falls back to a constant so accounting still
+    /// happens (conservatively, as one shared bucket) rather than silently disappearing.</summary>
+    /// <param name="context">The current request.</param>
+    internal static string Of(HttpContext context) =>
+        context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+}

--- a/apps/RustPlusApi.CredentialsWeb/Endpoints/EventEndpoints.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Endpoints/EventEndpoints.cs
@@ -1,0 +1,47 @@
+using RustPlusApi.CredentialsWeb.Sessions;
+using System.Text.Json;
+
+namespace RustPlusApi.CredentialsWeb.Endpoints;
+
+/// <summary>The server-to-client push channel. One-directional by design: the only thing the server
+/// ever tells the browser is where the flow has got to.</summary>
+internal static class EventEndpoints
+{
+    /// <summary>Maps <c>GET /api/sessions/{sessionId}/events</c>.</summary>
+    /// <param name="app">The route builder.</param>
+    internal static void MapEventEndpoints(this IEndpointRouteBuilder app) =>
+        app.MapGet("/api/sessions/{sessionId}/events", async (
+            string sessionId,
+            HttpContext context,
+            SessionStore store,
+            CancellationToken cancellationToken) =>
+        {
+            if (!store.TryGet(sessionId, out var session))
+            {
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                return;
+            }
+
+            context.Response.ContentType = "text/event-stream";
+            // Tells nginx not to buffer the stream; without it a proxy can hold events for minutes.
+            context.Response.Headers["X-Accel-Buffering"] = "no";
+            await context.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+            await foreach (var sessionEvent in session.Events
+                               .SubscribeAsync(cancellationToken)
+                               .ConfigureAwait(false))
+            {
+#pragma warning disable VSTHRD103 // Serializing an in-memory payload record is pure CPU work with
+                // no I/O to await; SerializeAsync would only add overhead for a string this small.
+                var json = sessionEvent.Data is null
+                    ? "{}"
+                    : JsonSerializer.Serialize(sessionEvent.Data, JsonSerializerOptions.Web);
+#pragma warning restore VSTHRD103
+
+                await context.Response
+                    .WriteAsync($"event: {sessionEvent.Type}\ndata: {json}\n\n", cancellationToken)
+                    .ConfigureAwait(false);
+                await context.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+        });
+}

--- a/apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs
@@ -1,0 +1,33 @@
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.Fcm.Registration.Steps;
+
+namespace RustPlusApi.CredentialsWeb.Endpoints;
+
+/// <summary>What the browser needs to start a flow.</summary>
+/// <param name="SessionId">The handle for the event stream and follow-up calls.</param>
+/// <param name="LoginUrl">The Facepunch login URL to send the visitor to.</param>
+internal sealed record CreateSessionResponse(string SessionId, string LoginUrl);
+
+/// <summary>Session lifecycle endpoints.</summary>
+internal static class SessionEndpoints
+{
+    private const string OverCapacityMessage =
+        "This instance is at capacity. Try again in a few minutes — or run your own: "
+        + "docker run -p 8080:8080 ghcr.io/handys11/rustplusapi-credentials";
+
+    /// <summary>Maps <c>POST /api/sessions</c>.</summary>
+    /// <param name="app">The route builder.</param>
+    internal static void MapSessionEndpoints(this IEndpointRouteBuilder app) =>
+        app.MapPost("/api/sessions", (HttpContext context, SessionStore store, AppOptions options) =>
+        {
+            if (!store.TryCreate(ClientAddress.Of(context), out var session, out _))
+            {
+                return Results.Json(new ErrorPayload(OverCapacityMessage), statusCode: 429);
+            }
+
+            var returnUrl = $"{options.PublicBaseUrl}/callback/{session.ReturnToken}";
+            return Results.Ok(new CreateSessionResponse(
+                session.SessionId,
+                SteamLoginService.BuildLoginUrl(returnUrl)));
+        });
+}

--- a/apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs
@@ -1,3 +1,4 @@
+using RustPlusApi.CredentialsWeb.Flow;
 using RustPlusApi.CredentialsWeb.Sessions;
 using RustPlusApi.Fcm.Registration.Steps;
 
@@ -15,9 +16,14 @@ internal static class SessionEndpoints
         "This instance is at capacity. Try again in a few minutes — or run your own: "
         + "docker run -p 8080:8080 ghcr.io/handys11/rustplusapi-credentials";
 
-    /// <summary>Maps <c>POST /api/sessions</c>.</summary>
+    private const string PairingBusyMessage =
+        "This instance is already holding as many pairing listeners as it allows. Try again in a "
+        + "few minutes — or run your own: docker run -p 8080:8080 ghcr.io/handys11/rustplusapi-credentials";
+
+    /// <summary>Maps <c>POST /api/sessions</c> and <c>POST /api/sessions/{sessionId}/pairing</c>.</summary>
     /// <param name="app">The route builder.</param>
-    internal static void MapSessionEndpoints(this IEndpointRouteBuilder app) =>
+    internal static void MapSessionEndpoints(this IEndpointRouteBuilder app)
+    {
         app.MapPost("/api/sessions", (HttpContext context, SessionStore store, AppOptions options) =>
         {
             if (!store.TryCreate(ClientAddress.Of(context), out var session, out _))
@@ -30,4 +36,32 @@ internal static class SessionEndpoints
                 session.SessionId,
                 SteamLoginService.BuildLoginUrl(returnUrl)));
         });
+
+        app.MapPost("/api/sessions/{sessionId}/pairing", (
+            string sessionId,
+            SessionStore store,
+            CredentialFlow flow) =>
+        {
+            if (!store.TryGet(sessionId, out var session))
+            {
+                return Results.NotFound();
+            }
+
+            if (session.State != SessionState.Ready)
+            {
+                return Results.Conflict(new ErrorPayload(
+                    "This session is not ready to wait for a pairing."));
+            }
+
+            // The slot is taken here rather than inside the flow so that a refusal is a plain 429
+            // with nothing started; CredentialFlow.WaitForPairingAsync always releases it.
+            if (!store.TryAcquirePairingSlot())
+            {
+                return Results.Json(new ErrorPayload(PairingBusyMessage), statusCode: 429);
+            }
+
+            session.BackgroundWork = flow.WaitForPairingAsync(session, session.Lifetime.Token);
+            return Results.Accepted();
+        });
+    }
 }

--- a/apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs
@@ -57,6 +57,10 @@ internal static class SessionEndpoints
                 return Results.NotFound();
             }
 
+            // Advisory: it settles the ordinary 409 without starting anything, but it is a read of
+            // a state a concurrent request can change a moment later. What actually holds a session
+            // to one pairing wait is Session.TryClaimForPairing, which
+            // CredentialFlow.WaitForPairingAsync takes before it touches the network.
             if (session.State != SessionState.Ready)
             {
                 return Results.Conflict(new ErrorPayload(

--- a/apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs
@@ -16,6 +16,9 @@ internal static class SessionEndpoints
         "This instance is at capacity. Try again in a few minutes — or run your own: "
         + "docker run -p 8080:8080 ghcr.io/handys11/rustplusapi-credentials";
 
+    private const string ActiveSessionMessage =
+        "You already have a session in progress. Reopen that tab, or wait a few minutes and try again.";
+
     private const string PairingBusyMessage =
         "This instance is already holding as many pairing listeners as it allows. Try again in a "
         + "few minutes — or run your own: docker run -p 8080:8080 ghcr.io/handys11/rustplusapi-credentials";
@@ -26,9 +29,16 @@ internal static class SessionEndpoints
     {
         app.MapPost("/api/sessions", (HttpContext context, SessionStore store, AppOptions options) =>
         {
-            if (!store.TryCreate(ClientAddress.Of(context), out var session, out _))
+            if (!store.TryCreate(ClientAddress.Of(context), out var session, out var failure))
             {
-                return Results.Json(new ErrorPayload(OverCapacityMessage), statusCode: 429);
+                // ActiveSessionForIp means a resumable session already exists for this address —
+                // "at capacity" would be false and would send the visitor into a five-minute wait
+                // for no reason. GlobalLimit and HourlyLimit are genuine capacity/rate limits, so
+                // they keep the existing message.
+                var message = failure == SessionCreateFailure.ActiveSessionForIp
+                    ? ActiveSessionMessage
+                    : OverCapacityMessage;
+                return Results.Json(new ErrorPayload(message), statusCode: 429);
             }
 
             var returnUrl = $"{options.PublicBaseUrl}/callback/{session.ReturnToken}";

--- a/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs
@@ -106,12 +106,19 @@ internal sealed class CredentialFlow(
         // cuts it short.
         session.Advance(SessionState.AwaitingPairing, Deadline(options.SessionTtl));
 
-        using var pairingDeadline = new CancellationTokenSource(options.PairingTtl, timeProvider);
-        using var linkedToken =
-            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, pairingDeadline.Token);
-
         try
         {
+            // Constructed inside the try, not before it: new CancellationTokenSource(delay, ...)
+            // throws ArgumentOutOfRangeException for a delay above ~49.7 days, and a misconfigured
+            // PairingTtl is only guarded against being zero or negative (AppOptionsValidator), not
+            // against being unreasonably large. Building these here — rather than between the
+            // Advance above and this try, where such a throw would escape past the finally below —
+            // keeps "this method always releases the pairing slot" true unconditionally instead of
+            // depending on validation staying in sync with CancellationTokenSource's own limits.
+            using var pairingDeadline = new CancellationTokenSource(options.PairingTtl, timeProvider);
+            using var linkedToken =
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, pairingDeadline.Token);
+
             var pairing = await steps.WaitForPairingAsync(credentials, linkedToken.Token).ConfigureAwait(false);
 
             session.SetPairing(pairing);

--- a/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs
@@ -88,23 +88,29 @@ internal sealed class CredentialFlow(
     /// <summary>Step 6: hold an MCS socket until a pairing push arrives, the TTL runs out, or the
     /// session is disposed. The caller must already hold a pairing slot; this method always
     /// releases it.</summary>
-    /// <param name="session">A session in <see cref="SessionState.Ready"/>.</param>
+    /// <param name="session">The session to pair. Refused unless the claim below finds it still in
+    /// <see cref="SessionState.Ready"/> with credentials to pair against.</param>
     /// <param name="cancellationToken">Token to abandon the wait.</param>
     internal async Task WaitForPairingAsync(Session session, CancellationToken cancellationToken)
     {
-        if (session.State != SessionState.Ready || session.Credentials is not { } credentials)
+        // One atomic claim rather than a Ready check followed by a separate Advance: the endpoint
+        // dispatches this against a state it read a moment earlier, so two concurrent pairing POSTs
+        // for one session can both arrive here believing it is Ready. Session.TryClaimForPairing
+        // settles that under the session's own lock — the loser starts nothing and hands its slot
+        // straight back — and returns the credentials it read there, so a racing disposal cannot
+        // null them between the check and their use.
+        //
+        // The expiry it commits is the *session's* TTL, not the pairing wait's — a pairing timeout
+        // must not make the sweeper reap the session out from under it (that would also cancel
+        // session.Lifetime, the only thing the Advance calls below could then no-op against). The
+        // wait gets its own deadline instead: a TimeProvider-driven source (so FakeTimeProvider-
+        // driven tests can still fire it deterministically) linked to the caller's token so
+        // disposal still cuts it short.
+        if (!session.TryClaimForPairing(Deadline(options.SessionTtl), out var credentials))
         {
             store.ReleasePairingSlot();
             return;
         }
-
-        // The session's own expiry is the *session's* TTL, not the pairing wait's — a pairing
-        // timeout must not make the sweeper reap the session out from under it (that would also
-        // cancel session.Lifetime, the only thing Advance below could then no-op against). The wait
-        // gets its own deadline instead: a TimeProvider-driven source (so FakeTimeProvider-driven
-        // tests can still fire it deterministically) linked to the caller's token so disposal still
-        // cuts it short.
-        session.Advance(SessionState.AwaitingPairing, Deadline(options.SessionTtl));
 
         try
         {

--- a/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs
@@ -85,6 +85,58 @@ internal sealed class CredentialFlow(
         }
     }
 
+    /// <summary>Step 6: hold an MCS socket until a pairing push arrives, the TTL runs out, or the
+    /// session is disposed. The caller must already hold a pairing slot; this method always
+    /// releases it.</summary>
+    /// <param name="session">A session in <see cref="SessionState.Ready"/>.</param>
+    /// <param name="cancellationToken">Token to abandon the wait.</param>
+    internal async Task WaitForPairingAsync(Session session, CancellationToken cancellationToken)
+    {
+        if (session.State != SessionState.Ready || session.Credentials is not { } credentials)
+        {
+            store.ReleasePairingSlot();
+            return;
+        }
+
+        session.Advance(SessionState.AwaitingPairing, Deadline(options.PairingTtl));
+
+        try
+        {
+            var pairing = await steps.WaitForPairingAsync(credentials, cancellationToken).ConfigureAwait(false);
+
+            session.SetPairing(pairing);
+            session.Advance(SessionState.Paired, Deadline(options.SessionTtl));
+            session.Events.Publish(new SessionEvent("paired", new PairedPayload(
+                pairing.Ip,
+                pairing.Port,
+                pairing.PlayerId.ToString(CultureInfo.InvariantCulture),
+                pairing.PlayerToken,
+                pairing.Name)));
+        }
+        catch (OperationCanceledException)
+        {
+            // Back to Ready, not a terminal state: the credentials are still good, so the visitor
+            // can start another pairing wait without repeating the Steam login.
+            session.Advance(SessionState.Ready, Deadline(options.SessionTtl));
+            session.Events.Publish(new SessionEvent("expired", null));
+        }
+#pragma warning disable CA1031 // A failed socket must land the session in Failed rather than crash the host.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            logger.LogPairingFailed(session.SessionId, ex);
+            session.Advance(SessionState.Failed, Deadline(options.SessionTtl));
+            session.Events.Publish(new SessionEvent("error", new ErrorPayload(
+                "The pairing listener stopped unexpectedly. Your credentials are still valid — "
+                + "try the pairing step again.")));
+        }
+        finally
+        {
+            // A leaked slot permanently shrinks this instance's pairing capacity and nothing reports it.
+            store.ReleasePairingSlot();
+        }
+    }
+
     /// <summary>Now plus <paramref name="ttl"/>, from the injected clock.</summary>
     /// <param name="ttl">How long the session should live from now.</param>
     private DateTimeOffset Deadline(TimeSpan ttl) => timeProvider.GetUtcNow().Add(ttl);

--- a/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs
@@ -1,0 +1,91 @@
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.CredentialsWeb.Upstream;
+using RustPlusApi.Fcm.Registration;
+using System.Globalization;
+
+namespace RustPlusApi.CredentialsWeb.Flow;
+
+/// <summary>Drives the credential flow in the order 4 → 1,2,3 → 5, so that a real Steam login gates
+/// every upstream call. An unauthenticated visitor costs one dictionary entry and nothing else.</summary>
+/// <param name="steps">The upstream seam.</param>
+/// <param name="store">The session registry, for completion accounting and pairing slots.</param>
+/// <param name="options">TTLs and caps.</param>
+/// <param name="timeProvider">Clock.</param>
+/// <param name="logger">Diagnostics. Never receives a secret.</param>
+internal sealed class CredentialFlow(
+    IRegistrationSteps steps,
+    SessionStore store,
+    AppOptions options,
+    TimeProvider timeProvider,
+    ILogger<CredentialFlow> logger)
+{
+    /// <summary>Runs steps 1-3 then 5 for a session whose Steam login has just landed.</summary>
+    /// <param name="session">The session the callback belonged to.</param>
+    /// <param name="login">The parsed callback result.</param>
+    /// <param name="cancellationToken">Token to cancel the flow.</param>
+    internal async Task CompleteRegistrationAsync(
+        Session session,
+        SteamLoginResult login,
+        CancellationToken cancellationToken)
+    {
+        session.SetSteamLogin(login);
+        session.Advance(SessionState.Authenticated, Deadline(options.SessionTtl));
+        session.Advance(SessionState.Registering, Deadline(options.SessionTtl));
+
+        var step = "device registration";
+
+        try
+        {
+            var credentials = await steps.AcquireDeviceCredentialsAsync(cancellationToken).ConfigureAwait(false);
+
+            // Pattern rather than string.IsNullOrEmpty so the compiler sees the non-null narrowing.
+            if (credentials.ExpoPushToken is not { Length: > 0 })
+            {
+                // RCS1140 wants this documented on the method, but the exception never escapes it —
+                // the catch block right below handles it. Suppressed rather than documented, since
+                // documenting it would mislead a caller into thinking it can propagate.
+#pragma warning disable RCS1140
+                throw new InvalidOperationException("Device registration returned no Expo push token.");
+#pragma warning restore RCS1140
+            }
+
+            step = "Rust Companion registration";
+#pragma warning disable RCS1140 // Caught by the catch block below; see the comment above.
+            var steamToken = session.SteamToken
+                             ?? throw new InvalidOperationException("The session carries no Steam token.");
+#pragma warning restore RCS1140
+
+            await steps.RegisterWithCompanionAsync(steamToken, credentials.ExpoPushToken, cancellationToken)
+                .ConfigureAwait(false);
+
+            session.ClearSteamToken();
+            session.SetCredentials(credentials);
+            store.RecordCompletion(session.ClientIp);
+            session.Advance(SessionState.Ready, Deadline(options.SessionTtl));
+
+            session.Events.Publish(new SessionEvent("credentials", new CredentialsPayload(
+                session.SteamId.ToString(CultureInfo.InvariantCulture),
+                CredentialsStore.Serialize(credentials))));
+        }
+        catch (OperationCanceledException)
+        {
+            // The session was disposed or the host is shutting down. Nothing to report.
+            session.ClearSteamToken();
+        }
+#pragma warning disable CA1031 // Any upstream failure must land the session in Failed rather than crash the host.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            session.ClearSteamToken();
+            logger.LogFlowFailed(step, session.SessionId, ex);
+
+            session.Advance(SessionState.Failed, Deadline(options.SessionTtl));
+            session.Events.Publish(new SessionEvent("error", new ErrorPayload(
+                $"Something went wrong during {step}. Start over — nothing was saved.")));
+        }
+    }
+
+    /// <summary>Now plus <paramref name="ttl"/>, from the injected clock.</summary>
+    /// <param name="ttl">How long the session should live from now.</param>
+    private DateTimeOffset Deadline(TimeSpan ttl) => timeProvider.GetUtcNow().Add(ttl);
+}

--- a/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs
@@ -98,11 +98,21 @@ internal sealed class CredentialFlow(
             return;
         }
 
-        session.Advance(SessionState.AwaitingPairing, Deadline(options.PairingTtl));
+        // The session's own expiry is the *session's* TTL, not the pairing wait's — a pairing
+        // timeout must not make the sweeper reap the session out from under it (that would also
+        // cancel session.Lifetime, the only thing Advance below could then no-op against). The wait
+        // gets its own deadline instead: a TimeProvider-driven source (so FakeTimeProvider-driven
+        // tests can still fire it deterministically) linked to the caller's token so disposal still
+        // cuts it short.
+        session.Advance(SessionState.AwaitingPairing, Deadline(options.SessionTtl));
+
+        using var pairingDeadline = new CancellationTokenSource(options.PairingTtl, timeProvider);
+        using var linkedToken =
+            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, pairingDeadline.Token);
 
         try
         {
-            var pairing = await steps.WaitForPairingAsync(credentials, cancellationToken).ConfigureAwait(false);
+            var pairing = await steps.WaitForPairingAsync(credentials, linkedToken.Token).ConfigureAwait(false);
 
             session.SetPairing(pairing);
             session.Advance(SessionState.Paired, Deadline(options.SessionTtl));
@@ -113,12 +123,18 @@ internal sealed class CredentialFlow(
                 pairing.PlayerToken,
                 pairing.Name)));
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
-            // Back to Ready, not a terminal state: the credentials are still good, so the visitor
-            // can start another pairing wait without repeating the Steam login.
+            // The pairing wait's own deadline elapsed — the caller's token is still live, so this
+            // is a genuine timeout, not a disposal. Back to Ready, not a terminal state: the
+            // credentials are still good, so the visitor can start another pairing wait without
+            // repeating the Steam login.
             session.Advance(SessionState.Ready, Deadline(options.SessionTtl));
             session.Events.Publish(new SessionEvent("expired", null));
+        }
+        catch (OperationCanceledException)
+        {
+            // The session was disposed or the host is shutting down. Nothing to report.
         }
 #pragma warning disable CA1031 // A failed socket must land the session in Failed rather than crash the host.
         catch (Exception ex)

--- a/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlowLog.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlowLog.cs
@@ -6,4 +6,7 @@ internal static partial class CredentialFlowLog
 {
     [LoggerMessage(Level = LogLevel.Error, Message = "Credential flow failed during {Step} for session {SessionId}.")]
     public static partial void LogFlowFailed(this ILogger logger, string step, string sessionId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Pairing wait failed for session {SessionId}.")]
+    public static partial void LogPairingFailed(this ILogger logger, string sessionId, Exception exception);
 }

--- a/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlowLog.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlowLog.cs
@@ -1,0 +1,9 @@
+namespace RustPlusApi.CredentialsWeb.Flow;
+
+/// <summary>Source-generated, structured log messages for <see cref="CredentialFlow"/>. Generated
+/// bodies carry <c>[GeneratedCode]</c> and are excluded from the coverage gate automatically.</summary>
+internal static partial class CredentialFlowLog
+{
+    [LoggerMessage(Level = LogLevel.Error, Message = "Credential flow failed during {Step} for session {SessionId}.")]
+    public static partial void LogFlowFailed(this ILogger logger, string step, string sessionId, Exception exception);
+}

--- a/apps/RustPlusApi.CredentialsWeb/Program.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Program.cs
@@ -72,6 +72,7 @@ app.UseDefaultFiles();
 app.UseStaticFiles();
 
 app.MapSessionEndpoints();
+app.MapCallbackEndpoints();
 
 await app.RunAsync().ConfigureAwait(false);
 return 0;

--- a/apps/RustPlusApi.CredentialsWeb/Program.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Program.cs
@@ -1,4 +1,11 @@
+using Microsoft.AspNetCore.HttpOverrides;
+using System.Net;
 using RustPlusApi.CredentialsWeb;
+using RustPlusApi.CredentialsWeb.Endpoints;
+using RustPlusApi.CredentialsWeb.Flow;
+using RustPlusApi.CredentialsWeb.Security;
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.CredentialsWeb.Upstream;
 using System.Diagnostics.CodeAnalysis;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -10,7 +17,12 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Logging.AddFilter("Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Warning);
 
 var options = new AppOptions();
-builder.Configuration.GetSection(AppOptions.SectionName).Bind(options);
+
+// Every AppOptions member is internal (this app's blanket visibility rule), so the default binder
+// — which only reflects over public properties — would silently leave everything at its default.
+// BindNonPublicProperties opts into binding those internal setters instead.
+builder.Configuration.GetSection(AppOptions.SectionName)
+    .Bind(options, static o => o.BindNonPublicProperties = true);
 
 var validationError = AppOptionsValidator.Validate(options);
 if (validationError is not null)
@@ -21,11 +33,45 @@ if (validationError is not null)
 
 builder.Services.AddSingleton(options);
 builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<SessionStore>();
+builder.Services.AddSingleton<CredentialFlow>();
+builder.Services.AddHostedService<SessionSweeper>();
+builder.Services.AddHttpClient(LiveRegistrationSteps.HttpClientName);
+builder.Services.AddSingleton<IRegistrationSteps>(serviceProvider => new LiveRegistrationSteps(
+    serviceProvider.GetRequiredService<IHttpClientFactory>(),
+    serviceProvider.GetRequiredService<ILoggerFactory>()));
+
+// Without this, every visitor behind a reverse proxy presents as the proxy and shares one per-IP
+// bucket, silently voiding the caps. Configured too loosely it is worse: trusting X-Forwarded-For
+// from anyone lets a caller spoof their way past the limits. So the operator must name their proxy
+// explicitly, and with none named the headers are ignored.
+builder.Services.Configure<ForwardedHeadersOptions>(forwarded =>
+{
+    forwarded.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    foreach (var proxy in options.KnownProxies)
+    {
+        forwarded.KnownProxies.Add(IPAddress.Parse(proxy));
+    }
+});
 
 var app = builder.Build();
 
+// ForwardedHeadersOptions ships with its own default trusted network (loopback), so merely leaving
+// KnownProxies unpopulated does NOT make the middleware ignore X-Forwarded-For — it would still
+// honor it from what it considers the loopback proxy. And the documented way to stop trusting that
+// default — clearing KnownNetworks/KnownProxies — means the opposite of what it sounds like: an
+// empty restriction list is treated as "trust every address," not "trust none." The only way to
+// genuinely ignore forwarded headers with nothing configured is to never run this middleware at all.
+if (options.KnownProxies.Count > 0)
+{
+    app.UseForwardedHeaders();
+}
+
+app.UseSecurityHeaders();
 app.UseDefaultFiles();
 app.UseStaticFiles();
+
+app.MapSessionEndpoints();
 
 await app.RunAsync().ConfigureAwait(false);
 return 0;

--- a/apps/RustPlusApi.CredentialsWeb/Program.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Program.cs
@@ -1,0 +1,39 @@
+using RustPlusApi.CredentialsWeb;
+using System.Diagnostics.CodeAnalysis;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// ASP.NET Core's hosting diagnostics log the full request line — path AND query — at Information.
+// The Facepunch callback carries the Steam auth token in its query string, so that logger is
+// silenced outright rather than filtered per-path: the "Request starting" entry is written before
+// any middleware of ours could redact it. Enforced by SecretsAreNeverLoggedTests.
+builder.Logging.AddFilter("Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Warning);
+
+var options = new AppOptions();
+builder.Configuration.GetSection(AppOptions.SectionName).Bind(options);
+
+var validationError = AppOptionsValidator.Validate(options);
+if (validationError is not null)
+{
+    await Console.Error.WriteLineAsync($"Configuration error: {validationError}").ConfigureAwait(false);
+    return 1;
+}
+
+builder.Services.AddSingleton(options);
+builder.Services.AddSingleton(TimeProvider.System);
+
+var app = builder.Build();
+
+app.UseDefaultFiles();
+app.UseStaticFiles();
+
+await app.RunAsync().ConfigureAwait(false);
+return 0;
+
+/// <summary>Entry point marker so <c>WebApplicationFactory&lt;Program&gt;</c> can boot the app in tests.</summary>
+[ExcludeFromCodeCoverage(Justification = "Host wiring: composition only, exercised end to end by the endpoint tests.")]
+[SuppressMessage("Design", "CA1515:Consider making public types internal",
+    Justification = "Must stay public: WebApplicationFactory<Program> in the test assembly needs a public type parameter.")]
+[SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors",
+    Justification = "Not a utility class — an empty marker type WebApplicationFactory<Program> uses to locate the app's assembly.")]
+public partial class Program;

--- a/apps/RustPlusApi.CredentialsWeb/Program.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Program.cs
@@ -73,6 +73,7 @@ app.UseStaticFiles();
 
 app.MapSessionEndpoints();
 app.MapCallbackEndpoints();
+app.MapEventEndpoints();
 
 await app.RunAsync().ConfigureAwait(false);
 return 0;

--- a/apps/RustPlusApi.CredentialsWeb/Program.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Program.cs
@@ -81,7 +81,9 @@ return 0;
 /// <summary>Entry point marker so <c>WebApplicationFactory&lt;Program&gt;</c> can boot the app in tests.</summary>
 [ExcludeFromCodeCoverage(Justification = "Host wiring: composition only, exercised end to end by the endpoint tests.")]
 [SuppressMessage("Design", "CA1515:Consider making public types internal",
-    Justification = "Must stay public: WebApplicationFactory<Program> in the test assembly needs a public type parameter.")]
+    Justification =
+        "Must stay public: WebApplicationFactory<Program> in the test assembly needs a public type parameter.")]
 [SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors",
-    Justification = "Not a utility class — an empty marker type WebApplicationFactory<Program> uses to locate the app's assembly.")]
+    Justification =
+        "Not a utility class — an empty marker type WebApplicationFactory<Program> uses to locate the app's assembly.")]
 public partial class Program;

--- a/apps/RustPlusApi.CredentialsWeb/README.md
+++ b/apps/RustPlusApi.CredentialsWeb/README.md
@@ -1,0 +1,90 @@
+# Rust+ credentials website
+
+A single-page web app that walks a visitor from nothing to working Rust+ credentials. It is both a
+self-host starter and the code behind the public instance.
+
+## Run it
+
+```bash
+docker run -p 8080:8080 \
+  -e CredentialsWeb__PublicBaseUrl=https://creds.example.org \
+  ghcr.io/handys11/rustplusapi-credentials
+```
+
+`PublicBaseUrl` is **required** and must be the externally reachable origin, with no trailing
+slash. It cannot be inferred: it is the URL Facepunch redirects the browser back to, and behind a
+reverse proxy that is not what Kestrel sees. Startup validates it before the host is built —
+if it is missing, not an absolute URL, has a trailing slash, or is not `https`, the process prints
+`Configuration error: ...` to stderr and exits with code 1 rather than starting. The one exception
+is scheme: set `CredentialsWeb__AllowInsecureBaseUrl=true` to permit a non-`https` base URL, for
+local development only.
+
+For local development without a container:
+
+```bash
+dotnet run --project apps/RustPlusApi.CredentialsWeb \
+  -- --CredentialsWeb:PublicBaseUrl=http://localhost:5000 --CredentialsWeb:AllowInsecureBaseUrl=true
+```
+
+## Two things that will bite you behind a reverse proxy
+
+**Your access log will record Steam auth tokens.** Facepunch appends the token to the callback URL
+as a query parameter (`?steamId=...&token=...`). The app itself never logs it — the ASP.NET Core
+hosting request logger is switched off outright for exactly this reason, and
+`SecretsAreNeverLoggedTests` asserts it, not just intends it — but your reverse proxy's default
+access-log format records the full request line regardless. Filter the query string before it
+reaches disk; `Caddyfile.example` in this directory shows how (it drops `steamId` and `token` from
+the logged URI).
+
+**Your per-IP limits will silently do nothing.** Without the proxy's own address listed in
+`CredentialsWeb__KnownProxies__0` (and `__1`, `__2`, ... for more than one), every visitor presents
+as the proxy and shares one bucket — the caps in the table below stop meaning anything per visitor.
+Configured too loosely — trusting an address you don't control — the same header lets a caller
+spoof `X-Forwarded-For` and step past the limits entirely. With `KnownProxies` left empty (the
+default), forwarded headers are ignored outright, which is the right behavior when the app is
+reached directly. See `docker-compose.yml` for a worked example naming the proxy's address on the
+container network.
+
+> **Test coverage caveat.** The test suite proves that *configuring* `KnownProxies` turns
+> forwarding on (a request bearing `X-Forwarded-For` is honored once a proxy is named) and that
+> leaving it empty keeps forwarding off. It cannot exercise ASP.NET Core's own proxy-address
+> matching — the check that a forwarded header is only trusted when it actually arrived from one of
+> the named addresses — because the in-process `TestServer` used by those tests leaves
+> `HttpContext.Connection.RemoteIpAddress` null, so that check never runs in the test. Whether a
+> real deployment correctly rejects a forwarded header from an untrusted peer relies on Kestrel's
+> and `ForwardedHeadersMiddleware`'s own behavior with a real remote address, not on anything this
+> repository's tests confirm.
+
+## Configuration
+
+All settings live under the `CredentialsWeb` section (`CredentialsWeb__Name` as an environment
+variable, `--CredentialsWeb:Name` on the command line).
+
+| Setting | Default | What it does |
+|---|---|---|
+| `PublicBaseUrl` | *(required)* | Externally reachable origin, no trailing slash |
+| `AllowInsecureBaseUrl` | `false` | Permits a non-https base URL. Development only |
+| `KnownProxies__0`, `__1`, ... | *(empty)* | Reverse proxy addresses whose `X-Forwarded-For` is trusted |
+| `MaxConcurrentSessions` | `200` | Global cap on live sessions, in any state |
+| `MaxConcurrentPairings` | `50` | Global cap on live MCS sockets held open waiting for a pairing |
+| `MaxCompletionsPerIpPerHour` | `5` | Rolling per-IP cap on completed flows |
+| `CreatedTtl` | `00:05:00` | Lifetime of a session before the Steam login completes |
+| `SessionTtl` | `00:15:00` | Lifetime of a session once the Steam login has completed |
+| `PairingTtl` | `00:10:00` | Maximum time an MCS socket is held waiting for a pairing push |
+
+## What it does with credentials
+
+- **In memory only.** No database, no session cache, no disk. A restart wipes everything.
+- **The Steam auth token is dropped** the moment your device is registered with Rust Companion.
+- **Nothing is logged.** Asserted by `SecretsAreNeverLoggedTests`, not just intended.
+- **The callback responds 302**, so the token-bearing URL never becomes a browser history entry,
+  and the session handle travels in a URL fragment, which browsers never send to a server.
+- **The server does see the token** in the request line. Facepunch decides the callback shape and
+  nothing can change that; the design minimises its lifetime rather than pretending otherwise.
+
+## Flow
+
+The steps run in the order `4 → 1,2,3 → 5`, not the console app's `1,2,3 → 4 → 5`. Putting the
+Steam login first means an anonymous visitor cannot trigger Google device registrations: they cost
+one dictionary entry with a five-minute TTL and nothing else. Step 6, the pairing wait, is an
+opt-in continuation because it is the only step that holds a socket open.

--- a/apps/RustPlusApi.CredentialsWeb/README.md
+++ b/apps/RustPlusApi.CredentialsWeb/README.md
@@ -26,7 +26,7 @@ dotnet run --project apps/RustPlusApi.CredentialsWeb \
   -- --CredentialsWeb:PublicBaseUrl=http://localhost:5000 --CredentialsWeb:AllowInsecureBaseUrl=true
 ```
 
-## Two things that will bite you behind a reverse proxy
+## Three things that will bite you behind a reverse proxy
 
 **Your access log will record Steam auth tokens.** Facepunch appends the token to the callback URL
 as a query parameter (`?steamId=...&token=...`). The app itself never logs it — the ASP.NET Core
@@ -35,6 +35,15 @@ hosting request logger is switched off outright for exactly this reason, and
 access-log format records the full request line regardless. Filter the query string before it
 reaches disk; `Caddyfile.example` in this directory shows how (it drops `steamId` and `token` from
 the logged URI).
+
+**Your access log will also record the session handle.** The post-login redirect carries the
+session id in a URL fragment (`/#session=...`), which keeps it out of that one callback log line
+and out of `Referer` headers — but the browser immediately opens
+`GET /api/sessions/{sessionId}/events` to attach the event stream, and *that* request puts the
+handle straight in the path, where a default access log records it like any other URL. The handle
+is the sole authenticator for a stream that replays the full credentials payload once they're
+acquired, so treat it as sensitive too. `Caddyfile.example` redacts the session path alongside
+`steamId` and `token`.
 
 **Your per-IP limits will silently do nothing.** Without the proxy's own address listed in
 `CredentialsWeb__KnownProxies__0` (and `__1`, `__2`, ... for more than one), every visitor presents
@@ -76,7 +85,9 @@ variable, `--CredentialsWeb:Name` on the command line).
 
 - **In memory only.** No database, no session cache, no disk. A restart wipes everything.
 - **The Steam auth token is dropped** the moment your device is registered with Rust Companion.
-- **Nothing is logged.** Asserted by `SecretsAreNeverLoggedTests`, not just intended.
+- **No credential is logged.** Session ids, step names and exception text do appear in the app's
+  own logs — but never a Steam token, FCM/GCM/Expo credential or `playerToken`. Asserted by
+  `SecretsAreNeverLoggedTests`, not just intended.
 - **The callback responds 302**, so the token-bearing URL never becomes a browser history entry,
   and the session handle travels in a URL fragment, which browsers never send to a server.
 - **The server does see the token** in the request line. Facepunch decides the callback shape and

--- a/apps/RustPlusApi.CredentialsWeb/RustPlusApi.CredentialsWeb.csproj
+++ b/apps/RustPlusApi.CredentialsWeb/RustPlusApi.CredentialsWeb.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <!-- The app is net10.0-only and deliberately outside the netstandard2.0 parity story
+             that governs src/. See docs/superpowers/specs/2026-09-03-credential-acquisition-website-design.md -->
+        <UserSecretsId>rustplusapi-credentialsweb</UserSecretsId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\RustPlusApi.Fcm.Registration\RustPlusApi.Fcm.Registration.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="RustPlusApi.CredentialsWeb.UnitTests" />
+    </ItemGroup>
+
+</Project>

--- a/apps/RustPlusApi.CredentialsWeb/Security/SecurityHeaders.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Security/SecurityHeaders.cs
@@ -1,0 +1,29 @@
+namespace RustPlusApi.CredentialsWeb.Security;
+
+/// <summary>Response headers that back the page's trust claims: no referrer leakage, no caching of
+/// anything that carries a credential, and a content policy admitting no third-party origin — which
+/// is also what keeps the client a single auditable file.</summary>
+internal static class SecurityHeaders
+{
+    private const string ContentSecurityPolicy =
+        "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; "
+        + "connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'";
+
+    /// <summary>Adds the headers to every response.</summary>
+    /// <param name="app">The application pipeline.</param>
+    internal static void UseSecurityHeaders(this IApplicationBuilder app) =>
+        app.Use(async (context, next) =>
+        {
+            context.Response.OnStarting(() =>
+            {
+                var headers = context.Response.Headers;
+                headers.ContentSecurityPolicy = ContentSecurityPolicy;
+                headers["Referrer-Policy"] = "no-referrer";
+                headers.XContentTypeOptions = "nosniff";
+                headers.CacheControl = "no-store";
+                return Task.CompletedTask;
+            });
+
+            await next(context).ConfigureAwait(false);
+        });
+}

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
@@ -66,13 +66,20 @@ internal sealed class Session(string sessionId, string returnToken, string clien
     /// <summary>Where the visitor is in the flow.</summary>
     internal SessionState State { get; private set; } = SessionState.Created;
 
-    /// <summary>Cancels in-flight work, ends the event stream and drops every secret. Idempotent
-    /// and never throws: <see cref="CancellationTokenSource.Cancel()"/> rethrows any exception a
-    /// registered callback raises, and letting that escape here would abort cleanup for whichever
-    /// caller is disposing this session — the sweeper mid-sweep, or <see cref="SessionStore.TryCreate"/>
-    /// evicting a batch — and skip <see cref="Events"/>' completion and <see cref="Lifetime"/>'s own
-    /// disposal for good measure, leaking both. The callback exception is swallowed instead, and the
-    /// rest of cleanup runs in a <c>finally</c> regardless.</summary>
+    /// <summary><para>Cancels in-flight work, ends the event stream and drops every secret.
+    /// Idempotent and never throws. <see cref="CancellationTokenSource.Cancel()"/> rethrows any
+    /// exception a registered callback raises, and letting that escape here would abort cleanup
+    /// for whichever caller is disposing this session — the sweeper mid-sweep, or
+    /// <see cref="SessionStore.TryCreate"/> evicting a batch — and skip <see cref="Events"/>'
+    /// completion and <see cref="Lifetime"/>'s own disposal for good measure, leaking both.</para>
+    ///
+    /// <para>Each of the three steps below runs in isolation via <see cref="RunCleanupStep"/>
+    /// rather than only guarding <see cref="CancellationTokenSource.Cancel()"/>: today it is the
+    /// only one that can actually throw (<see cref="SessionEventStream.Complete"/> is a lock, a
+    /// bool check and two list operations; <see cref="CancellationTokenSource.Dispose()"/> has no
+    /// user code to run), but guarding only it would make "all three steps always run, and
+    /// Dispose() never throws" true by accident rather than by construction — a future change to
+    /// either could quietly reintroduce exactly the bug this fixes.</para></summary>
     public void Dispose()
     {
         lock (_gate)
@@ -89,28 +96,33 @@ internal sealed class Session(string sessionId, string returnToken, string clien
         }
 
         // Outside the lock: cancellation callbacks may re-enter session code.
+        RunCleanupStep(Lifetime.Cancel);
+        RunCleanupStep(Events.Complete);
+        RunCleanupStep(Lifetime.Dispose);
+    }
+
+    /// <summary>Runs one <see cref="Dispose"/> cleanup step, swallowing any exception it raises so
+    /// that the remaining steps still run and <see cref="Dispose"/> itself never throws. Not logged:
+    /// a swallowed exception here indicates a bug in whatever registered a throwing callback on
+    /// <see cref="Lifetime"/>'s token, not in the session itself, and <see cref="Session"/> carries
+    /// no logger today — it is constructed directly by <see cref="SessionStore"/> rather than
+    /// through DI, so threading one through every construction site (including the many direct
+    /// <c>new Session(...)</c> calls in tests) for a single defensive catch was judged not worth the
+    /// added surface. A misbehaving callback is caught by <c>SessionSweeperTests</c> instead.</summary>
+    /// <param name="step">The cleanup step to run.</param>
+#pragma warning disable CA1031, RCS1075 // Deliberate: see the remarks on Dispose() and this method.
+    private static void RunCleanupStep(Action step)
+    {
         try
         {
-            Lifetime.Cancel();
+            step();
         }
-#pragma warning disable CA1031, RCS1075 // Deliberate: Dispose() must never throw; see the remarks above.
         catch (Exception)
-#pragma warning restore CA1031, RCS1075
         {
-            // Swallowed by design (see remarks). Not logged: this indicates a bug in whatever
-            // registered the throwing callback on Lifetime.Token, not in the session itself, and
-            // Session carries no logger today — it is constructed directly by SessionStore rather
-            // than through DI, so threading one through every construction site (including the
-            // many direct `new Session(...)` calls in tests) for a single defensive catch was
-            // judged not worth the added surface. A misbehaving callback is caught by
-            // SessionSweeperTests instead.
-        }
-        finally
-        {
-            Events.Complete();
-            Lifetime.Dispose();
+            // Swallowed by design; see the remarks above.
         }
     }
+#pragma warning restore CA1031, RCS1075
 
     /// <summary>Moves to <paramref name="state"/>, resets the expiry and publishes a <c>step</c> event.
     /// A no-op once the session is disposed or <see cref="TryClaimForEviction"/> has claimed it.</summary>

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
@@ -1,0 +1,133 @@
+using RustPlusApi.Fcm.Data;
+using RustPlusApi.Fcm.Registration;
+
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>One visitor's flow: its state, its secrets and their lifetimes. Everything here is
+/// in-memory only and dies with <see cref="Dispose"/> or the process — nothing is ever persisted.</summary>
+/// <param name="sessionId">The handle the browser uses for the event stream and follow-up calls.</param>
+/// <param name="returnToken">Single-use token embedded in the Facepunch <c>returnUrl</c> path.</param>
+/// <param name="clientIp">The caller's address, for per-IP accounting.</param>
+/// <param name="expiresAt">When this session becomes sweepable.</param>
+internal sealed class Session(string sessionId, string returnToken, string clientIp, DateTimeOffset expiresAt)
+    : IDisposable
+{
+    private readonly Lock _gate = new();
+    private bool _disposed;
+
+    /// <summary>Background work started for this session, kept so it is observed rather than fire-and-forget.</summary>
+    internal Task BackgroundWork { get; set; } = Task.CompletedTask;
+
+    /// <summary>The caller's address.</summary>
+    internal string ClientIp { get; } = clientIp;
+
+    /// <summary>Credentials from steps 1-3, once acquired.</summary>
+    internal Credentials? Credentials { get; private set; }
+
+    /// <summary>This session's event stream.</summary>
+    internal SessionEventStream Events { get; } = new();
+
+    /// <summary>When this session becomes sweepable.</summary>
+    internal DateTimeOffset ExpiresAt { get; private set; } = expiresAt;
+
+    /// <summary>Cancelled on disposal, so any in-flight upstream work stops with the session.</summary>
+    internal CancellationTokenSource Lifetime { get; } = new();
+
+    /// <summary>The pairing, once a push arrives.</summary>
+    internal ServerPairing? Pairing { get; private set; }
+
+    /// <summary>Single-use token embedded in the Facepunch <c>returnUrl</c> path.</summary>
+    internal string ReturnToken { get; } = returnToken;
+
+    /// <summary>The handle the browser uses. Never appears in a <c>returnUrl</c>.</summary>
+    internal string SessionId { get; } = sessionId;
+
+    /// <summary>The Steam64 from the callback. Not a secret; kept for display.</summary>
+    internal ulong SteamId { get; private set; }
+
+    /// <summary>The Steam auth token. Dropped the moment step 5 succeeds.</summary>
+    internal string? SteamToken { get; private set; }
+
+    /// <summary>Where the visitor is in the flow.</summary>
+    internal SessionState State { get; private set; } = SessionState.Created;
+
+    /// <summary>Cancels in-flight work, ends the event stream and drops every secret. Idempotent.</summary>
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            SteamToken = null;
+            Credentials = null;
+            Pairing = null;
+        }
+
+        // Outside the lock: cancellation callbacks may re-enter session code.
+        Lifetime.Cancel();
+        Events.Complete();
+        Lifetime.Dispose();
+    }
+
+    /// <summary>Moves to <paramref name="state"/>, resets the expiry and publishes a <c>step</c> event.</summary>
+    /// <param name="state">The new state.</param>
+    /// <param name="newExpiry">The new expiry instant.</param>
+    internal void Advance(SessionState state, DateTimeOffset newExpiry)
+    {
+        lock (_gate)
+        {
+            State = state;
+            ExpiresAt = newExpiry;
+        }
+
+        Events.Publish(new SessionEvent("step", new StepPayload(state.ToString())));
+    }
+
+    /// <summary>Drops the Steam auth token once it has no further use.</summary>
+    internal void ClearSteamToken()
+    {
+        lock (_gate)
+        {
+            SteamToken = null;
+        }
+    }
+
+    /// <summary>True once <paramref name="now"/> has reached the expiry.</summary>
+    /// <param name="now">The current instant, from the ambient <see cref="TimeProvider"/>.</param>
+    internal bool IsExpired(DateTimeOffset now) => now >= ExpiresAt;
+
+    /// <summary>Stores the credentials from steps 1-3.</summary>
+    /// <param name="credentials">The acquired credentials.</param>
+    internal void SetCredentials(Credentials credentials)
+    {
+        lock (_gate)
+        {
+            Credentials = credentials;
+        }
+    }
+
+    /// <summary>Stores the pairing from step 6.</summary>
+    /// <param name="pairing">The pairing that arrived.</param>
+    internal void SetPairing(ServerPairing pairing)
+    {
+        lock (_gate)
+        {
+            Pairing = pairing;
+        }
+    }
+
+    /// <summary>Stores the Steam identity captured from the Facepunch callback.</summary>
+    /// <param name="login">The parsed callback result.</param>
+    internal void SetSteamLogin(SteamLoginResult login)
+    {
+        lock (_gate)
+        {
+            SteamId = login.SteamId;
+            SteamToken = login.Token;
+        }
+    }
+}

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
@@ -73,13 +73,19 @@ internal sealed class Session(string sessionId, string returnToken, string clien
         Lifetime.Dispose();
     }
 
-    /// <summary>Moves to <paramref name="state"/>, resets the expiry and publishes a <c>step</c> event.</summary>
+    /// <summary>Moves to <paramref name="state"/>, resets the expiry and publishes a <c>step</c> event.
+    /// A no-op once the session is disposed.</summary>
     /// <param name="state">The new state.</param>
     /// <param name="newExpiry">The new expiry instant.</param>
     internal void Advance(SessionState state, DateTimeOffset newExpiry)
     {
         lock (_gate)
         {
+            if (_disposed)
+            {
+                return;
+            }
+
             State = state;
             ExpiresAt = newExpiry;
         }
@@ -100,32 +106,48 @@ internal sealed class Session(string sessionId, string returnToken, string clien
     /// <param name="now">The current instant, from the ambient <see cref="TimeProvider"/>.</param>
     internal bool IsExpired(DateTimeOffset now) => now >= ExpiresAt;
 
-    /// <summary>Stores the credentials from steps 1-3.</summary>
+    /// <summary>Stores the credentials from steps 1-3. A no-op once the session is disposed.</summary>
     /// <param name="credentials">The acquired credentials.</param>
     internal void SetCredentials(Credentials credentials)
     {
         lock (_gate)
         {
+            if (_disposed)
+            {
+                return;
+            }
+
             Credentials = credentials;
         }
     }
 
-    /// <summary>Stores the pairing from step 6.</summary>
+    /// <summary>Stores the pairing from step 6. A no-op once the session is disposed.</summary>
     /// <param name="pairing">The pairing that arrived.</param>
     internal void SetPairing(ServerPairing pairing)
     {
         lock (_gate)
         {
+            if (_disposed)
+            {
+                return;
+            }
+
             Pairing = pairing;
         }
     }
 
-    /// <summary>Stores the Steam identity captured from the Facepunch callback.</summary>
+    /// <summary>Stores the Steam identity captured from the Facepunch callback. A no-op once the
+    /// session is disposed.</summary>
     /// <param name="login">The parsed callback result.</param>
     internal void SetSteamLogin(SteamLoginResult login)
     {
         lock (_gate)
         {
+            if (_disposed)
+            {
+                return;
+            }
+
             SteamId = login.SteamId;
             SteamToken = login.Token;
         }

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
@@ -1,5 +1,6 @@
 using RustPlusApi.Fcm.Data;
 using RustPlusApi.Fcm.Registration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace RustPlusApi.CredentialsWeb.Sessions;
 
@@ -242,5 +243,53 @@ internal sealed class Session(string sessionId, string returnToken, string clien
             _claimedForEviction = true;
             return true;
         }
+    }
+
+    /// <summary><para>Atomically decides, with respect to any concurrent claim, whether a pairing
+    /// wait may start on this session, and commits the <see cref="SessionState.Ready"/> to
+    /// <see cref="SessionState.AwaitingPairing"/> transition together with the credentials that wait
+    /// needs. The pairing endpoint's own <see cref="SessionState.Ready"/> check is only an advisory
+    /// fast path for its 409: two concurrent <c>POST /api/sessions/{sessionId}/pairing</c> calls
+    /// (two tabs on one session handle, or a retried request) can both read
+    /// <see cref="SessionState.Ready"/> there, so this claim — not that check — is what holds a
+    /// session to a single pairing wait. Without it both callers would open an MCS socket against
+    /// the same credentials and whichever finished last would overwrite the other's outcome: a
+    /// timeout dropping an already-<see cref="SessionState.Paired"/> session back to
+    /// <see cref="SessionState.Ready"/> with a spurious <c>expired</c> event, or a socket error
+    /// flipping it to <see cref="SessionState.Failed"/>.</para>
+    ///
+    /// <para>This runs under the same <see cref="_gate"/> that <see cref="Advance"/> writes
+    /// <see cref="State"/> under, so the loser of a race reads the winner's
+    /// <see cref="SessionState.AwaitingPairing"/> rather than the stale
+    /// <see cref="SessionState.Ready"/> it was dispatched on. The two conditions below also
+    /// subsume the two flags every other setter tests explicitly, which is why neither is repeated
+    /// here and why both would be unreachable if it were: a session claimed by
+    /// <see cref="TryClaimForEviction"/> is in <see cref="SessionState.Created"/> or
+    /// <see cref="SessionState.Failed"/> by that method's own precondition and so never
+    /// <see cref="SessionState.Ready"/>, and a disposed one has had <see cref="Credentials"/>
+    /// nulled under this very lock.</para></summary>
+    /// <param name="newExpiry">The new expiry instant — the session's TTL, not the pairing wait's.</param>
+    /// <param name="credentials">The credentials to pair against, read under the lock so a racing
+    /// <see cref="Dispose"/> cannot null them out from under the caller.</param>
+    /// <returns><see langword="true"/> if the caller now owns this session's pairing wait.</returns>
+    internal bool TryClaimForPairing(DateTimeOffset newExpiry, [NotNullWhen(true)] out Credentials? credentials)
+    {
+        lock (_gate)
+        {
+            if (State != SessionState.Ready || Credentials is not { } acquired)
+            {
+                credentials = null;
+                return false;
+            }
+
+            credentials = acquired;
+            State = SessionState.AwaitingPairing;
+            _expiresAt = newExpiry;
+        }
+
+        // Outside the lock, and identical to what Advance would have published: the browser sees one
+        // step event per state change either way.
+        Events.Publish(new SessionEvent("step", new StepPayload(nameof(SessionState.AwaitingPairing))));
+        return true;
     }
 }

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
@@ -15,6 +15,8 @@ internal sealed class Session(string sessionId, string returnToken, string clien
     private readonly Lock _gate = new();
     private bool _disposed;
 
+    private DateTimeOffset _expiresAt = expiresAt;
+
     /// <summary>Background work started for this session, kept so it is observed rather than fire-and-forget.</summary>
     internal Task BackgroundWork { get; set; } = Task.CompletedTask;
 
@@ -27,8 +29,19 @@ internal sealed class Session(string sessionId, string returnToken, string clien
     /// <summary>This session's event stream.</summary>
     internal SessionEventStream Events { get; } = new();
 
-    /// <summary>When this session becomes sweepable.</summary>
-    internal DateTimeOffset ExpiresAt { get; private set; } = expiresAt;
+    /// <summary>When this session becomes sweepable. The getter takes <see cref="_gate"/>: the
+    /// sweeper reads this concurrently with <see cref="Advance"/>'s writes on the flow's own thread,
+    /// and <see cref="DateTimeOffset"/> is not guaranteed to read or write atomically.</summary>
+    internal DateTimeOffset ExpiresAt
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _expiresAt;
+            }
+        }
+    }
 
     /// <summary>Cancelled on disposal, so any in-flight upstream work stops with the session.</summary>
     internal CancellationTokenSource Lifetime { get; } = new();
@@ -45,7 +58,8 @@ internal sealed class Session(string sessionId, string returnToken, string clien
     /// <summary>The Steam64 from the callback. Not a secret; kept for display.</summary>
     internal ulong SteamId { get; private set; }
 
-    /// <summary>The Steam auth token. Dropped the moment step 5 succeeds.</summary>
+    /// <summary>The Steam auth token. Dropped on success, failure and cancellation alike — never
+    /// retained once step 5 has run to any conclusion.</summary>
     internal string? SteamToken { get; private set; }
 
     /// <summary>Where the visitor is in the flow.</summary>
@@ -87,7 +101,7 @@ internal sealed class Session(string sessionId, string returnToken, string clien
             }
 
             State = state;
-            ExpiresAt = newExpiry;
+            _expiresAt = newExpiry;
         }
 
         Events.Publish(new SessionEvent("step", new StepPayload(state.ToString())));

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
@@ -13,6 +13,7 @@ internal sealed class Session(string sessionId, string returnToken, string clien
     : IDisposable
 {
     private readonly Lock _gate = new();
+    private bool _claimedForEviction;
     private bool _disposed;
 
     private DateTimeOffset _expiresAt = expiresAt;
@@ -112,14 +113,14 @@ internal sealed class Session(string sessionId, string returnToken, string clien
     }
 
     /// <summary>Moves to <paramref name="state"/>, resets the expiry and publishes a <c>step</c> event.
-    /// A no-op once the session is disposed.</summary>
+    /// A no-op once the session is disposed or <see cref="TryClaimForEviction"/> has claimed it.</summary>
     /// <param name="state">The new state.</param>
     /// <param name="newExpiry">The new expiry instant.</param>
     internal void Advance(SessionState state, DateTimeOffset newExpiry)
     {
         lock (_gate)
         {
-            if (_disposed)
+            if (_disposed || _claimedForEviction)
             {
                 return;
             }
@@ -144,13 +145,14 @@ internal sealed class Session(string sessionId, string returnToken, string clien
     /// <param name="now">The current instant, from the ambient <see cref="TimeProvider"/>.</param>
     internal bool IsExpired(DateTimeOffset now) => now >= ExpiresAt;
 
-    /// <summary>Stores the credentials from steps 1-3. A no-op once the session is disposed.</summary>
+    /// <summary>Stores the credentials from steps 1-3. A no-op once the session is disposed or
+    /// <see cref="TryClaimForEviction"/> has claimed it.</summary>
     /// <param name="credentials">The acquired credentials.</param>
     internal void SetCredentials(Credentials credentials)
     {
         lock (_gate)
         {
-            if (_disposed)
+            if (_disposed || _claimedForEviction)
             {
                 return;
             }
@@ -159,13 +161,14 @@ internal sealed class Session(string sessionId, string returnToken, string clien
         }
     }
 
-    /// <summary>Stores the pairing from step 6. A no-op once the session is disposed.</summary>
+    /// <summary>Stores the pairing from step 6. A no-op once the session is disposed or
+    /// <see cref="TryClaimForEviction"/> has claimed it.</summary>
     /// <param name="pairing">The pairing that arrived.</param>
     internal void SetPairing(ServerPairing pairing)
     {
         lock (_gate)
         {
-            if (_disposed)
+            if (_disposed || _claimedForEviction)
             {
                 return;
             }
@@ -175,19 +178,57 @@ internal sealed class Session(string sessionId, string returnToken, string clien
     }
 
     /// <summary>Stores the Steam identity captured from the Facepunch callback. A no-op once the
-    /// session is disposed.</summary>
+    /// session is disposed or <see cref="TryClaimForEviction"/> has claimed it.</summary>
     /// <param name="login">The parsed callback result.</param>
     internal void SetSteamLogin(SteamLoginResult login)
     {
         lock (_gate)
         {
-            if (_disposed)
+            if (_disposed || _claimedForEviction)
             {
                 return;
             }
 
             SteamId = login.SteamId;
             SteamToken = login.Token;
+        }
+    }
+
+    /// <summary><para>Atomically decides, with respect to any concurrent <see cref="Advance"/> call,
+    /// whether <see cref="SessionStore.TryCreate"/> may evict this session. Only a session still in
+    /// <see cref="SessionState.Created"/> (it never touched upstream) or terminally
+    /// <see cref="SessionState.Failed"/> is evictable; anything else has resumable upstream work and
+    /// the caller must refuse instead of evicting.</para>
+    ///
+    /// <para>This runs under the same <see cref="_gate"/> that <see cref="Advance"/> writes
+    /// <see cref="State"/> under, so a racing <see cref="Advance"/> call can never interleave with
+    /// the decision: it either commits first — this call then observes the new state and returns
+    /// <see langword="false"/>, correctly refusing rather than evicting mid-flight work — or it
+    /// loses the race, in which case this call marks the session so that <see cref="Advance"/> (and
+    /// every other setter) becomes a no-op instead of resurrecting a session that is about to be
+    /// disposed. Deliberately a separate flag from <see cref="_disposed"/>: unlike disposal, a claim
+    /// here does not itself run any cleanup — <see cref="Dispose"/> still has to.</para>
+    ///
+    /// <para>A session that is already disposed returns <see langword="true"/> too: something else
+    /// (the sweeper, a concurrent eviction) already claimed and is disposing it, so there is nothing
+    /// left here to protect, and refusing would incorrectly block a new session over one that is
+    /// already gone.</para></summary>
+    internal bool TryClaimForEviction()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return true;
+            }
+
+            if (State != SessionState.Created && State != SessionState.Failed)
+            {
+                return false;
+            }
+
+            _claimedForEviction = true;
+            return true;
         }
     }
 }

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
@@ -65,7 +65,13 @@ internal sealed class Session(string sessionId, string returnToken, string clien
     /// <summary>Where the visitor is in the flow.</summary>
     internal SessionState State { get; private set; } = SessionState.Created;
 
-    /// <summary>Cancels in-flight work, ends the event stream and drops every secret. Idempotent.</summary>
+    /// <summary>Cancels in-flight work, ends the event stream and drops every secret. Idempotent
+    /// and never throws: <see cref="CancellationTokenSource.Cancel()"/> rethrows any exception a
+    /// registered callback raises, and letting that escape here would abort cleanup for whichever
+    /// caller is disposing this session — the sweeper mid-sweep, or <see cref="SessionStore.TryCreate"/>
+    /// evicting a batch — and skip <see cref="Events"/>' completion and <see cref="Lifetime"/>'s own
+    /// disposal for good measure, leaking both. The callback exception is swallowed instead, and the
+    /// rest of cleanup runs in a <c>finally</c> regardless.</summary>
     public void Dispose()
     {
         lock (_gate)
@@ -82,9 +88,27 @@ internal sealed class Session(string sessionId, string returnToken, string clien
         }
 
         // Outside the lock: cancellation callbacks may re-enter session code.
-        Lifetime.Cancel();
-        Events.Complete();
-        Lifetime.Dispose();
+        try
+        {
+            Lifetime.Cancel();
+        }
+#pragma warning disable CA1031, RCS1075 // Deliberate: Dispose() must never throw; see the remarks above.
+        catch (Exception)
+#pragma warning restore CA1031, RCS1075
+        {
+            // Swallowed by design (see remarks). Not logged: this indicates a bug in whatever
+            // registered the throwing callback on Lifetime.Token, not in the session itself, and
+            // Session carries no logger today — it is constructed directly by SessionStore rather
+            // than through DI, so threading one through every construction site (including the
+            // many direct `new Session(...)` calls in tests) for a single defensive catch was
+            // judged not worth the added surface. A misbehaving callback is caught by
+            // SessionSweeperTests instead.
+        }
+        finally
+        {
+            Events.Complete();
+            Lifetime.Dispose();
+        }
     }
 
     /// <summary>Moves to <paramref name="state"/>, resets the expiry and publishes a <c>step</c> event.

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionEvent.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionEvent.cs
@@ -1,0 +1,7 @@
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>One server-sent event. <paramref name="Type"/> becomes the SSE <c>event:</c> name and
+/// <paramref name="Data"/> is serialized to JSON for the <c>data:</c> line.</summary>
+/// <param name="Type">One of <c>step</c>, <c>credentials</c>, <c>paired</c>, <c>error</c>, <c>expired</c>.</param>
+/// <param name="Data">Payload, or <see langword="null"/> for an event that carries none.</param>
+internal sealed record SessionEvent(string Type, object? Data);

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionEventPayloads.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionEventPayloads.cs
@@ -1,0 +1,23 @@
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>Payload of a <c>step</c> event.</summary>
+/// <param name="State">The new <see cref="SessionState"/>, as its enum name.</param>
+internal sealed record StepPayload(string State);
+
+/// <summary>Payload of a <c>credentials</c> event.</summary>
+/// <param name="SteamId">Steam64 as a string: it exceeds JavaScript's safe integer range.</param>
+/// <param name="ConfigJson">The exact contents of rustplus.config.json, from <c>CredentialsStore.Serialize</c>.</param>
+internal sealed record CredentialsPayload(string SteamId, string ConfigJson);
+
+/// <summary>Payload of a <c>paired</c> event.</summary>
+/// <param name="Ip">Server address.</param>
+/// <param name="Port">Server app port.</param>
+/// <param name="PlayerId">Steam64 as a string, for the same reason as <see cref="CredentialsPayload.SteamId"/>.</param>
+/// <param name="PlayerToken">The pairing token. Full Rust+ account access.</param>
+/// <param name="Name">Server name, when the push carried one.</param>
+internal sealed record PairedPayload(string Ip, int Port, string PlayerId, int PlayerToken, string? Name);
+
+/// <summary>Payload of an <c>error</c> event. Always a fixed, non-reflective message: never an
+/// exception message, which could carry upstream response content.</summary>
+/// <param name="Message">What to show the visitor.</param>
+internal sealed record ErrorPayload(string Message);

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionEventStream.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionEventStream.cs
@@ -8,8 +8,8 @@ namespace RustPlusApi.CredentialsWeb.Sessions;
 /// which matters because the drop happens exactly when the visitor alt-tabs into fullscreen Rust.</summary>
 internal sealed class SessionEventStream
 {
-    private readonly List<SessionEvent> _history = [];
     private readonly Lock _gate = new();
+    private readonly List<SessionEvent> _history = [];
     private readonly List<Channel<SessionEvent>> _subscribers = [];
     private bool _completed;
 
@@ -112,8 +112,7 @@ internal sealed class SessionEventStream
 
             var channel = Channel.CreateUnbounded<SessionEvent>(new UnboundedChannelOptions
             {
-                SingleReader = true,
-                SingleWriter = false
+                SingleReader = true, SingleWriter = false
             });
 
             _subscribers.Add(channel);

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionEventStream.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionEventStream.cs
@@ -13,6 +13,18 @@ internal sealed class SessionEventStream
     private readonly List<Channel<SessionEvent>> _subscribers = [];
     private bool _completed;
 
+    /// <summary>The current number of active subscribers. For testing only.</summary>
+    internal int SubscriberCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _subscribers.Count;
+            }
+        }
+    }
+
     /// <summary>Appends an event to the history and pushes it to every live subscriber.
     /// Ignored once <see cref="Complete"/> has been called.</summary>
     /// <param name="sessionEvent">The event to publish.</param>
@@ -61,27 +73,34 @@ internal sealed class SessionEventStream
     internal async IAsyncEnumerable<SessionEvent> SubscribeAsync(
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var (history, reader) = Subscribe();
+        var (history, channel) = Subscribe();
 
         foreach (var item in history)
         {
             yield return item;
         }
 
-        if (reader is null)
+        if (channel is null)
         {
             yield break;
         }
 
-        await foreach (var item in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        try
         {
-            yield return item;
+            await foreach (var item in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                yield return item;
+            }
+        }
+        finally
+        {
+            Unsubscribe(channel);
         }
     }
 
     /// <summary>Snapshots the history and registers a subscriber under one lock, so no event can slip
-    /// between the two. Returns a null reader when the stream is already complete.</summary>
-    private (IReadOnlyList<SessionEvent> History, ChannelReader<SessionEvent>? Reader) Subscribe()
+    /// between the two. Returns a null channel when the stream is already complete.</summary>
+    private (IReadOnlyList<SessionEvent> History, Channel<SessionEvent>? Channel) Subscribe()
     {
         lock (_gate)
         {
@@ -98,7 +117,18 @@ internal sealed class SessionEventStream
             });
 
             _subscribers.Add(channel);
-            return (history, channel.Reader);
+            return (history, channel);
+        }
+    }
+
+    /// <summary>Deregisters a subscriber when its enumeration ends. Safe to call even if the channel
+    /// is not currently registered (e.g., if <see cref="Complete"/> already cleared <see cref="_subscribers"/>).</summary>
+    /// <param name="channel">The channel to remove.</param>
+    private void Unsubscribe(Channel<SessionEvent> channel)
+    {
+        lock (_gate)
+        {
+            _subscribers.Remove(channel);
         }
     }
 }

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionEventStream.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionEventStream.cs
@@ -1,0 +1,104 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>Fans one session's events out to every subscriber, replaying the events published
+/// before each subscription. Replay is what makes an SSE reconnect resume rather than restart —
+/// which matters because the drop happens exactly when the visitor alt-tabs into fullscreen Rust.</summary>
+internal sealed class SessionEventStream
+{
+    private readonly List<SessionEvent> _history = [];
+    private readonly Lock _gate = new();
+    private readonly List<Channel<SessionEvent>> _subscribers = [];
+    private bool _completed;
+
+    /// <summary>Appends an event to the history and pushes it to every live subscriber.
+    /// Ignored once <see cref="Complete"/> has been called.</summary>
+    /// <param name="sessionEvent">The event to publish.</param>
+    internal void Publish(SessionEvent sessionEvent)
+    {
+        lock (_gate)
+        {
+            if (_completed)
+            {
+                return;
+            }
+
+            _history.Add(sessionEvent);
+            foreach (var subscriber in _subscribers)
+            {
+                // Unbounded channel: writes always succeed, so a slow reader can never block the flow.
+                subscriber.Writer.TryWrite(sessionEvent);
+            }
+        }
+    }
+
+    /// <summary>Ends every subscriber's enumeration. Idempotent.</summary>
+    internal void Complete()
+    {
+        lock (_gate)
+        {
+            if (_completed)
+            {
+                return;
+            }
+
+            _completed = true;
+            foreach (var subscriber in _subscribers)
+            {
+                subscriber.Writer.TryComplete();
+            }
+
+            _subscribers.Clear();
+        }
+    }
+
+    /// <summary>Yields every event published so far, then every subsequent one until the stream is
+    /// completed or <paramref name="cancellationToken"/> fires.</summary>
+    /// <param name="cancellationToken">Cancellation token for the subscription.</param>
+    /// <returns>An async enumerable of events.</returns>
+    internal async IAsyncEnumerable<SessionEvent> SubscribeAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var (history, reader) = Subscribe();
+
+        foreach (var item in history)
+        {
+            yield return item;
+        }
+
+        if (reader is null)
+        {
+            yield break;
+        }
+
+        await foreach (var item in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        {
+            yield return item;
+        }
+    }
+
+    /// <summary>Snapshots the history and registers a subscriber under one lock, so no event can slip
+    /// between the two. Returns a null reader when the stream is already complete.</summary>
+    private (IReadOnlyList<SessionEvent> History, ChannelReader<SessionEvent>? Reader) Subscribe()
+    {
+        lock (_gate)
+        {
+            var history = _history.ToArray();
+            if (_completed)
+            {
+                return (history, null);
+            }
+
+            var channel = Channel.CreateUnbounded<SessionEvent>(new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = false
+            });
+
+            _subscribers.Add(channel);
+            return (history, channel.Reader);
+        }
+    }
+}

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionIds.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionIds.cs
@@ -1,0 +1,11 @@
+using System.Security.Cryptography;
+
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>Generates the opaque identifiers used for both the session handle and the return token.</summary>
+internal static class SessionIds
+{
+    /// <summary>A fresh 128-bit identifier as 32 lowercase hex characters.</summary>
+    internal static string New() =>
+        Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant();
+}

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionState.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionState.cs
@@ -1,0 +1,31 @@
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>Where a visitor is in the credential flow.</summary>
+internal enum SessionState
+{
+    /// <summary>Created; the visitor has not completed the Steam login yet. Nothing upstream touched.</summary>
+    Created = 0,
+
+    /// <summary>The Facepunch callback arrived with a usable Steam token.</summary>
+    Authenticated = 1,
+
+    /// <summary>Steps 1-3 and 5 are running.</summary>
+    Registering = 2,
+
+    /// <summary>Credentials acquired and registered with Rust Companion.</summary>
+    Ready = 3,
+
+    /// <summary>Holding an MCS socket, waiting for the in-game pairing push.</summary>
+    AwaitingPairing = 4,
+
+    /// <summary>A pairing push arrived; the flow is complete.</summary>
+    Paired = 5,
+
+    /// <summary>A step failed. Terminal.</summary>
+    Failed = 6
+}
+
+// There is deliberately no Expired state. A pairing wait that times out returns the session to
+// Ready and emits an `expired` event: the credentials are still valid, so the visitor can retry
+// the pairing without repeating the Steam login. A session that outlives its TTL is removed by
+// the sweeper rather than parked in a state nobody can observe.

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs
@@ -1,0 +1,123 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>Why <see cref="SessionStore.TryCreate"/> refused.</summary>
+internal enum SessionCreateFailure
+{
+    /// <summary>Creation succeeded.</summary>
+    None = 0,
+
+    /// <summary>The instance-wide session cap is full.</summary>
+    GlobalLimit = 1,
+
+    /// <summary>This address already holds a session past <see cref="SessionState.Created"/>.</summary>
+    ActiveSessionForIp = 2,
+
+    /// <summary>This address has completed too many flows in the last hour.</summary>
+    HourlyLimit = 3
+}
+
+/// <summary>The in-memory session registry. There is no persistence anywhere in this app: a process
+/// restart wipes every session by construction.</summary>
+/// <param name="options">Caps and TTLs.</param>
+/// <param name="timeProvider">Clock, injected so TTLs are testable.</param>
+internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider) : IDisposable
+{
+    private readonly ConcurrentDictionary<string, string> _byReturnToken = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Session> _bySessionId = new(StringComparer.Ordinal);
+
+    /// <summary>Live sessions in any state.</summary>
+    internal int Count => _bySessionId.Count;
+
+    /// <summary>Disposes every live session.</summary>
+    public void Dispose()
+    {
+        foreach (var sessionId in _bySessionId.Keys)
+        {
+            Remove(sessionId);
+        }
+    }
+
+    /// <summary>Forgets a session and disposes it, invalidating its return token.</summary>
+    /// <param name="sessionId">The session handle.</param>
+    internal void Remove(string sessionId)
+    {
+        if (!_bySessionId.TryRemove(sessionId, out var session))
+        {
+            return;
+        }
+
+        _byReturnToken.TryRemove(session.ReturnToken, out _);
+        session.Dispose();
+    }
+
+    /// <summary>Disposes every session whose expiry has passed. Returns how many were removed.</summary>
+    internal int SweepExpired()
+    {
+        var now = timeProvider.GetUtcNow();
+        var swept = 0;
+
+        foreach (var (sessionId, session) in _bySessionId)
+        {
+            if (!session.IsExpired(now))
+            {
+                continue;
+            }
+
+            Remove(sessionId);
+            swept++;
+        }
+
+        return swept;
+    }
+
+    /// <summary>Looks a session up by its return token and invalidates that token, so a callback URL
+    /// replayed from browser history finds nothing.</summary>
+    /// <param name="returnToken">The token from the callback path.</param>
+    /// <param name="session">The owning session when the token was live.</param>
+    internal bool TryConsumeReturnToken(string returnToken, [NotNullWhen(true)] out Session? session)
+    {
+        session = null;
+        return _byReturnToken.TryRemove(returnToken, out var sessionId)
+            && _bySessionId.TryGetValue(sessionId, out session);
+    }
+
+    /// <summary>Creates a session for <paramref name="clientIp"/>, or explains why it could not.</summary>
+    /// <param name="clientIp">The caller's address.</param>
+    /// <param name="session">The new session on success.</param>
+    /// <param name="failure">Why creation was refused.</param>
+    internal bool TryCreate(
+        string clientIp,
+        [NotNullWhen(true)] out Session? session,
+        out SessionCreateFailure failure)
+    {
+        session = null;
+
+        if (_bySessionId.Count >= options.MaxConcurrentSessions)
+        {
+            failure = SessionCreateFailure.GlobalLimit;
+            return false;
+        }
+
+        var created = new Session(
+            SessionIds.New(),
+            SessionIds.New(),
+            clientIp,
+            timeProvider.GetUtcNow().Add(options.CreatedTtl));
+
+        _bySessionId[created.SessionId] = created;
+        _byReturnToken[created.ReturnToken] = created.SessionId;
+
+        session = created;
+        failure = SessionCreateFailure.None;
+        return true;
+    }
+
+    /// <summary>Looks a session up by its handle. The return token is deliberately not accepted here.</summary>
+    /// <param name="sessionId">The session handle.</param>
+    /// <param name="session">The session when found.</param>
+    internal bool TryGet(string sessionId, [NotNullWhen(true)] out Session? session) =>
+        _bySessionId.TryGetValue(sessionId, out session);
+}

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs
@@ -28,6 +28,15 @@ internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider
     private readonly ConcurrentDictionary<string, string> _byReturnToken = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, Session> _bySessionId = new(StringComparer.Ordinal);
 
+    private readonly ConcurrentDictionary<string, List<DateTimeOffset>> _completionsByIp =
+        new(StringComparer.Ordinal);
+
+    private readonly Lock _createGate = new();
+    private int _activePairings;
+
+    /// <summary>Live MCS sockets.</summary>
+    internal int ActivePairings => Volatile.Read(ref _activePairings);
+
     /// <summary>Live sessions in any state.</summary>
     internal int Count => _bySessionId.Count;
 
@@ -81,10 +90,62 @@ internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider
     {
         session = null;
         return _byReturnToken.TryRemove(returnToken, out var sessionId)
-            && _bySessionId.TryGetValue(sessionId, out session);
+               && _bySessionId.TryGetValue(sessionId, out session);
     }
 
-    /// <summary>Creates a session for <paramref name="clientIp"/>, or explains why it could not.</summary>
+    /// <summary>Records that <paramref name="clientIp"/> finished a flow, for the rolling hourly cap.</summary>
+    /// <param name="clientIp">The caller's address.</param>
+    internal void RecordCompletion(string clientIp)
+    {
+        var stamps = _completionsByIp.GetOrAdd(clientIp, static _ => []);
+        lock (stamps)
+        {
+            stamps.Add(timeProvider.GetUtcNow());
+        }
+    }
+
+    /// <summary>Releases a pairing slot. Safe to call more often than it was acquired.</summary>
+    internal void ReleasePairingSlot()
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref _activePairings);
+            if (current == 0)
+            {
+                return;
+            }
+
+            if (Interlocked.CompareExchange(ref _activePairings, current - 1, current) == current)
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>Takes one of the globally capped MCS socket slots.</summary>
+    internal bool TryAcquirePairingSlot()
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref _activePairings);
+            if (current >= options.MaxConcurrentPairings)
+            {
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _activePairings, current + 1, current) == current)
+            {
+                return true;
+            }
+        }
+    }
+
+    /// <summary>Creates a session for <paramref name="clientIp"/>, or explains why it could not.
+    /// A session from the same address that is still in <see cref="SessionState.Created"/> is
+    /// evicted rather than blocking: a visitor who closed the tab and started over must not be
+    /// locked out by their own abandoned attempt. An address holding a session past
+    /// <see cref="SessionState.Created"/> is refused instead — real upstream work exists there,
+    /// and that session is resumable via its handle.</summary>
     /// <param name="clientIp">The caller's address.</param>
     /// <param name="session">The new session on success.</param>
     /// <param name="failure">Why creation was refused.</param>
@@ -95,24 +156,49 @@ internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider
     {
         session = null;
 
-        if (_bySessionId.Count >= options.MaxConcurrentSessions)
+        lock (_createGate)
         {
-            failure = SessionCreateFailure.GlobalLimit;
-            return false;
+            if (CountCompletions(clientIp) >= options.MaxCompletionsPerIpPerHour)
+            {
+                failure = SessionCreateFailure.HourlyLimit;
+                return false;
+            }
+
+            foreach (var (sessionId, existing) in _bySessionId)
+            {
+                if (!string.Equals(existing.ClientIp, clientIp, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (existing.State != SessionState.Created)
+                {
+                    failure = SessionCreateFailure.ActiveSessionForIp;
+                    return false;
+                }
+
+                Remove(sessionId);
+            }
+
+            if (_bySessionId.Count >= options.MaxConcurrentSessions)
+            {
+                failure = SessionCreateFailure.GlobalLimit;
+                return false;
+            }
+
+            var created = new Session(
+                SessionIds.New(),
+                SessionIds.New(),
+                clientIp,
+                timeProvider.GetUtcNow().Add(options.CreatedTtl));
+
+            _bySessionId[created.SessionId] = created;
+            _byReturnToken[created.ReturnToken] = created.SessionId;
+
+            session = created;
+            failure = SessionCreateFailure.None;
+            return true;
         }
-
-        var created = new Session(
-            SessionIds.New(),
-            SessionIds.New(),
-            clientIp,
-            timeProvider.GetUtcNow().Add(options.CreatedTtl));
-
-        _bySessionId[created.SessionId] = created;
-        _byReturnToken[created.ReturnToken] = created.SessionId;
-
-        session = created;
-        failure = SessionCreateFailure.None;
-        return true;
     }
 
     /// <summary>Looks a session up by its handle. The return token is deliberately not accepted here.</summary>
@@ -120,4 +206,27 @@ internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider
     /// <param name="session">The session when found.</param>
     internal bool TryGet(string sessionId, [NotNullWhen(true)] out Session? session) =>
         _bySessionId.TryGetValue(sessionId, out session);
+
+    /// <summary>Completions by this address inside the trailing hour, pruning older entries as it goes
+    /// so the map cannot grow without bound.</summary>
+    /// <param name="clientIp">The caller's address.</param>
+    private int CountCompletions(string clientIp)
+    {
+        if (!_completionsByIp.TryGetValue(clientIp, out var stamps))
+        {
+            return 0;
+        }
+
+        var cutoff = timeProvider.GetUtcNow().AddHours(-1);
+        lock (stamps)
+        {
+            stamps.RemoveAll(stamp => stamp < cutoff);
+            if (stamps.Count == 0)
+            {
+                _completionsByIp.TryRemove(clientIp, out _);
+            }
+
+            return stamps.Count;
+        }
+    }
 }

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs
@@ -161,7 +161,10 @@ internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider
     /// is resumable — the former never touched upstream, the latter is terminal — so a visitor who
     /// closed the tab, or whose flow simply failed, must not be locked out by their own abandoned or
     /// dead attempt. An address holding a session in any other state is refused instead — real,
-    /// resumable upstream work exists there, reachable via that session's handle.</summary>
+    /// resumable upstream work exists there, reachable via that session's handle. The eligibility
+    /// check itself is atomic with <see cref="Session.Advance"/> (see
+    /// <see cref="Session.TryClaimForEviction"/>): a plain read of <c>existing.State</c> here would
+    /// race a callback that is concurrently advancing the session past <see cref="SessionState.Created"/>.</summary>
     /// <param name="clientIp">The caller's address.</param>
     /// <param name="session">The new session on success.</param>
     /// <param name="failure">Why creation was refused.</param>
@@ -190,7 +193,7 @@ internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider
                         continue;
                     }
 
-                    if (existing.State != SessionState.Created && existing.State != SessionState.Failed)
+                    if (!existing.TryClaimForEviction())
                     {
                         failure = SessionCreateFailure.ActiveSessionForIp;
                         return false;

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs
@@ -93,13 +93,17 @@ internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider
                && _bySessionId.TryGetValue(sessionId, out session);
     }
 
-    /// <summary>Records that <paramref name="clientIp"/> finished a flow, for the rolling hourly cap.</summary>
+    /// <summary>Records that <paramref name="clientIp"/> finished a flow, for the rolling hourly cap.
+    /// Runs under the same gate as <see cref="TryCreate"/> rather than a per-list lock: a per-list
+    /// lock lets a completion race the exact moment <see cref="CountCompletionsUnderGate"/> prunes
+    /// that address's list to empty and unlinks it from the map, silently losing the completion.
+    /// A single gate removes that interleaving entirely instead of patching around it.</summary>
     /// <param name="clientIp">The caller's address.</param>
     internal void RecordCompletion(string clientIp)
     {
-        var stamps = _completionsByIp.GetOrAdd(clientIp, static _ => []);
-        lock (stamps)
+        lock (_createGate)
         {
+            var stamps = _completionsByIp.GetOrAdd(clientIp, static _ => []);
             stamps.Add(timeProvider.GetUtcNow());
         }
     }
@@ -158,7 +162,7 @@ internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider
 
         lock (_createGate)
         {
-            if (CountCompletions(clientIp) >= options.MaxCompletionsPerIpPerHour)
+            if (CountCompletionsUnderGate(clientIp) >= options.MaxCompletionsPerIpPerHour)
             {
                 failure = SessionCreateFailure.HourlyLimit;
                 return false;
@@ -207,10 +211,14 @@ internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider
     internal bool TryGet(string sessionId, [NotNullWhen(true)] out Session? session) =>
         _bySessionId.TryGetValue(sessionId, out session);
 
-    /// <summary>Completions by this address inside the trailing hour, pruning older entries as it goes
-    /// so the map cannot grow without bound.</summary>
+    /// <summary>Completions by this address inside the trailing hour, pruning older entries as it goes.
+    /// This bounds an address's own list only when that address calls <see cref="TryCreate"/> again —
+    /// it is the only caller, so an address that keeps calling <see cref="RecordCompletion"/> without
+    /// ever retrying <see cref="TryCreate"/> keeps growing its list, since nothing else visits it to
+    /// prune. Must be called while already holding <see cref="_createGate"/>: it does no locking of
+    /// its own and relies on the caller for exclusive access to <see cref="_completionsByIp"/>.</summary>
     /// <param name="clientIp">The caller's address.</param>
-    private int CountCompletions(string clientIp)
+    private int CountCompletionsUnderGate(string clientIp)
     {
         if (!_completionsByIp.TryGetValue(clientIp, out var stamps))
         {
@@ -218,15 +226,12 @@ internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider
         }
 
         var cutoff = timeProvider.GetUtcNow().AddHours(-1);
-        lock (stamps)
+        stamps.RemoveAll(stamp => stamp < cutoff);
+        if (stamps.Count == 0)
         {
-            stamps.RemoveAll(stamp => stamp < cutoff);
-            if (stamps.Count == 0)
-            {
-                _completionsByIp.TryRemove(clientIp, out _);
-            }
-
-            return stamps.Count;
+            _completionsByIp.TryRemove(clientIp, out _);
         }
+
+        return stamps.Count;
     }
 }

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs
@@ -51,15 +51,26 @@ internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider
 
     /// <summary>Forgets a session and disposes it, invalidating its return token.</summary>
     /// <param name="sessionId">The session handle.</param>
-    internal void Remove(string sessionId)
+    internal void Remove(string sessionId) => RemoveFromMaps(sessionId)?.Dispose();
+
+    /// <summary>Removes a session from both lookup maps without disposing it.</summary>
+    /// <remarks>Splitting removal from disposal lets <see cref="TryCreate"/> collect every victim
+    /// while holding <see cref="_createGate"/> and dispose them only after releasing it: disposal
+    /// cancels <see cref="Session.Lifetime"/>, and running cancellation callbacks — arbitrary code
+    /// registered against that token — while still holding the gate that serialises every session
+    /// creation would let that code call back into this store and deadlock, or simply hold up every
+    /// other creation for as long as the callback takes.</remarks>
+    /// <param name="sessionId">The session handle.</param>
+    /// <returns>The removed session, or <see langword="null"/> when it was already gone.</returns>
+    private Session? RemoveFromMaps(string sessionId)
     {
         if (!_bySessionId.TryRemove(sessionId, out var session))
         {
-            return;
+            return null;
         }
 
         _byReturnToken.TryRemove(session.ReturnToken, out _);
-        session.Dispose();
+        return session;
     }
 
     /// <summary>Disposes every session whose expiry has passed. Returns how many were removed.</summary>
@@ -145,11 +156,12 @@ internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider
     }
 
     /// <summary>Creates a session for <paramref name="clientIp"/>, or explains why it could not.
-    /// A session from the same address that is still in <see cref="SessionState.Created"/> is
-    /// evicted rather than blocking: a visitor who closed the tab and started over must not be
-    /// locked out by their own abandoned attempt. An address holding a session past
-    /// <see cref="SessionState.Created"/> is refused instead — real upstream work exists there,
-    /// and that session is resumable via its handle.</summary>
+    /// A session from the same address that is still in <see cref="SessionState.Created"/> or
+    /// already <see cref="SessionState.Failed"/> is evicted rather than blocking: nothing in either
+    /// is resumable — the former never touched upstream, the latter is terminal — so a visitor who
+    /// closed the tab, or whose flow simply failed, must not be locked out by their own abandoned or
+    /// dead attempt. An address holding a session in any other state is refused instead — real,
+    /// resumable upstream work exists there, reachable via that session's handle.</summary>
     /// <param name="clientIp">The caller's address.</param>
     /// <param name="session">The new session on success.</param>
     /// <param name="failure">Why creation was refused.</param>
@@ -159,49 +171,71 @@ internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider
         out SessionCreateFailure failure)
     {
         session = null;
+        List<Session>? evicted = null;
 
-        lock (_createGate)
+        try
         {
-            if (CountCompletionsUnderGate(clientIp) >= options.MaxCompletionsPerIpPerHour)
+            lock (_createGate)
             {
-                failure = SessionCreateFailure.HourlyLimit;
-                return false;
-            }
-
-            foreach (var (sessionId, existing) in _bySessionId)
-            {
-                if (!string.Equals(existing.ClientIp, clientIp, StringComparison.Ordinal))
+                if (CountCompletionsUnderGate(clientIp) >= options.MaxCompletionsPerIpPerHour)
                 {
-                    continue;
-                }
-
-                if (existing.State != SessionState.Created)
-                {
-                    failure = SessionCreateFailure.ActiveSessionForIp;
+                    failure = SessionCreateFailure.HourlyLimit;
                     return false;
                 }
 
-                Remove(sessionId);
-            }
+                foreach (var (sessionId, existing) in _bySessionId)
+                {
+                    if (!string.Equals(existing.ClientIp, clientIp, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
 
-            if (_bySessionId.Count >= options.MaxConcurrentSessions)
+                    if (existing.State != SessionState.Created && existing.State != SessionState.Failed)
+                    {
+                        failure = SessionCreateFailure.ActiveSessionForIp;
+                        return false;
+                    }
+
+                    // Removed from the maps now, but ownership passes to `evicted`: disposal is
+                    // deliberately deferred to the `finally` below, after the gate is released —
+                    // see the remarks on RemoveFromMaps. CA2000 cannot see that far.
+#pragma warning disable CA2000
+                    if (RemoveFromMaps(sessionId) is { } victim)
+                    {
+                        (evicted ??= []).Add(victim);
+                    }
+#pragma warning restore CA2000
+                }
+
+                if (_bySessionId.Count >= options.MaxConcurrentSessions)
+                {
+                    failure = SessionCreateFailure.GlobalLimit;
+                    return false;
+                }
+
+                var created = new Session(
+                    SessionIds.New(),
+                    SessionIds.New(),
+                    clientIp,
+                    timeProvider.GetUtcNow().Add(options.CreatedTtl));
+
+                _bySessionId[created.SessionId] = created;
+                _byReturnToken[created.ReturnToken] = created.SessionId;
+
+                session = created;
+                failure = SessionCreateFailure.None;
+                return true;
+            }
+        }
+        finally
+        {
+            if (evicted is not null)
             {
-                failure = SessionCreateFailure.GlobalLimit;
-                return false;
+                foreach (var victim in evicted)
+                {
+                    victim.Dispose();
+                }
             }
-
-            var created = new Session(
-                SessionIds.New(),
-                SessionIds.New(),
-                clientIp,
-                timeProvider.GetUtcNow().Add(options.CreatedTtl));
-
-            _bySessionId[created.SessionId] = created;
-            _byReturnToken[created.ReturnToken] = created.SessionId;
-
-            session = created;
-            failure = SessionCreateFailure.None;
-            return true;
         }
     }
 

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionSweeper.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionSweeper.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Hosting;
+
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>Disposes sessions past their TTL, which is what actually bounds how long an MCS socket
+/// and a set of credentials can live in memory.</summary>
+/// <param name="store">The registry to sweep.</param>
+/// <param name="timeProvider">Clock, injected so the interval is testable.</param>
+internal sealed class SessionSweeper(SessionStore store, TimeProvider timeProvider) : BackgroundService
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(30);
+
+    /// <inheritdoc/>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(Interval, timeProvider);
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                store.SweepExpired();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown.
+        }
+    }
+}

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionSweeper.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionSweeper.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace RustPlusApi.CredentialsWeb.Sessions;
 
@@ -6,7 +7,9 @@ namespace RustPlusApi.CredentialsWeb.Sessions;
 /// and a set of credentials can live in memory.</summary>
 /// <param name="store">The registry to sweep.</param>
 /// <param name="timeProvider">Clock, injected so the interval is testable.</param>
-internal sealed class SessionSweeper(SessionStore store, TimeProvider timeProvider) : BackgroundService
+/// <param name="logger">For logging sweep failures without losing the exception and retrying on the next tick.</param>
+internal sealed class SessionSweeper(SessionStore store, TimeProvider timeProvider, ILogger<SessionSweeper> logger)
+    : BackgroundService
 {
     private static readonly TimeSpan Interval = TimeSpan.FromSeconds(30);
 
@@ -19,7 +22,14 @@ internal sealed class SessionSweeper(SessionStore store, TimeProvider timeProvid
         {
             while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
             {
-                store.SweepExpired();
+                try
+                {
+                    store.SweepExpired();
+                }
+                catch (Exception ex)
+                {
+                    logger.LogSweepFailed(ex);
+                }
             }
         }
         catch (OperationCanceledException)

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/SessionSweeperLog.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/SessionSweeperLog.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Logging;
+
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>Source-generated, structured log messages for <see cref="SessionSweeper"/>. Generated
+/// bodies carry <c>[GeneratedCode]</c> and are excluded from the coverage gate automatically.</summary>
+internal static partial class SessionSweeperLog
+{
+    [LoggerMessage(Level = LogLevel.Error, Message = "Sweep failed; the next tick will retry.")]
+    public static partial void LogSweepFailed(this ILogger logger, Exception exception);
+}

--- a/apps/RustPlusApi.CredentialsWeb/Upstream/IRegistrationSteps.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Upstream/IRegistrationSteps.cs
@@ -1,0 +1,24 @@
+using RustPlusApi.Fcm.Data;
+using RustPlusApi.Fcm.Registration;
+
+namespace RustPlusApi.CredentialsWeb.Upstream;
+
+/// <summary>The app's seam over the four live-network classes in RustPlusApi.Fcm.Registration, so the
+/// flow can be tested without reaching Google, Expo or Facepunch.</summary>
+internal interface IRegistrationSteps
+{
+    /// <summary>Steps 1-3: GCM check-in, Firebase install, FCM register, Expo token.</summary>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    Task<Credentials> AcquireDeviceCredentialsAsync(CancellationToken cancellationToken);
+
+    /// <summary>Step 5: register the device's Expo token with Rust Companion.</summary>
+    /// <param name="steamToken">The Steam auth token from the Facepunch callback.</param>
+    /// <param name="expoPushToken">The Expo token from <see cref="AcquireDeviceCredentialsAsync"/>.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    Task RegisterWithCompanionAsync(string steamToken, string expoPushToken, CancellationToken cancellationToken);
+
+    /// <summary>Step 6: hold an MCS socket until an in-game pairing push arrives.</summary>
+    /// <param name="credentials">Credentials from <see cref="AcquireDeviceCredentialsAsync"/>.</param>
+    /// <param name="cancellationToken">Token to cancel the wait.</param>
+    Task<ServerPairing> WaitForPairingAsync(Credentials credentials, CancellationToken cancellationToken);
+}

--- a/apps/RustPlusApi.CredentialsWeb/Upstream/LiveRegistrationSteps.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Upstream/LiveRegistrationSteps.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Http;
+using RustPlusApi.Fcm.Data;
+using RustPlusApi.Fcm.Registration;
+using RustPlusApi.Fcm.Registration.Steps;
+using System.Diagnostics.CodeAnalysis;
+
+namespace RustPlusApi.CredentialsWeb.Upstream;
+
+/// <summary>The real implementation, delegating to RustPlusApi.Fcm.Registration.</summary>
+/// <param name="httpClientFactory">Source of clients. A factory rather than a captured
+/// <see cref="HttpClient"/> because this type is a singleton, and a singleton-held client never
+/// picks up DNS changes.</param>
+/// <param name="loggerFactory">Passed to <see cref="PairingListener"/> so its skip paths are visible.</param>
+[ExcludeFromCodeCoverage(Justification =
+    "Live-network seam: every member drives Google, Expo, Facepunch or the MCS socket and cannot be "
+    + "validated offline. All logic above it is tested against IRegistrationSteps.")]
+internal sealed class LiveRegistrationSteps(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory)
+    : IRegistrationSteps
+{
+    /// <summary>Named client used for every upstream call.</summary>
+    internal const string HttpClientName = "upstream";
+
+    /// <inheritdoc/>
+    public async Task<Credentials> AcquireDeviceCredentialsAsync(CancellationToken cancellationToken)
+    {
+        var client = httpClientFactory.CreateClient(HttpClientName);
+        var (gcm, fcmToken) = await new AndroidFcmRegister(client)
+            .RegisterAsync(cancellationToken).ConfigureAwait(false);
+        var expoToken = await new ExpoPushClient(client)
+            .GetTokenAsync(fcmToken, cancellationToken).ConfigureAwait(false);
+
+        return new Credentials
+        {
+            Gcm = gcm,
+            Fcm = new FcmToken
+            {
+                Token = fcmToken
+            },
+            ExpoPushToken = expoToken
+        };
+    }
+
+    /// <inheritdoc/>
+    public Task RegisterWithCompanionAsync(
+        string steamToken,
+        string expoPushToken,
+        CancellationToken cancellationToken) =>
+        new RustCompanionClient(httpClientFactory.CreateClient(HttpClientName))
+            .RegisterAsync(steamToken, expoPushToken, cancellationToken: cancellationToken);
+
+    /// <inheritdoc/>
+    public async Task<ServerPairing> WaitForPairingAsync(
+        Credentials credentials,
+        CancellationToken cancellationToken)
+    {
+        using var listener = new PairingListener(
+            credentials,
+            loggerFactory: loggerFactory,
+            httpClient: httpClientFactory.CreateClient(HttpClientName));
+
+        return await listener.WaitForServerPairingAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/RustPlusApi.CredentialsWeb/docker-compose.yml
+++ b/apps/RustPlusApi.CredentialsWeb/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  credentials:
+    image: ghcr.io/handys11/rustplusapi-credentials:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:8080"
+    environment:
+      # Must be the externally reachable origin, with no trailing slash. This is the value
+      # Facepunch redirects back to, so it cannot be inferred from what Kestrel sees.
+      CredentialsWeb__PublicBaseUrl: "https://creds.example.org"
+      # Per-IP limits are silently void unless the proxy's address is trusted here: without it
+      # every visitor presents as the proxy and shares one bucket. Set this to the proxy's address
+      # on the container network, and never to a host you do not control. Leave it unset when the
+      # app is reached directly, so X-Forwarded-For from a caller is ignored.
+      CredentialsWeb__KnownProxies__0: "172.18.0.2"
+    # Enforces "nothing is written to disk" at the runtime level rather than by intent.
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL

--- a/apps/RustPlusApi.CredentialsWeb/wwwroot/app.css
+++ b/apps/RustPlusApi.CredentialsWeb/wwwroot/app.css
@@ -1,0 +1,83 @@
+:root {
+    color-scheme: light dark;
+    --bg: #fbfbfa;
+    --fg: #1d1c1a;
+    --muted: #5c5952;
+    --line: #d9d6cf;
+    --accent: #b4552d;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #171614;
+        --fg: #ecebe7;
+        --muted: #a19d94;
+        --line: #35322d;
+        --accent: #e07a4c;
+    }
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font: 16px/1.6 system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+main {
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 3rem 1.25rem 6rem;
+}
+
+h1 { font-size: 1.75rem; margin-bottom: 1.5rem; }
+h2 { font-size: 1.25rem; }
+h3 { font-size: 1rem; margin-top: 2rem; }
+
+section { border-top: 1px solid var(--line); padding-top: 1.5rem; margin-top: 1.5rem; }
+section:first-of-type { border-top: none; margin-top: 0; padding-top: 0; }
+
+details {
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    margin: 1.5rem 0;
+}
+
+summary { cursor: pointer; font-weight: 600; }
+details ul { margin: 0.75rem 0 0; padding-left: 1.1rem; color: var(--muted); }
+details li { margin-bottom: 0.5rem; }
+
+button {
+    font: inherit;
+    font-weight: 600;
+    color: #fff;
+    background: var(--accent);
+    border: none;
+    border-radius: 6px;
+    padding: 0.6rem 1.1rem;
+    cursor: pointer;
+}
+
+button:disabled { opacity: 0.5; cursor: default; }
+
+code, pre {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.9em;
+}
+
+pre {
+    background: color-mix(in srgb, var(--fg) 6%, transparent);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 0.9rem;
+    overflow-x: auto;
+}
+
+dl { display: grid; grid-template-columns: max-content 1fr; gap: 0.4rem 1.25rem; }
+dt { color: var(--muted); }
+dd { margin: 0; font-family: ui-monospace, Menlo, Consolas, monospace; word-break: break-all; }
+
+a { color: var(--accent); }

--- a/apps/RustPlusApi.CredentialsWeb/wwwroot/app.js
+++ b/apps/RustPlusApi.CredentialsWeb/wwwroot/app.js
@@ -1,0 +1,143 @@
+"use strict";
+
+const SESSION_KEY = "rustplus-credentials-session";
+
+const view = {
+    intro: document.getElementById("intro"),
+    progress: document.getElementById("progress"),
+    ready: document.getElementById("ready"),
+    waiting: document.getElementById("waiting"),
+    paired: document.getElementById("paired"),
+    failed: document.getElementById("failed")
+};
+
+let sessionId = null;
+let configJson = null;
+
+function show(name) {
+    for (const [key, element] of Object.entries(view)) {
+        element.hidden = key !== name;
+    }
+}
+
+function fail(message) {
+    document.getElementById("error").textContent = message;
+    show("failed");
+}
+
+function readSessionId() {
+    const match = /^#session=([0-9a-f]{32})$/.exec(location.hash);
+    if (match) {
+        // Drop the fragment so a shared or bookmarked URL does not carry the session handle.
+        history.replaceState({}, "", location.pathname);
+        sessionStorage.setItem(SESSION_KEY, match[1]);
+        return match[1];
+    }
+    return sessionStorage.getItem(SESSION_KEY);
+}
+
+function download(name, text) {
+    const url = URL.createObjectURL(new Blob([text], { type: "application/json" }));
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = name;
+    link.click();
+    URL.revokeObjectURL(url);
+}
+
+function onStep(payload) {
+    if (payload.state === "AwaitingPairing") {
+        show("waiting");
+    } else if (payload.state === "Registering" || payload.state === "Authenticated") {
+        show("progress");
+    }
+}
+
+function onCredentials(payload) {
+    configJson = payload.configJson;
+    document.getElementById("steam-id").textContent = payload.steamId;
+    show("ready");
+}
+
+function onPaired(payload) {
+    document.getElementById("server-name").textContent = payload.name ?? "(unnamed)";
+    document.getElementById("pair-ip").textContent = payload.ip;
+    document.getElementById("pair-port").textContent = payload.port;
+    document.getElementById("pair-player-id").textContent = payload.playerId;
+    document.getElementById("pair-player-token").textContent = payload.playerToken;
+    document.getElementById("snippet").textContent =
+        "new RustPlus(new RustPlusConnection(\"" + payload.ip + "\", " + payload.port +
+        ", " + payload.playerId + ", " + payload.playerToken + "));";
+    show("paired");
+}
+
+function listen(id) {
+    const source = new EventSource("/api/sessions/" + id + "/events");
+
+    source.addEventListener("step", e => onStep(JSON.parse(e.data)));
+    source.addEventListener("credentials", e => onCredentials(JSON.parse(e.data)));
+    source.addEventListener("paired", e => { onPaired(JSON.parse(e.data)); source.close(); });
+    source.addEventListener("error", e => {
+        // A named "error" event carries our payload; a transport error has no data and
+        // EventSource reconnects on its own, so it is not surfaced.
+        if (e.data) {
+            fail(JSON.parse(e.data).message);
+            source.close();
+        }
+    });
+    source.addEventListener("expired", () => {
+        // Not a failure: the session is back in Ready, so the stream stays open and the visitor
+        // can start another wait without repeating the Steam login.
+        document.getElementById("pair").disabled = false;
+        document.getElementById("pair-note").textContent =
+            "No pairing arrived in time. Your credentials are still valid — try again when you're in game.";
+        show("ready");
+    });
+}
+
+async function start() {
+    const button = document.getElementById("start");
+    button.disabled = true;
+
+    const response = await fetch("/api/sessions", { method: "POST" });
+    if (!response.ok) {
+        const body = await response.json().catch(() => ({ message: "This instance is busy." }));
+        fail(body.message);
+        return;
+    }
+
+    const body = await response.json();
+    sessionStorage.setItem(SESSION_KEY, body.sessionId);
+    location.href = body.loginUrl;
+}
+
+async function pair() {
+    const button = document.getElementById("pair");
+    button.disabled = true;
+
+    const response = await fetch("/api/sessions/" + sessionId + "/pairing", { method: "POST" });
+    if (!response.ok) {
+        const body = await response.json().catch(() => ({ message: "Could not start the pairing wait." }));
+        fail(body.message);
+        button.disabled = false;
+    }
+}
+
+document.getElementById("start").addEventListener("click", start);
+document.getElementById("pair").addEventListener("click", pair);
+document.getElementById("download").addEventListener("click",
+    () => download("rustplus.config.json", configJson));
+document.getElementById("download-paired").addEventListener("click",
+    () => download("rustplus.config.json", configJson));
+document.getElementById("restart").addEventListener("click", () => {
+    sessionStorage.removeItem(SESSION_KEY);
+    location.href = "/";
+});
+
+sessionId = readSessionId();
+if (sessionId) {
+    show("progress");
+    listen(sessionId);
+} else {
+    show("intro");
+}

--- a/apps/RustPlusApi.CredentialsWeb/wwwroot/app.js
+++ b/apps/RustPlusApi.CredentialsWeb/wwwroot/app.js
@@ -83,6 +83,13 @@ function listen(id) {
         if (e.data) {
             fail(JSON.parse(e.data).message);
             source.close();
+        } else if (source.readyState === EventSource.CLOSED) {
+            // A non-2xx response (e.g. a 404 for an unknown or swept session) makes the browser
+            // fail the connection permanently rather than retry, leaving readyState CLOSED. A
+            // transient network blip leaves it CONNECTING and the browser retries on its own, so
+            // only CLOSED means the session is actually gone.
+            sessionStorage.removeItem(SESSION_KEY);
+            fail("This session has expired. Start over — nothing was saved.");
         }
     });
     source.addEventListener("expired", () => {

--- a/apps/RustPlusApi.CredentialsWeb/wwwroot/index.html
+++ b/apps/RustPlusApi.CredentialsWeb/wwwroot/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Rust+ credentials</title>
+    <link rel="stylesheet" href="app.css">
+</head>
+<body>
+<main>
+    <h1>Get your Rust+ credentials</h1>
+
+    <section id="intro">
+        <p>
+            Sign in through Steam, then pair in game. You end up with the four values a Rust+ client
+            needs, and a <code>rustplus.config.json</code> you can download.
+        </p>
+        <details open>
+            <summary>What this server sees, and what it keeps</summary>
+            <ul>
+                <li>Your Steam auth token reaches this server, because Facepunch sends it here as a
+                    query parameter and nothing can change that. It is dropped the moment your device
+                    is registered.</li>
+                <li>Nothing is written to disk or to a database. Everything lives in memory and is
+                    discarded when your session ends or the process restarts.</li>
+                <li>No credential is written to any log. The web server's request logging is turned
+                    off precisely because it would record that query parameter.</li>
+                <li>Your <code>playerToken</code> is full access to your Rust+ account. Treat it like
+                    a password and don't paste it anywhere public.</li>
+                <li>Prefer not to trust someone else's server? <a href="https://github.com/HandyS11/RustPlusApi">Run your own.</a></li>
+            </ul>
+        </details>
+        <button id="start" type="button">Sign in with Steam</button>
+    </section>
+
+    <section id="progress" hidden>
+        <h2>Working…</h2>
+        <p id="status">Registering a device with Google and Rust Companion.</p>
+    </section>
+
+    <section id="ready" hidden>
+        <h2>Credentials ready</h2>
+        <p>Signed in as <code id="steam-id"></code>.</p>
+        <button id="download" type="button">Download rustplus.config.json</button>
+        <h3>Optional: get your pairing values</h3>
+        <p>
+            To get <code>ip</code>, <code>port</code>, <code>playerId</code> and
+            <code>playerToken</code>, this server has to hold a connection open to Google while you
+            pair in game. Start it only when you're ready to alt-tab into Rust.
+        </p>
+        <button id="pair" type="button">Wait for my pairing</button>
+        <p id="pair-note"></p>
+    </section>
+
+    <section id="waiting" hidden>
+        <h2>Waiting for your pairing</h2>
+        <p>Open Rust, join a server, and choose <strong>Pair with Server</strong>.</p>
+    </section>
+
+    <section id="paired" hidden>
+        <h2>Paired</h2>
+        <dl>
+            <dt>Server</dt><dd id="server-name"></dd>
+            <dt>IP</dt><dd id="pair-ip"></dd>
+            <dt>Port</dt><dd id="pair-port"></dd>
+            <dt>Player ID</dt><dd id="pair-player-id"></dd>
+            <dt>Player token</dt><dd id="pair-player-token"></dd>
+        </dl>
+        <pre id="snippet"></pre>
+        <button id="download-paired" type="button">Download rustplus.config.json</button>
+    </section>
+
+    <section id="failed" hidden>
+        <h2>Something went wrong</h2>
+        <p id="error"></p>
+        <button id="restart" type="button">Start over</button>
+    </section>
+</main>
+<script src="app.js"></script>
+</body>
+</html>

--- a/docs/articles/credentials.md
+++ b/docs/articles/credentials.md
@@ -10,6 +10,29 @@ To use Rust+ you need credentials. There are two kinds:
 The `RustPlusApi.Fcm.Registration` package acquires both natively, replacing the
 `rustplus.js` Node CLI.
 
+## The credentials website (recommended)
+
+The fastest way to get both kinds of credentials — no .NET SDK required — is the
+[Rust+ credentials website](https://github.com/HandyS11/RustPlusApi/blob/develop/apps/RustPlusApi.CredentialsWeb/README.md):
+a single-page app that walks you through the Steam login in a browser and hands back the four
+pairing values plus a downloadable `rustplus.config.json`. It is both a self-host starter and the
+code behind the public instance. Self-host it with:
+
+```bash
+docker run -p 8080:8080 \
+  -e CredentialsWeb__PublicBaseUrl=https://creds.example.org \
+  ghcr.io/handys11/rustplusapi-credentials
+```
+
+See the
+[website's README](https://github.com/HandyS11/RustPlusApi/blob/develop/apps/RustPlusApi.CredentialsWeb/README.md)
+for the full self-host guide — including two reverse-proxy footguns worth reading before you put
+anything in front of it.
+
+Everything below documents the same registration chain driven directly from your own code — what
+the website's server does under the hood, and the route to use if you're integrating
+`RustPlusApi.Fcm.Registration` into your own app (the local route) rather than running the website.
+
 ## The flow
 
 ```mermaid
@@ -27,8 +50,8 @@ sequenceDiagram
     G-->>App: FCM token
     App->>E: 4. Expo push token
     E-->>App: ExponentPushToken[...]
-    App->>St: 5. Interactive Steam login (browser redirect)
-    St-->>App: Steam auth token + Steam64 id
+    App->>St: 5. Interactive Steam login (browser redirect to App's own /callback/<nonce>)
+    St-->>App: Steam auth token + Steam64 id, delivered at that callback
     App->>FP: 6. Register device with Rust Companion
     FP-->>App: subscribed to pairing pushes
     Note over App: 7. CredentialsStore.Save("rustplus.config.json")
@@ -75,6 +98,10 @@ ServerPairing pairing = await listener.WaitForServerPairingAsync();
 Steps 1–7 run once. Step 8 happens every time you pair a new server in game.
 
 ## How the Steam login works
+
+This section covers the local route — driving `SteamLoginService` yourself, as the console app
+does. The credentials website above uses the same mechanism, except the callback listener is the
+website's own `/callback/<nonce>` endpoint rather than a `localhost` `HttpListener`.
 
 `SteamLoginService` binds an `HttpListener` on `http://localhost:<port>/` and sends the browser to:
 

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -21,10 +21,15 @@ dotnet add package RustPlusApi.Fcm.Extensions.DependencyInjection   # DI registr
 
 ## 1. Get your credentials
 
-You need credentials to connect. The recommended way is the native
-[RustPlusApi.Fcm.Registration](credentials.md) package, which logs you into Steam and links your
-account with Rust+ — no Node.js required. The quickest path is the `RustPlus.Register.ConsoleApp`
-sample:
+You need credentials to connect. The quickest way — no .NET SDK required — is the
+[Rust+ credentials website](https://github.com/HandyS11/RustPlusApi/blob/develop/apps/RustPlusApi.CredentialsWeb/README.md):
+a browser flow that logs you into Steam and hands back the four pairing values plus a downloadable
+`rustplus.config.json`. Self-host it with `docker run` (see its README for the full command and
+two footguns to read before putting it behind a reverse proxy).
+
+If you'd rather stay entirely in .NET, the native [RustPlusApi.Fcm.Registration](credentials.md)
+package does the same thing from your own code — no Node.js required. The quickest path is the
+`RustPlus.Register.ConsoleApp` sample:
 
 ```bash
 dotnet run --project samples/RustPlus.Register.ConsoleApp

--- a/docs/articles/troubleshooting.md
+++ b/docs/articles/troubleshooting.md
@@ -101,6 +101,25 @@ npx @liamcottle/rustplus.js fcm-register
 
 See [Credentials — upstream fragility](credentials.md#upstream-fragility) for more context.
 
+## Credentials website
+
+Issues specific to the [Rust+ credentials website](https://github.com/HandyS11/RustPlusApi/blob/develop/apps/RustPlusApi.CredentialsWeb/README.md)
+rather than the library.
+
+**The callback returns 404.** The return token in the callback URL is single-use: once Facepunch
+has redirected the browser back and the site has consumed it, that exact URL will always 404 —
+refreshing the page, going back, or reopening a bookmarked callback link all hit an already-consumed
+token. Start the flow over from the beginning; there is no way to resume a used callback URL.
+
+**I get a 429.** The instance you're using is at capacity — either its global session/pairing caps
+are full, or you've completed more flows in the last hour than its per-IP limit allows. Wait a few
+minutes and try again, or self-host your own instance (`docker run`, see the website's README).
+
+**The pairing never arrives.** The wait for a pairing push is capped at the instance's `PairingTtl`
+(10 minutes by default). Make sure you press **Pair with Server** in game *while* the page still
+says it is waiting. Your credentials remain valid even if the wait times out, so retry just the
+pairing step rather than starting the whole flow — including the Steam login — over again.
+
 ## Entity events never fire
 
 **Symptom:** `OnSmartDeviceTriggered` or `OnStorageMonitorTriggered` never fires even when the

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -131,6 +131,17 @@ Two members are excluded from the app's coverage gate:
   — a live-network seam: every member drives Google, Expo, Facepunch or the MCS socket and cannot
   be validated offline. All logic above it is tested against the `IRegistrationSteps` abstraction.
 
+`SessionSweeper` (`apps/RustPlusApi.CredentialsWeb/Sessions/SessionSweeper.cs`) is **not** excluded,
+but its per-class figures in `tools/coverage/report.sh`'s gap list (currently ~75% line / 50%
+branch) are expected rather than a regression to chase. `ExecuteAsync`'s `catch (Exception ex)`
+around `store.SweepExpired()` is retained defensive coding — the right response if a future change
+to what `SessionStore.SweepExpired()`/`Session.Dispose()` can throw ever reintroduces a failure
+mode — but nothing reachable today throws there: `Session.Dispose()` was fixed to never throw (see
+`Session.Dispose`'s remarks), which was the only source of an exception on that path. The branch is
+therefore permanently unreachable through legitimate application behaviour, and inventing a
+contrived throw just to exercise it would test nothing real. The app's aggregate gate absorbs this
+without difficulty (headroom same as the libraries, above).
+
 ---
 
 ## Running mutation testing (Stryker.NET)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -110,6 +110,29 @@ don't trip the gate.
 
 ---
 
+## Credentials web app
+
+`apps/RustPlusApi.CredentialsWeb` targets `net10.0` only — it is an ASP.NET Core app, not a
+multi-targeted library — so it sits outside the multi-TFM parity mechanism described above and is
+exercised on a single TFM host rather than two.
+
+It is gated separately, at the same **95% line / 90% branch** bar as the libraries, via a second
+ReportGenerator merge that `tools/coverage/report.sh` produces and checks alongside the library one:
+`TestResults/merged-web/Cobertura.xml`, filtered to just `RustPlusApi.CredentialsWeb`. The library
+merge (`TestResults/merged/Cobertura.xml`) explicitly filters the app assembly *out*, so the
+library gate stays exactly what it was before the app existed — folding a net10.0-only app into
+that aggregate would change the bar the libraries have to clear.
+
+Two members are excluded from the app's coverage gate:
+
+- **`Program`** (`apps/RustPlusApi.CredentialsWeb/Program.cs`) — host wiring: composition only,
+  exercised end to end by the endpoint tests.
+- **`LiveRegistrationSteps`** (`apps/RustPlusApi.CredentialsWeb/Upstream/LiveRegistrationSteps.cs`)
+  — a live-network seam: every member drives Google, Expo, Facepunch or the MCS socket and cannot
+  be validated offline. All logic above it is tested against the `IRegistrationSteps` abstraction.
+
+---
+
 ## Running mutation testing (Stryker.NET)
 
 Each mutation-tested source project has its own `stryker-config.json` located in its corresponding

--- a/docs/superpowers/plans/2026-09-03-credential-acquisition-website.md
+++ b/docs/superpowers/plans/2026-09-03-credential-acquisition-website.md
@@ -1,0 +1,4924 @@
+# Credential-acquisition website Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A single-page web app that walks a visitor from nothing to working Rust+ credentials in a browser, deployable by anyone with one `docker run` and hostable as a public instance.
+
+**Architecture:** An ASP.NET Core minimal-API app in `apps/RustPlusApi.CredentialsWeb`, referencing `RustPlusApi.Fcm.Registration` and using only its existing public API. Per-visitor state lives in an in-memory `SessionStore` with hard TTLs; the browser gets progress over Server-Sent Events. The credential flow is reordered to `4 → 1,2,3 → 5` so a real Steam login gates all upstream work, with step 6 (the pairing wait, which holds a live MCS socket) offered as an opt-in continuation.
+
+**Tech Stack:** .NET 10, ASP.NET Core minimal API, Server-Sent Events, hand-written HTML/CSS/JS with no build step, xUnit, `WebApplicationFactory`, `FakeTimeProvider`, Docker.
+
+**Spec:** `docs/superpowers/specs/2026-09-03-credential-acquisition-website-design.md`
+
+## Global Constraints
+
+- **Target framework:** `net10.0` only. This project is deliberately outside the `netstandard2.0` multi-TFM parity story that governs `src/`. The test project also targets `net10.0` only.
+- **No library changes.** `src/**` must not be modified. The app uses only the existing public API: `SteamLoginService.BuildLoginUrl`, `SteamLoginService.ParseCallback`, `AndroidFcmRegister`, `ExpoPushClient`, `RustCompanionClient`, `PairingListener`, `CredentialsStore`.
+- **Build is strict.** `TreatWarningsAsErrors`, `AnalysisLevel=latest-all`, Roslynator + Sonar + VSTHRD analyzers, `GenerateDocumentationFile=true`. Because XML-doc warnings (CS1591) apply only to public members, **every type in this app is `internal`**, and the test project gets access via `InternalsVisibleTo`. Add XML doc comments to internal members anyway where intent is non-obvious — it matches the repo's style.
+- **Central package management.** Versions go in `Directory.Packages.props`; `PackageReference` elements carry no `Version` attribute.
+- **Formatting.** `dotnet jb cleanupcode RustPlusApi.sln --profile="ReformatAndReorder"` must produce no diff. A pre-push hook enforces this.
+- **Ids are 128-bit.** Both `sessionId` and `returnToken` come from `RandomNumberGenerator.GetBytes(16)` rendered as 32 lowercase hex characters.
+- **`ulong` values are serialized as JSON strings.** `steamId` and `playerId` exceed JavaScript's `Number.MAX_SAFE_INTEGER` (2^53). Emitting them as JSON numbers silently corrupts them in the browser.
+- **Secrets are never logged.** No log statement, exception message, or metric may contain a Steam token, an FCM/Expo credential, or a `playerToken`. Task 13 adds the test that enforces this.
+- **Time comes from `TimeProvider`.** Never `DateTimeOffset.UtcNow` directly — every TTL must be testable with `FakeTimeProvider`.
+- **Commit after every task.** Conventional Commits, matching repo history (`feat:`, `fix:`, `chore:`, `docs:`, `test:`).
+
+## File Structure
+
+```
+apps/RustPlusApi.CredentialsWeb/
+    RustPlusApi.CredentialsWeb.csproj
+    Program.cs                      Host wiring only. [ExcludeFromCodeCoverage].
+    AppOptions.cs                   Config record + pure validator.
+    Sessions/
+        SessionIds.cs               128-bit hex id generation.
+        SessionState.cs             The state enum.
+        SessionEvent.cs             One SSE event: type + payload.
+        SessionEventPayloads.cs     Typed payloads for step/credentials/paired/error.
+        SessionEventStream.cs       Replay history + multi-subscriber fan-out.
+        Session.cs                  One visitor's state and secrets.
+        SessionStore.cs             Create / lookup / consume / caps / TTL sweep.
+        SessionSweeper.cs           BackgroundService driving SessionStore.SweepExpired.
+    Upstream/
+        IRegistrationSteps.cs       Seam over the four live-network classes.
+        LiveRegistrationSteps.cs    Real implementation. [ExcludeFromCodeCoverage].
+    Flow/
+        CredentialFlow.cs           Orchestrates 4→1,2,3→5, and optionally 6.
+    Endpoints/
+        SessionEndpoints.cs         POST /api/sessions, POST /api/sessions/{id}/pairing
+        CallbackEndpoints.cs        GET /callback/{returnToken}
+        EventEndpoints.cs           GET /api/sessions/{id}/events (SSE)
+    Security/
+        SecurityHeaders.cs          CSP, Referrer-Policy, no-store, nosniff.
+    wwwroot/
+        index.html                  The page.
+        app.js                      Flow driver + SSE client.
+        app.css                     Styles.
+    Dockerfile
+    docker-compose.yml              Copyable documentation, not a second install path.
+    Caddyfile.example               Ditto — shows the safe log format.
+    README.md                       Self-host guide.
+tests/RustPlusApi.CredentialsWeb.UnitTests/
+    RustPlusApi.CredentialsWeb.UnitTests.csproj
+    AssemblyInfo.cs                 Serializes the assembly (the factory uses global env vars).
+    AppOptionsValidatorTests.cs
+    SessionEventStreamTests.cs
+    SessionTests.cs
+    SessionStoreTests.cs
+    SessionStoreCapsTests.cs
+    SessionSweeperTests.cs
+    CredentialFlowTests.cs
+    CredentialFlowPairingTests.cs
+    FakeRegistrationSteps.cs        Shared test double for IRegistrationSteps.
+    CredentialsWebFactory.cs        WebApplicationFactory harness + log capture.
+    SessionEndpointTests.cs
+    CallbackEndpointTests.cs
+    EventEndpointTests.cs
+    PairingEndpointTests.cs
+    SecretsAreNeverLoggedTests.cs
+```
+
+---
+
+### Task 1: Project scaffolding and startup validation
+
+Creates both projects, wires them into the solution, and lands the one piece of startup logic that has a testable contract: the app must refuse to run with a non-`https` public base URL.
+
+**Files:**
+- Create: `apps/RustPlusApi.CredentialsWeb/RustPlusApi.CredentialsWeb.csproj`
+- Create: `apps/RustPlusApi.CredentialsWeb/AppOptions.cs`
+- Create: `apps/RustPlusApi.CredentialsWeb/Program.cs`
+- Create: `tests/RustPlusApi.CredentialsWeb.UnitTests/RustPlusApi.CredentialsWeb.UnitTests.csproj`
+- Create: `tests/RustPlusApi.CredentialsWeb.UnitTests/AppOptionsValidatorTests.cs`
+- Modify: `Directory.Packages.props`
+- Modify: `RustPlusApi.sln`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `internal sealed class AppOptions` with `SectionName`, `PublicBaseUrl`, `AllowInsecureBaseUrl`, `KnownProxies`, `MaxConcurrentSessions`, `MaxConcurrentPairings`, `MaxCompletionsPerIpPerHour`, `CreatedTtl`, `SessionTtl`, `PairingTtl`; and `internal static class AppOptionsValidator` with `internal static string? Validate(AppOptions options)` returning `null` when valid or a human-readable error otherwise.
+
+- [ ] **Step 1: Add the new package versions**
+
+In `Directory.Packages.props`, add to the `<!-- Test stack -->` `ItemGroup`:
+
+```xml
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
+```
+
+- [ ] **Step 2: Create the app project file**
+
+`apps/RustPlusApi.CredentialsWeb/RustPlusApi.CredentialsWeb.csproj`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <!-- The app is net10.0-only and deliberately outside the netstandard2.0 parity story
+             that governs src/. See docs/superpowers/specs/2026-09-03-credential-acquisition-website-design.md -->
+        <UserSecretsId>rustplusapi-credentialsweb</UserSecretsId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\RustPlusApi.Fcm.Registration\RustPlusApi.Fcm.Registration.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="RustPlusApi.CredentialsWeb.UnitTests" />
+    </ItemGroup>
+
+</Project>
+```
+
+- [ ] **Step 3: Create the test project file**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/RustPlusApi.CredentialsWeb.UnitTests.csproj`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <!-- net10.0 only: the app under test is net10.0 only, so there is no
+             netstandard2.0 build to validate for parity. -->
+        <TargetFramework>net10.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\apps\RustPlusApi.CredentialsWeb\RustPlusApi.CredentialsWeb.csproj" />
+    </ItemGroup>
+
+</Project>
+```
+
+- [ ] **Step 4: Add both projects to the solution**
+
+```bash
+dotnet sln RustPlusApi.sln add apps/RustPlusApi.CredentialsWeb/RustPlusApi.CredentialsWeb.csproj
+dotnet sln RustPlusApi.sln add tests/RustPlusApi.CredentialsWeb.UnitTests/RustPlusApi.CredentialsWeb.UnitTests.csproj
+```
+
+- [ ] **Step 5: Write the failing tests**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/AppOptionsValidatorTests.cs`:
+
+```csharp
+using RustPlusApi.CredentialsWeb;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class AppOptionsValidatorTests
+{
+    private static AppOptions Valid() => new() { PublicBaseUrl = "https://creds.example.org" };
+
+    [Fact]
+    public void Validate_ReturnsNull_ForHttpsBaseUrl()
+    {
+        Assert.Null(AppOptionsValidator.Validate(Valid()));
+    }
+
+    [Fact]
+    public void Validate_Rejects_BlankBaseUrl()
+    {
+        var options = Valid();
+        options.PublicBaseUrl = "   ";
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("PublicBaseUrl", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_Rejects_HttpBaseUrl()
+    {
+        var options = Valid();
+        options.PublicBaseUrl = "http://creds.example.org";
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("AllowInsecureBaseUrl", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_Allows_HttpBaseUrl_WhenEscapeHatchSet()
+    {
+        var options = Valid();
+        options.PublicBaseUrl = "http://localhost:8080";
+        options.AllowInsecureBaseUrl = true;
+
+        Assert.Null(AppOptionsValidator.Validate(options));
+    }
+
+    [Fact]
+    public void Validate_Rejects_BaseUrlWithTrailingSlash()
+    {
+        var options = Valid();
+        options.PublicBaseUrl = "https://creds.example.org/";
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("trailing", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_Rejects_NonAbsoluteBaseUrl()
+    {
+        var options = Valid();
+        options.PublicBaseUrl = "creds.example.org";
+
+        Assert.NotNull(AppOptionsValidator.Validate(options));
+    }
+
+    [Fact]
+    public void Validate_Rejects_AKnownProxyThatIsNotAnIpAddress()
+    {
+        var options = Valid();
+        options.KnownProxies.Add("proxy.example.org");
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("KnownProxies", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_Accepts_AKnownProxyIpAddress()
+    {
+        var options = Valid();
+        options.KnownProxies.Add("172.18.0.2");
+
+        Assert.Null(AppOptionsValidator.Validate(options));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_Rejects_NonPositiveSessionLimit(int limit)
+    {
+        var options = Valid();
+        options.MaxConcurrentSessions = limit;
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("MaxConcurrentSessions", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_Rejects_NonPositiveTtl()
+    {
+        var options = Valid();
+        options.SessionTtl = TimeSpan.Zero;
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("SessionTtl", error, StringComparison.Ordinal);
+    }
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they fail**
+
+Run: `dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~AppOptionsValidatorTests"`
+Expected: FAIL — `AppOptions` and `AppOptionsValidator` do not exist (CS0246).
+
+- [ ] **Step 7: Write AppOptions and the validator**
+
+`apps/RustPlusApi.CredentialsWeb/AppOptions.cs`:
+
+```csharp
+using System.Net;
+
+namespace RustPlusApi.CredentialsWeb;
+
+/// <summary>Every knob the app exposes. Bound from the "CredentialsWeb" configuration section.</summary>
+internal sealed class AppOptions
+{
+    /// <summary>Configuration section these options bind from.</summary>
+    internal const string SectionName = "CredentialsWeb";
+
+    /// <summary>The externally reachable origin, with no trailing slash. Required: behind a reverse
+    /// proxy this is not what Kestrel sees, and the Facepunch returnUrl must be the external one.</summary>
+    internal string PublicBaseUrl { get; set; } = string.Empty;
+
+    /// <summary>Development escape hatch permitting a non-https <see cref="PublicBaseUrl"/>.</summary>
+    internal bool AllowInsecureBaseUrl { get; set; }
+
+    /// <summary>Addresses of reverse proxies whose <c>X-Forwarded-For</c> is trusted. Empty means
+    /// forwarded headers are ignored, which is the safe default: trusting them from anyone lets a
+    /// caller spoof their address past every per-IP cap.</summary>
+    internal IList<string> KnownProxies { get; } = [];
+
+    /// <summary>Global cap on live sessions in any state.</summary>
+    internal int MaxConcurrentSessions { get; set; } = 200;
+
+    /// <summary>Global cap on concurrent MCS sockets — the genuinely scarce resource.</summary>
+    internal int MaxConcurrentPairings { get; set; } = 50;
+
+    /// <summary>Per-IP cap on completed flows in a rolling hour. Bounds Google device registrations.</summary>
+    internal int MaxCompletionsPerIpPerHour { get; set; } = 5;
+
+    /// <summary>Lifetime of a session that has not yet completed the Steam login. Shortest leash:
+    /// this is the cheapest state to create and therefore the cheapest to spam.</summary>
+    internal TimeSpan CreatedTtl { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>Lifetime of a session once the Steam login has completed.</summary>
+    internal TimeSpan SessionTtl { get; set; } = TimeSpan.FromMinutes(15);
+
+    /// <summary>Maximum time an MCS socket is held waiting for a pairing push.</summary>
+    internal TimeSpan PairingTtl { get; set; } = TimeSpan.FromMinutes(10);
+}
+
+/// <summary>Pure validation for <see cref="AppOptions"/>, kept separate from host wiring so it is
+/// unit-testable without building a web host.</summary>
+internal static class AppOptionsValidator
+{
+    /// <summary>Returns <see langword="null"/> when the options are usable, or a message naming the
+    /// offending setting.</summary>
+    internal static string? Validate(AppOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.PublicBaseUrl))
+        {
+            return $"{AppOptions.SectionName}:PublicBaseUrl is required. Set it to the externally "
+                + "reachable origin of this instance, for example https://creds.example.org.";
+        }
+
+        if (!Uri.TryCreate(options.PublicBaseUrl, UriKind.Absolute, out var baseUri))
+        {
+            return $"{AppOptions.SectionName}:PublicBaseUrl must be an absolute URL, "
+                + $"but was '{options.PublicBaseUrl}'.";
+        }
+
+        if (options.PublicBaseUrl.EndsWith('/'))
+        {
+            return $"{AppOptions.SectionName}:PublicBaseUrl must not have a trailing slash.";
+        }
+
+        if (!baseUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.Ordinal)
+            && !options.AllowInsecureBaseUrl)
+        {
+            return $"{AppOptions.SectionName}:PublicBaseUrl must use https, because it carries the "
+                + "Steam auth token back from Facepunch. Set "
+                + $"{AppOptions.SectionName}:AllowInsecureBaseUrl=true only for local development.";
+        }
+
+        foreach (var proxy in options.KnownProxies)
+        {
+            if (!IPAddress.TryParse(proxy, out _))
+            {
+                return $"{AppOptions.SectionName}:KnownProxies contains '{proxy}', which is not an "
+                    + "IP address.";
+            }
+        }
+
+        if (options.MaxConcurrentSessions <= 0)
+        {
+            return $"{AppOptions.SectionName}:MaxConcurrentSessions must be greater than zero.";
+        }
+
+        if (options.MaxConcurrentPairings <= 0)
+        {
+            return $"{AppOptions.SectionName}:MaxConcurrentPairings must be greater than zero.";
+        }
+
+        if (options.MaxCompletionsPerIpPerHour <= 0)
+        {
+            return $"{AppOptions.SectionName}:MaxCompletionsPerIpPerHour must be greater than zero.";
+        }
+
+        if (options.CreatedTtl <= TimeSpan.Zero)
+        {
+            return $"{AppOptions.SectionName}:CreatedTtl must be greater than zero.";
+        }
+
+        if (options.SessionTtl <= TimeSpan.Zero)
+        {
+            return $"{AppOptions.SectionName}:SessionTtl must be greater than zero.";
+        }
+
+        return options.PairingTtl <= TimeSpan.Zero
+            ? $"{AppOptions.SectionName}:PairingTtl must be greater than zero."
+            : null;
+    }
+}
+```
+
+- [ ] **Step 8: Write the minimal Program.cs**
+
+Endpoints and services arrive in later tasks. `Program` is `[ExcludeFromCodeCoverage]` wiring; the `public partial class Program` declaration at the bottom is what `WebApplicationFactory<Program>` needs in Task 13.
+
+`apps/RustPlusApi.CredentialsWeb/Program.cs`:
+
+```csharp
+using RustPlusApi.CredentialsWeb;
+using System.Diagnostics.CodeAnalysis;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// ASP.NET Core's hosting diagnostics log the full request line — path AND query — at Information.
+// The Facepunch callback carries the Steam auth token in its query string, so that logger is
+// silenced outright rather than filtered per-path: the "Request starting" entry is written before
+// any middleware of ours could redact it. Enforced by SecretsAreNeverLoggedTests.
+builder.Logging.AddFilter("Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Warning);
+
+var options = new AppOptions();
+builder.Configuration.GetSection(AppOptions.SectionName).Bind(options);
+
+var validationError = AppOptionsValidator.Validate(options);
+if (validationError is not null)
+{
+    Console.Error.WriteLine($"Configuration error: {validationError}");
+    return 1;
+}
+
+builder.Services.AddSingleton(options);
+builder.Services.AddSingleton(TimeProvider.System);
+
+var app = builder.Build();
+
+app.UseDefaultFiles();
+app.UseStaticFiles();
+
+await app.RunAsync();
+return 0;
+
+/// <summary>Entry point marker so <c>WebApplicationFactory&lt;Program&gt;</c> can boot the app in tests.</summary>
+[ExcludeFromCodeCoverage(Justification = "Host wiring: composition only, exercised end to end by the endpoint tests.")]
+public partial class Program;
+```
+
+- [ ] **Step 9: Run the tests to verify they pass**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~AppOptionsValidatorTests"`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 10: Verify the strict build is clean**
+
+Run: `dtk dotnet build RustPlusApi.sln`
+Expected: no warnings, no errors. If `Bind` is unresolved, add `using Microsoft.Extensions.Configuration;`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add Directory.Packages.props RustPlusApi.sln apps/ tests/RustPlusApi.CredentialsWeb.UnitTests/
+git commit -m "feat(web): scaffold credentials web app with validated startup options"
+```
+
+---
+
+### Task 2: Session event stream
+
+The SSE plumbing, built first because everything downstream publishes into it. Two requirements make it more than a `Channel`: a reconnecting client must receive events it missed, and the Steam login may complete in a different browser from the one holding the stream, so there can be more than one subscriber.
+
+**Files:**
+- Create: `apps/RustPlusApi.CredentialsWeb/Sessions/SessionEvent.cs`
+- Create: `apps/RustPlusApi.CredentialsWeb/Sessions/SessionEventPayloads.cs`
+- Create: `apps/RustPlusApi.CredentialsWeb/Sessions/SessionEventStream.cs`
+- Test: `tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEventStreamTests.cs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `internal sealed record SessionEvent(string Type, object? Data)`; the payload records `StepPayload(string State)`, `CredentialsPayload(string SteamId, string ConfigJson)`, `PairedPayload(string Ip, int Port, string PlayerId, int PlayerToken, string? Name)` and `ErrorPayload(string Message)`; `internal sealed class SessionEventStream` with `internal void Publish(SessionEvent sessionEvent)`, `internal void Complete()`, and `internal IAsyncEnumerable<SessionEvent> SubscribeAsync(CancellationToken cancellationToken)`. A new subscriber receives every event published so far, in order, before any live one. `Publish` after `Complete` is a no-op.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEventStreamTests.cs`:
+
+```csharp
+using RustPlusApi.CredentialsWeb.Sessions;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SessionEventStreamTests
+{
+    private static async Task<List<SessionEvent>> DrainAsync(SessionEventStream stream, int expected)
+    {
+        var received = new List<SessionEvent>();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await foreach (var item in stream.SubscribeAsync(timeout.Token))
+        {
+            received.Add(item);
+            if (received.Count == expected)
+            {
+                break;
+            }
+        }
+
+        return received;
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_ReplaysEventsPublishedBeforeSubscription()
+    {
+        var stream = new SessionEventStream();
+        stream.Publish(new SessionEvent("step", new StepPayload("Registering")));
+        stream.Publish(new SessionEvent("step", new StepPayload("Ready")));
+
+        var received = await DrainAsync(stream, 2);
+
+        Assert.Equal(2, received.Count);
+        Assert.All(received, e => Assert.Equal("step", e.Type));
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_DeliversEventsPublishedAfterSubscription()
+    {
+        var stream = new SessionEventStream();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var enumerator = stream.SubscribeAsync(timeout.Token).GetAsyncEnumerator(timeout.Token);
+
+        stream.Publish(new SessionEvent("paired", null));
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("paired", enumerator.Current.Type);
+        await enumerator.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_ReplaysThenStreams_InOrder()
+    {
+        var stream = new SessionEventStream();
+        stream.Publish(new SessionEvent("first", null));
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var enumerator = stream.SubscribeAsync(timeout.Token).GetAsyncEnumerator(timeout.Token);
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("first", enumerator.Current.Type);
+
+        stream.Publish(new SessionEvent("second", null));
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("second", enumerator.Current.Type);
+        await enumerator.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_SupportsTwoConcurrentSubscribers()
+    {
+        var stream = new SessionEventStream();
+        var first = DrainAsync(stream, 1);
+        var second = DrainAsync(stream, 1);
+
+        // Give both subscribers a chance to register before publishing.
+        await Task.Delay(50);
+        stream.Publish(new SessionEvent("step", null));
+
+        Assert.Single(await first);
+        Assert.Single(await second);
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_CompletesWhenStreamCompleted()
+    {
+        var stream = new SessionEventStream();
+        stream.Publish(new SessionEvent("expired", null));
+        stream.Complete();
+
+        var received = new List<SessionEvent>();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await foreach (var item in stream.SubscribeAsync(timeout.Token))
+        {
+            received.Add(item);
+        }
+
+        Assert.Single(received);
+    }
+
+    [Fact]
+    public async Task Publish_AfterComplete_IsIgnored()
+    {
+        var stream = new SessionEventStream();
+        stream.Complete();
+        stream.Publish(new SessionEvent("step", null));
+
+        var received = new List<SessionEvent>();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await foreach (var item in stream.SubscribeAsync(timeout.Token))
+        {
+            received.Add(item);
+        }
+
+        Assert.Empty(received);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~SessionEventStreamTests"`
+Expected: FAIL — `SessionEvent` and `SessionEventStream` do not exist.
+
+- [ ] **Step 3: Write SessionEvent**
+
+`apps/RustPlusApi.CredentialsWeb/Sessions/SessionEvent.cs`:
+
+```csharp
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>One server-sent event. <paramref name="Type"/> becomes the SSE <c>event:</c> name and
+/// <paramref name="Data"/> is serialized to JSON for the <c>data:</c> line.</summary>
+/// <param name="Type">One of <c>step</c>, <c>credentials</c>, <c>paired</c>, <c>error</c>, <c>expired</c>.</param>
+/// <param name="Data">Payload, or <see langword="null"/> for an event that carries none.</param>
+internal sealed record SessionEvent(string Type, object? Data);
+```
+
+- [ ] **Step 3b: Write the payload records**
+
+Concrete records rather than anonymous objects, so tests can assert on payloads and so the
+`ulong`-as-string rule is enforced by the type rather than by remembering it at each call site.
+
+`apps/RustPlusApi.CredentialsWeb/Sessions/SessionEventPayloads.cs`:
+
+```csharp
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>Payload of a <c>step</c> event.</summary>
+/// <param name="State">The new <see cref="SessionState"/>, as its enum name.</param>
+internal sealed record StepPayload(string State);
+
+/// <summary>Payload of a <c>credentials</c> event.</summary>
+/// <param name="SteamId">Steam64 as a string: it exceeds JavaScript's safe integer range.</param>
+/// <param name="ConfigJson">The exact contents of rustplus.config.json, from <c>CredentialsStore.Serialize</c>.</param>
+internal sealed record CredentialsPayload(string SteamId, string ConfigJson);
+
+/// <summary>Payload of a <c>paired</c> event.</summary>
+/// <param name="Ip">Server address.</param>
+/// <param name="Port">Server app port.</param>
+/// <param name="PlayerId">Steam64 as a string, for the same reason as <see cref="CredentialsPayload.SteamId"/>.</param>
+/// <param name="PlayerToken">The pairing token. Full Rust+ account access.</param>
+/// <param name="Name">Server name, when the push carried one.</param>
+internal sealed record PairedPayload(string Ip, int Port, string PlayerId, int PlayerToken, string? Name);
+
+/// <summary>Payload of an <c>error</c> event. Always a fixed, non-reflective message: never an
+/// exception message, which could carry upstream response content.</summary>
+/// <param name="Message">What to show the visitor.</param>
+internal sealed record ErrorPayload(string Message);
+```
+
+- [ ] **Step 4: Write SessionEventStream**
+
+The lock covers both the history snapshot and the subscriber registration, so an event published between the two cannot be lost. The snapshot is taken in a non-iterator helper because `lock` cannot span a `yield`.
+
+`apps/RustPlusApi.CredentialsWeb/Sessions/SessionEventStream.cs`:
+
+```csharp
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>Fans one session's events out to every subscriber, replaying the events published
+/// before each subscription. Replay is what makes an SSE reconnect resume rather than restart —
+/// which matters because the drop happens exactly when the visitor alt-tabs into fullscreen Rust.</summary>
+internal sealed class SessionEventStream
+{
+    private readonly List<SessionEvent> _history = [];
+    private readonly Lock _gate = new();
+    private readonly List<Channel<SessionEvent>> _subscribers = [];
+    private bool _completed;
+
+    /// <summary>Appends an event to the history and pushes it to every live subscriber.
+    /// Ignored once <see cref="Complete"/> has been called.</summary>
+    internal void Publish(SessionEvent sessionEvent)
+    {
+        lock (_gate)
+        {
+            if (_completed)
+            {
+                return;
+            }
+
+            _history.Add(sessionEvent);
+            foreach (var subscriber in _subscribers)
+            {
+                // Unbounded channel: writes always succeed, so a slow reader can never block the flow.
+                subscriber.Writer.TryWrite(sessionEvent);
+            }
+        }
+    }
+
+    /// <summary>Ends every subscriber's enumeration. Idempotent.</summary>
+    internal void Complete()
+    {
+        lock (_gate)
+        {
+            if (_completed)
+            {
+                return;
+            }
+
+            _completed = true;
+            foreach (var subscriber in _subscribers)
+            {
+                subscriber.Writer.TryComplete();
+            }
+
+            _subscribers.Clear();
+        }
+    }
+
+    /// <summary>Yields every event published so far, then every subsequent one until the stream is
+    /// completed or <paramref name="cancellationToken"/> fires.</summary>
+    internal async IAsyncEnumerable<SessionEvent> SubscribeAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var (history, reader) = Subscribe();
+
+        foreach (var item in history)
+        {
+            yield return item;
+        }
+
+        if (reader is null)
+        {
+            yield break;
+        }
+
+        await foreach (var item in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        {
+            yield return item;
+        }
+    }
+
+    /// <summary>Snapshots the history and registers a subscriber under one lock, so no event can slip
+    /// between the two. Returns a null reader when the stream is already complete.</summary>
+    private (IReadOnlyList<SessionEvent> History, ChannelReader<SessionEvent>? Reader) Subscribe()
+    {
+        lock (_gate)
+        {
+            var history = _history.ToArray();
+            if (_completed)
+            {
+                return (history, null);
+            }
+
+            var channel = Channel.CreateUnbounded<SessionEvent>(new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = false
+            });
+
+            _subscribers.Add(channel);
+            return (history, channel.Reader);
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~SessionEventStreamTests"`
+Expected: PASS, 6 tests.
+
+Note: `System.Threading.Lock` is .NET 9+. If the analyzer objects, `private readonly object _gate = new();` is equivalent here.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/RustPlusApi.CredentialsWeb/Sessions/ tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEventStreamTests.cs
+git commit -m "feat(web): add replaying multi-subscriber session event stream"
+```
+
+---
+
+### Task 3: Session identity and state
+
+One visitor's state, its secrets, and their lifetimes. The two ids are deliberately separate: the `returnToken` is the value that necessarily travels through Facepunch and can land in logs, so it must not be the value that grants access to the session's events.
+
+**Files:**
+- Create: `apps/RustPlusApi.CredentialsWeb/Sessions/SessionIds.cs`
+- Create: `apps/RustPlusApi.CredentialsWeb/Sessions/SessionState.cs`
+- Create: `apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs`
+- Test: `tests/RustPlusApi.CredentialsWeb.UnitTests/SessionTests.cs`
+
+**Interfaces:**
+- Consumes: `SessionEvent`, `SessionEventStream` from Task 2.
+- Produces:
+  - `internal static class SessionIds` with `internal static string New()` → 32 lowercase hex characters.
+  - `internal enum SessionState { Created, Authenticated, Registering, Ready, AwaitingPairing, Paired, Failed }`
+  - `internal sealed class Session : IDisposable` — constructor `Session(string sessionId, string returnToken, string clientIp, DateTimeOffset expiresAt)`; properties `SessionId`, `ReturnToken`, `ClientIp`, `Events`, `State`, `ExpiresAt`, `SteamId`, `SteamToken`, `Credentials`, `Pairing`, `Lifetime`, `BackgroundWork`; methods `Advance(SessionState, DateTimeOffset)`, `SetSteamLogin(SteamLoginResult)`, `ClearSteamToken()`, `SetCredentials(Credentials)`, `SetPairing(ServerPairing)`, `IsExpired(DateTimeOffset)`, `Dispose()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/SessionTests.cs`:
+
+```csharp
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.Fcm.Data;
+using RustPlusApi.Fcm.Registration;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SessionTests
+{
+    private static readonly DateTimeOffset Origin = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    private static Session NewSession() =>
+        new("session-id", "return-token", "203.0.113.7", Origin.AddMinutes(5));
+
+    private static async Task<List<SessionEvent>> ReadAsync(Session session, int expected)
+    {
+        var received = new List<SessionEvent>();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await foreach (var item in session.Events.SubscribeAsync(timeout.Token))
+        {
+            received.Add(item);
+            if (received.Count == expected)
+            {
+                break;
+            }
+        }
+
+        return received;
+    }
+
+    [Fact]
+    public void New_StartsInCreatedState()
+    {
+        using var session = NewSession();
+
+        Assert.Equal(SessionState.Created, session.State);
+        Assert.Equal(Origin.AddMinutes(5), session.ExpiresAt);
+        Assert.Equal("203.0.113.7", session.ClientIp);
+    }
+
+    [Fact]
+    public async Task Advance_UpdatesStateAndExpiry_AndPublishesStepEvent()
+    {
+        using var session = NewSession();
+
+        session.Advance(SessionState.Registering, Origin.AddMinutes(15));
+
+        Assert.Equal(SessionState.Registering, session.State);
+        Assert.Equal(Origin.AddMinutes(15), session.ExpiresAt);
+
+        var events = await ReadAsync(session, 1);
+        Assert.Equal("step", events[0].Type);
+    }
+
+    [Fact]
+    public void SetSteamLogin_StoresIdAndToken()
+    {
+        using var session = NewSession();
+
+        session.SetSteamLogin(new SteamLoginResult { SteamId = 76561198249527954, Token = "steam-token" });
+
+        Assert.Equal(76561198249527954UL, session.SteamId);
+        Assert.Equal("steam-token", session.SteamToken);
+    }
+
+    [Fact]
+    public void ClearSteamToken_DropsTokenButKeepsSteamId()
+    {
+        using var session = NewSession();
+        session.SetSteamLogin(new SteamLoginResult { SteamId = 76561198249527954, Token = "steam-token" });
+
+        session.ClearSteamToken();
+
+        Assert.Null(session.SteamToken);
+        Assert.Equal(76561198249527954UL, session.SteamId);
+    }
+
+    [Fact]
+    public void SetCredentialsAndPairing_AreExposed()
+    {
+        using var session = NewSession();
+        var credentials = new Credentials { ExpoPushToken = "expo-token" };
+        var pairing = new ServerPairing { Ip = "10.0.0.1", Port = 28082, PlayerId = 1, PlayerToken = 2 };
+
+        session.SetCredentials(credentials);
+        session.SetPairing(pairing);
+
+        Assert.Same(credentials, session.Credentials);
+        Assert.Same(pairing, session.Pairing);
+    }
+
+    [Theory]
+    [InlineData(4, false)]
+    [InlineData(5, true)]
+    [InlineData(6, true)]
+    public void IsExpired_ComparesAgainstExpiry(int minutes, bool expected)
+    {
+        using var session = NewSession();
+
+        Assert.Equal(expected, session.IsExpired(Origin.AddMinutes(minutes)));
+    }
+
+    [Fact]
+    public void Dispose_ClearsSecretsAndCancelsLifetime()
+    {
+        var session = NewSession();
+        session.SetSteamLogin(new SteamLoginResult { SteamId = 1, Token = "steam-token" });
+        session.SetCredentials(new Credentials { ExpoPushToken = "expo-token" });
+        session.SetPairing(new ServerPairing { Ip = "10.0.0.1", Port = 1, PlayerId = 1, PlayerToken = 2 });
+
+        session.Dispose();
+
+        Assert.Null(session.SteamToken);
+        Assert.Null(session.Credentials);
+        Assert.Null(session.Pairing);
+        Assert.True(session.Lifetime.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task Dispose_CompletesTheEventStream()
+    {
+        var session = NewSession();
+        session.Dispose();
+
+        var received = new List<SessionEvent>();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await foreach (var item in session.Events.SubscribeAsync(timeout.Token))
+        {
+            received.Add(item);
+        }
+
+        Assert.Empty(received);
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var session = NewSession();
+
+        session.Dispose();
+        session.Dispose();
+    }
+
+    [Fact]
+    public void SessionIds_AreThirtyTwoLowercaseHexCharsAndUnique()
+    {
+        var first = SessionIds.New();
+        var second = SessionIds.New();
+
+        Assert.Equal(32, first.Length);
+        Assert.Matches("^[0-9a-f]{32}$", first);
+        Assert.NotEqual(first, second);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~SessionTests"`
+Expected: FAIL — `Session`, `SessionState` and `SessionIds` do not exist.
+
+- [ ] **Step 3: Write SessionIds and SessionState**
+
+`apps/RustPlusApi.CredentialsWeb/Sessions/SessionIds.cs`:
+
+```csharp
+using System.Security.Cryptography;
+
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>Generates the opaque identifiers used for both the session handle and the return token.</summary>
+internal static class SessionIds
+{
+    /// <summary>A fresh 128-bit identifier as 32 lowercase hex characters.</summary>
+    internal static string New() =>
+        Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant();
+}
+```
+
+`apps/RustPlusApi.CredentialsWeb/Sessions/SessionState.cs`:
+
+```csharp
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>Where a visitor is in the credential flow.</summary>
+internal enum SessionState
+{
+    /// <summary>Created; the visitor has not completed the Steam login yet. Nothing upstream touched.</summary>
+    Created,
+
+    /// <summary>The Facepunch callback arrived with a usable Steam token.</summary>
+    Authenticated,
+
+    /// <summary>Steps 1-3 and 5 are running.</summary>
+    Registering,
+
+    /// <summary>Credentials acquired and registered with Rust Companion.</summary>
+    Ready,
+
+    /// <summary>Holding an MCS socket, waiting for the in-game pairing push.</summary>
+    AwaitingPairing,
+
+    /// <summary>A pairing push arrived; the flow is complete.</summary>
+    Paired,
+
+    /// <summary>A step failed. Terminal.</summary>
+    Failed
+}
+
+// There is deliberately no Expired state. A pairing wait that times out returns the session to
+// Ready and emits an `expired` event: the credentials are still valid, so the visitor can retry
+// the pairing without repeating the Steam login. A session that outlives its TTL is removed by
+// the sweeper rather than parked in a state nobody can observe.
+```
+
+- [ ] **Step 4: Write Session**
+
+`apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs`:
+
+```csharp
+using RustPlusApi.Fcm.Data;
+using RustPlusApi.Fcm.Registration;
+
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>One visitor's flow: its state, its secrets and their lifetimes. Everything here is
+/// in-memory only and dies with <see cref="Dispose"/> or the process — nothing is ever persisted.</summary>
+/// <param name="sessionId">The handle the browser uses for the event stream and follow-up calls.</param>
+/// <param name="returnToken">Single-use token embedded in the Facepunch <c>returnUrl</c> path.</param>
+/// <param name="clientIp">The caller's address, for per-IP accounting.</param>
+/// <param name="expiresAt">When this session becomes sweepable.</param>
+internal sealed class Session(string sessionId, string returnToken, string clientIp, DateTimeOffset expiresAt)
+    : IDisposable
+{
+    private readonly Lock _gate = new();
+    private bool _disposed;
+
+    /// <summary>Background work started for this session, kept so it is observed rather than fire-and-forget.</summary>
+    internal Task BackgroundWork { get; set; } = Task.CompletedTask;
+
+    /// <summary>The caller's address.</summary>
+    internal string ClientIp { get; } = clientIp;
+
+    /// <summary>Credentials from steps 1-3, once acquired.</summary>
+    internal Credentials? Credentials { get; private set; }
+
+    /// <summary>This session's event stream.</summary>
+    internal SessionEventStream Events { get; } = new();
+
+    /// <summary>When this session becomes sweepable.</summary>
+    internal DateTimeOffset ExpiresAt { get; private set; } = expiresAt;
+
+    /// <summary>Cancelled on disposal, so any in-flight upstream work stops with the session.</summary>
+    internal CancellationTokenSource Lifetime { get; } = new();
+
+    /// <summary>The pairing, once a push arrives.</summary>
+    internal ServerPairing? Pairing { get; private set; }
+
+    /// <summary>Single-use token embedded in the Facepunch <c>returnUrl</c> path.</summary>
+    internal string ReturnToken { get; } = returnToken;
+
+    /// <summary>The handle the browser uses. Never appears in a <c>returnUrl</c>.</summary>
+    internal string SessionId { get; } = sessionId;
+
+    /// <summary>The Steam64 from the callback. Not a secret; kept for display.</summary>
+    internal ulong SteamId { get; private set; }
+
+    /// <summary>The Steam auth token. Dropped the moment step 5 succeeds.</summary>
+    internal string? SteamToken { get; private set; }
+
+    /// <summary>Where the visitor is in the flow.</summary>
+    internal SessionState State { get; private set; } = SessionState.Created;
+
+    /// <summary>Cancels in-flight work, ends the event stream and drops every secret. Idempotent.</summary>
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            SteamToken = null;
+            Credentials = null;
+            Pairing = null;
+        }
+
+        // Outside the lock: cancellation callbacks may re-enter session code.
+        Lifetime.Cancel();
+        Events.Complete();
+        Lifetime.Dispose();
+    }
+
+    /// <summary>Moves to <paramref name="state"/>, resets the expiry and publishes a <c>step</c> event.</summary>
+    /// <param name="state">The new state.</param>
+    /// <param name="newExpiry">The new expiry instant.</param>
+    internal void Advance(SessionState state, DateTimeOffset newExpiry)
+    {
+        lock (_gate)
+        {
+            State = state;
+            ExpiresAt = newExpiry;
+        }
+
+        Events.Publish(new SessionEvent("step", new StepPayload(state.ToString())));
+    }
+
+    /// <summary>Drops the Steam auth token once it has no further use.</summary>
+    internal void ClearSteamToken()
+    {
+        lock (_gate)
+        {
+            SteamToken = null;
+        }
+    }
+
+    /// <summary>True once <paramref name="now"/> has reached the expiry.</summary>
+    /// <param name="now">The current instant, from the ambient <see cref="TimeProvider"/>.</param>
+    internal bool IsExpired(DateTimeOffset now) => now >= ExpiresAt;
+
+    /// <summary>Stores the credentials from steps 1-3.</summary>
+    /// <param name="credentials">The acquired credentials.</param>
+    internal void SetCredentials(Credentials credentials)
+    {
+        lock (_gate)
+        {
+            Credentials = credentials;
+        }
+    }
+
+    /// <summary>Stores the pairing from step 6.</summary>
+    /// <param name="pairing">The pairing that arrived.</param>
+    internal void SetPairing(ServerPairing pairing)
+    {
+        lock (_gate)
+        {
+            Pairing = pairing;
+        }
+    }
+
+    /// <summary>Stores the Steam identity captured from the Facepunch callback.</summary>
+    /// <param name="login">The parsed callback result.</param>
+    internal void SetSteamLogin(SteamLoginResult login)
+    {
+        lock (_gate)
+        {
+            SteamId = login.SteamId;
+            SteamToken = login.Token;
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~SessionTests"`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/RustPlusApi.CredentialsWeb/Sessions/ tests/RustPlusApi.CredentialsWeb.UnitTests/SessionTests.cs
+git commit -m "feat(web): add session state, identity and secret lifetimes"
+```
+
+---
+
+### Task 4: Session store — create, lookup, consume, sweep
+
+The registry. This task implements everything except the IP-based caps, which arrive in Task 5.
+
+**Files:**
+- Create: `apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs`
+- Test: `tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreTests.cs`
+
+**Interfaces:**
+- Consumes: `AppOptions` (Task 1); `Session`, `SessionIds`, `SessionState` (Task 3).
+- Produces:
+  - `internal enum SessionCreateFailure { None, GlobalLimit, ActiveSessionForIp, HourlyLimit }`
+  - `internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider) : IDisposable` with:
+    - `internal bool TryCreate(string clientIp, [NotNullWhen(true)] out Session? session, out SessionCreateFailure failure)`
+    - `internal bool TryGet(string sessionId, [NotNullWhen(true)] out Session? session)`
+    - `internal bool TryConsumeReturnToken(string returnToken, [NotNullWhen(true)] out Session? session)`
+    - `internal void Remove(string sessionId)`
+    - `internal int SweepExpired()`
+    - `internal int Count { get; }`
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreTests.cs`:
+
+```csharp
+using Microsoft.Extensions.Time.Testing;
+using RustPlusApi.CredentialsWeb;
+using RustPlusApi.CredentialsWeb.Sessions;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SessionStoreTests
+{
+    private static readonly DateTimeOffset Origin = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    private static (SessionStore Store, FakeTimeProvider Time) NewStore()
+    {
+        var time = new FakeTimeProvider(Origin);
+        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        return (new SessionStore(options, time), time);
+    }
+
+    [Fact]
+    public void TryCreate_ReturnsCreatedSessionWithDistinctIds()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+
+        Assert.True(store.TryCreate("203.0.113.7", out var session, out var failure));
+
+        Assert.Equal(SessionCreateFailure.None, failure);
+        Assert.Equal(SessionState.Created, session.State);
+        Assert.Equal("203.0.113.7", session.ClientIp);
+        Assert.NotEqual(session.SessionId, session.ReturnToken);
+        Assert.Equal(Origin.AddMinutes(5), session.ExpiresAt);
+        Assert.Equal(1, store.Count);
+    }
+
+    [Fact]
+    public void TryGet_FindsSessionBySessionId()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var created, out _);
+
+        Assert.True(store.TryGet(created!.SessionId, out var found));
+        Assert.Same(created, found);
+    }
+
+    [Fact]
+    public void TryGet_ReturnsFalse_ForUnknownId()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+
+        Assert.False(store.TryGet("nope", out var found));
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public void TryGet_DoesNotAcceptTheReturnToken()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var created, out _);
+
+        Assert.False(store.TryGet(created!.ReturnToken, out _));
+    }
+
+    [Fact]
+    public void TryConsumeReturnToken_ReturnsSessionOnce()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var created, out _);
+
+        Assert.True(store.TryConsumeReturnToken(created!.ReturnToken, out var first));
+        Assert.Same(created, first);
+
+        Assert.False(store.TryConsumeReturnToken(created.ReturnToken, out var second));
+        Assert.Null(second);
+    }
+
+    [Fact]
+    public void TryConsumeReturnToken_ReturnsFalse_ForUnknownToken()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+
+        Assert.False(store.TryConsumeReturnToken("unknown", out _));
+    }
+
+    [Fact]
+    public void TryConsumeReturnToken_LeavesSessionRetrievable()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var created, out _);
+
+        store.TryConsumeReturnToken(created!.ReturnToken, out _);
+
+        Assert.True(store.TryGet(created.SessionId, out _));
+    }
+
+    [Fact]
+    public void Remove_DisposesAndForgetsTheSession()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var created, out _);
+
+        store.Remove(created!.SessionId);
+
+        Assert.False(store.TryGet(created.SessionId, out _));
+        Assert.True(created.Lifetime.IsCancellationRequested);
+        Assert.Equal(0, store.Count);
+    }
+
+    [Fact]
+    public void Remove_IsSafeForUnknownId()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+
+        store.Remove("unknown");
+    }
+
+    [Fact]
+    public void SweepExpired_RemovesOnlyExpiredSessions()
+    {
+        var (store, time) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var stale, out _);
+        time.Advance(TimeSpan.FromMinutes(6));
+        store.TryCreate("203.0.113.8", out var fresh, out _);
+
+        var swept = store.SweepExpired();
+
+        Assert.Equal(1, swept);
+        Assert.False(store.TryGet(stale!.SessionId, out _));
+        Assert.True(store.TryGet(fresh!.SessionId, out _));
+    }
+
+    [Fact]
+    public void SweepExpired_AlsoInvalidatesTheReturnToken()
+    {
+        var (store, time) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var session, out _);
+        time.Advance(TimeSpan.FromMinutes(6));
+
+        store.SweepExpired();
+
+        Assert.False(store.TryConsumeReturnToken(session!.ReturnToken, out _));
+    }
+
+    [Fact]
+    public void SweepExpired_UsesTheStateSpecificTtl()
+    {
+        var (store, time) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        // Authenticated sessions get SessionTtl (15 min), not CreatedTtl (5 min).
+        session!.Advance(SessionState.Authenticated, time.GetUtcNow().Add(TimeSpan.FromMinutes(15)));
+        time.Advance(TimeSpan.FromMinutes(6));
+
+        Assert.Equal(0, store.SweepExpired());
+    }
+
+    [Fact]
+    public void Dispose_DisposesEverySession()
+    {
+        var (store, _) = NewStore();
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        store.Dispose();
+
+        Assert.True(session!.Lifetime.IsCancellationRequested);
+        Assert.Equal(0, store.Count);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~SessionStoreTests"`
+Expected: FAIL — `SessionStore` and `SessionCreateFailure` do not exist.
+
+- [ ] **Step 3: Write SessionStore**
+
+The `ActiveSessionForIp` and `HourlyLimit` branches of `SessionCreateFailure` are declared here but only produced in Task 5; keeping the enum whole avoids a signature change one task later.
+
+`apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs`:
+
+```csharp
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>Why <see cref="SessionStore.TryCreate"/> refused.</summary>
+internal enum SessionCreateFailure
+{
+    /// <summary>Creation succeeded.</summary>
+    None,
+
+    /// <summary>The instance-wide session cap is full.</summary>
+    GlobalLimit,
+
+    /// <summary>This address already holds a session past <see cref="SessionState.Created"/>.</summary>
+    ActiveSessionForIp,
+
+    /// <summary>This address has completed too many flows in the last hour.</summary>
+    HourlyLimit
+}
+
+/// <summary>The in-memory session registry. There is no persistence anywhere in this app: a process
+/// restart wipes every session by construction.</summary>
+/// <param name="options">Caps and TTLs.</param>
+/// <param name="timeProvider">Clock, injected so TTLs are testable.</param>
+internal sealed class SessionStore(AppOptions options, TimeProvider timeProvider) : IDisposable
+{
+    private readonly ConcurrentDictionary<string, string> _byReturnToken = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Session> _bySessionId = new(StringComparer.Ordinal);
+
+    /// <summary>Live sessions in any state.</summary>
+    internal int Count => _bySessionId.Count;
+
+    /// <summary>Disposes every live session.</summary>
+    public void Dispose()
+    {
+        foreach (var sessionId in _bySessionId.Keys)
+        {
+            Remove(sessionId);
+        }
+    }
+
+    /// <summary>Forgets a session and disposes it, invalidating its return token.</summary>
+    /// <param name="sessionId">The session handle.</param>
+    internal void Remove(string sessionId)
+    {
+        if (!_bySessionId.TryRemove(sessionId, out var session))
+        {
+            return;
+        }
+
+        _byReturnToken.TryRemove(session.ReturnToken, out _);
+        session.Dispose();
+    }
+
+    /// <summary>Disposes every session whose expiry has passed. Returns how many were removed.</summary>
+    internal int SweepExpired()
+    {
+        var now = timeProvider.GetUtcNow();
+        var swept = 0;
+
+        foreach (var (sessionId, session) in _bySessionId)
+        {
+            if (!session.IsExpired(now))
+            {
+                continue;
+            }
+
+            Remove(sessionId);
+            swept++;
+        }
+
+        return swept;
+    }
+
+    /// <summary>Looks a session up by its return token and invalidates that token, so a callback URL
+    /// replayed from browser history finds nothing.</summary>
+    /// <param name="returnToken">The token from the callback path.</param>
+    /// <param name="session">The owning session when the token was live.</param>
+    internal bool TryConsumeReturnToken(string returnToken, [NotNullWhen(true)] out Session? session)
+    {
+        session = null;
+        return _byReturnToken.TryRemove(returnToken, out var sessionId)
+            && _bySessionId.TryGetValue(sessionId, out session);
+    }
+
+    /// <summary>Creates a session for <paramref name="clientIp"/>, or explains why it could not.</summary>
+    /// <param name="clientIp">The caller's address.</param>
+    /// <param name="session">The new session on success.</param>
+    /// <param name="failure">Why creation was refused.</param>
+    internal bool TryCreate(
+        string clientIp,
+        [NotNullWhen(true)] out Session? session,
+        out SessionCreateFailure failure)
+    {
+        session = null;
+
+        if (_bySessionId.Count >= options.MaxConcurrentSessions)
+        {
+            failure = SessionCreateFailure.GlobalLimit;
+            return false;
+        }
+
+        var created = new Session(
+            SessionIds.New(),
+            SessionIds.New(),
+            clientIp,
+            timeProvider.GetUtcNow().Add(options.CreatedTtl));
+
+        _bySessionId[created.SessionId] = created;
+        _byReturnToken[created.ReturnToken] = created.SessionId;
+
+        session = created;
+        failure = SessionCreateFailure.None;
+        return true;
+    }
+
+    /// <summary>Looks a session up by its handle. The return token is deliberately not accepted here.</summary>
+    /// <param name="sessionId">The session handle.</param>
+    /// <param name="session">The session when found.</param>
+    internal bool TryGet(string sessionId, [NotNullWhen(true)] out Session? session) =>
+        _bySessionId.TryGetValue(sessionId, out session);
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~SessionStoreTests"`
+Expected: PASS, 13 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreTests.cs
+git commit -m "feat(web): add in-memory session store with single-use return tokens"
+```
+
+---
+
+### Task 5: Caps, per-IP accounting and the eviction rule
+
+The bounding model. The subtle requirement is the eviction rule: a naive one-session-per-IP cap locks a visitor out of their own retry for five minutes when they close the tab and start over — which is the single most likely thing a confused first-time visitor does.
+
+**Files:**
+- Modify: `apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs`
+- Test: `tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs`
+
+**Interfaces:**
+- Consumes: everything from Task 4.
+- Produces, added to `SessionStore`:
+  - `internal void RecordCompletion(string clientIp)`
+  - `internal bool TryAcquirePairingSlot()`
+  - `internal void ReleasePairingSlot()`
+  - `internal int ActivePairings { get; }`
+  - `TryCreate` now also returns `SessionCreateFailure.ActiveSessionForIp` and `SessionCreateFailure.HourlyLimit`, and evicts a same-IP session still in `Created`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs`:
+
+```csharp
+using Microsoft.Extensions.Time.Testing;
+using RustPlusApi.CredentialsWeb;
+using RustPlusApi.CredentialsWeb.Sessions;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SessionStoreCapsTests
+{
+    private static readonly DateTimeOffset Origin = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    private static (SessionStore Store, FakeTimeProvider Time) NewStore(Action<AppOptions>? configure = null)
+    {
+        var time = new FakeTimeProvider(Origin);
+        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        configure?.Invoke(options);
+        return (new SessionStore(options, time), time);
+    }
+
+    [Fact]
+    public void TryCreate_Refuses_WhenGlobalLimitReached()
+    {
+        var (store, _) = NewStore(o => o.MaxConcurrentSessions = 1);
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out _, out _);
+
+        Assert.False(store.TryCreate("203.0.113.8", out var session, out var failure));
+
+        Assert.Null(session);
+        Assert.Equal(SessionCreateFailure.GlobalLimit, failure);
+    }
+
+    [Fact]
+    public void TryCreate_EvictsAbandonedCreatedSession_FromTheSameIp()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var abandoned, out _);
+
+        Assert.True(store.TryCreate("203.0.113.7", out var replacement, out var failure));
+
+        Assert.Equal(SessionCreateFailure.None, failure);
+        Assert.NotSame(abandoned, replacement);
+        Assert.False(store.TryGet(abandoned!.SessionId, out _));
+        Assert.True(store.TryGet(replacement!.SessionId, out _));
+        Assert.Equal(1, store.Count);
+    }
+
+    [Fact]
+    public void TryCreate_Refuses_WhenTheSameIpHasAnAuthenticatedSession()
+    {
+        var (store, time) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var active, out _);
+        active!.Advance(SessionState.Authenticated, time.GetUtcNow().AddMinutes(15));
+
+        Assert.False(store.TryCreate("203.0.113.7", out var session, out var failure));
+
+        Assert.Null(session);
+        Assert.Equal(SessionCreateFailure.ActiveSessionForIp, failure);
+    }
+
+    [Fact]
+    public void TryCreate_IsUnaffectedByOtherAddresses()
+    {
+        var (store, time) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var other, out _);
+        other!.Advance(SessionState.Authenticated, time.GetUtcNow().AddMinutes(15));
+
+        Assert.True(store.TryCreate("203.0.113.8", out _, out var failure));
+        Assert.Equal(SessionCreateFailure.None, failure);
+    }
+
+    [Fact]
+    public void TryCreate_Refuses_AfterTooManyCompletionsInAnHour()
+    {
+        var (store, _) = NewStore(o => o.MaxCompletionsPerIpPerHour = 2);
+        using var _s = store;
+        store.RecordCompletion("203.0.113.7");
+        store.RecordCompletion("203.0.113.7");
+
+        Assert.False(store.TryCreate("203.0.113.7", out _, out var failure));
+        Assert.Equal(SessionCreateFailure.HourlyLimit, failure);
+    }
+
+    [Fact]
+    public void TryCreate_Recovers_AfterTheHourlyWindowSlidesPast()
+    {
+        var (store, time) = NewStore(o => o.MaxCompletionsPerIpPerHour = 1);
+        using var _s = store;
+        store.RecordCompletion("203.0.113.7");
+        Assert.False(store.TryCreate("203.0.113.7", out _, out _));
+
+        time.Advance(TimeSpan.FromMinutes(61));
+
+        Assert.True(store.TryCreate("203.0.113.7", out _, out var failure));
+        Assert.Equal(SessionCreateFailure.None, failure);
+    }
+
+    [Fact]
+    public void RecordCompletion_IsScopedToOneAddress()
+    {
+        var (store, _) = NewStore(o => o.MaxCompletionsPerIpPerHour = 1);
+        using var _s = store;
+        store.RecordCompletion("203.0.113.7");
+
+        Assert.True(store.TryCreate("203.0.113.8", out _, out _));
+    }
+
+    [Fact]
+    public void TryAcquirePairingSlot_HonoursTheGlobalPairingCap()
+    {
+        var (store, _) = NewStore(o => o.MaxConcurrentPairings = 2);
+        using var _s = store;
+
+        Assert.True(store.TryAcquirePairingSlot());
+        Assert.True(store.TryAcquirePairingSlot());
+        Assert.False(store.TryAcquirePairingSlot());
+        Assert.Equal(2, store.ActivePairings);
+    }
+
+    [Fact]
+    public void ReleasePairingSlot_FreesCapacity()
+    {
+        var (store, _) = NewStore(o => o.MaxConcurrentPairings = 1);
+        using var _s = store;
+        store.TryAcquirePairingSlot();
+
+        store.ReleasePairingSlot();
+
+        Assert.Equal(0, store.ActivePairings);
+        Assert.True(store.TryAcquirePairingSlot());
+    }
+
+    [Fact]
+    public void ReleasePairingSlot_NeverGoesNegative()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+
+        store.ReleasePairingSlot();
+
+        Assert.Equal(0, store.ActivePairings);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~SessionStoreCapsTests"`
+Expected: FAIL — `RecordCompletion`, `TryAcquirePairingSlot`, `ReleasePairingSlot` and `ActivePairings` do not exist, and the eviction/limit tests fail.
+
+- [ ] **Step 3: Add the fields**
+
+In `SessionStore`, add alongside the existing dictionaries:
+
+```csharp
+    private readonly ConcurrentDictionary<string, List<DateTimeOffset>> _completionsByIp =
+        new(StringComparer.Ordinal);
+
+    private readonly Lock _createGate = new();
+    private int _activePairings;
+```
+
+- [ ] **Step 4: Replace TryCreate with the capped version**
+
+The whole method runs under `_createGate` so the eviction, the counts and the insert cannot interleave. Throughput is bounded by `MaxConcurrentSessions` anyway, so a single lock costs nothing real.
+
+```csharp
+    /// <summary>Creates a session for <paramref name="clientIp"/>, or explains why it could not.
+    /// A session from the same address that is still in <see cref="SessionState.Created"/> is
+    /// evicted rather than blocking: a visitor who closed the tab and started over must not be
+    /// locked out by their own abandoned attempt. An address holding a session past
+    /// <see cref="SessionState.Created"/> is refused instead — real upstream work exists there,
+    /// and that session is resumable via its handle.</summary>
+    /// <param name="clientIp">The caller's address.</param>
+    /// <param name="session">The new session on success.</param>
+    /// <param name="failure">Why creation was refused.</param>
+    internal bool TryCreate(
+        string clientIp,
+        [NotNullWhen(true)] out Session? session,
+        out SessionCreateFailure failure)
+    {
+        session = null;
+
+        lock (_createGate)
+        {
+            if (CountCompletions(clientIp) >= options.MaxCompletionsPerIpPerHour)
+            {
+                failure = SessionCreateFailure.HourlyLimit;
+                return false;
+            }
+
+            foreach (var (sessionId, existing) in _bySessionId)
+            {
+                if (!string.Equals(existing.ClientIp, clientIp, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (existing.State != SessionState.Created)
+                {
+                    failure = SessionCreateFailure.ActiveSessionForIp;
+                    return false;
+                }
+
+                Remove(sessionId);
+            }
+
+            if (_bySessionId.Count >= options.MaxConcurrentSessions)
+            {
+                failure = SessionCreateFailure.GlobalLimit;
+                return false;
+            }
+
+            var created = new Session(
+                SessionIds.New(),
+                SessionIds.New(),
+                clientIp,
+                timeProvider.GetUtcNow().Add(options.CreatedTtl));
+
+            _bySessionId[created.SessionId] = created;
+            _byReturnToken[created.ReturnToken] = created.SessionId;
+
+            session = created;
+            failure = SessionCreateFailure.None;
+            return true;
+        }
+    }
+```
+
+- [ ] **Step 5: Add the completion counter and pairing slots**
+
+```csharp
+    /// <summary>Live MCS sockets.</summary>
+    internal int ActivePairings => Volatile.Read(ref _activePairings);
+
+    /// <summary>Records that <paramref name="clientIp"/> finished a flow, for the rolling hourly cap.</summary>
+    /// <param name="clientIp">The caller's address.</param>
+    internal void RecordCompletion(string clientIp)
+    {
+        var stamps = _completionsByIp.GetOrAdd(clientIp, static _ => []);
+        lock (stamps)
+        {
+            stamps.Add(timeProvider.GetUtcNow());
+        }
+    }
+
+    /// <summary>Releases a pairing slot. Safe to call more often than it was acquired.</summary>
+    internal void ReleasePairingSlot()
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref _activePairings);
+            if (current == 0)
+            {
+                return;
+            }
+
+            if (Interlocked.CompareExchange(ref _activePairings, current - 1, current) == current)
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>Takes one of the globally capped MCS socket slots.</summary>
+    internal bool TryAcquirePairingSlot()
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref _activePairings);
+            if (current >= options.MaxConcurrentPairings)
+            {
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _activePairings, current + 1, current) == current)
+            {
+                return true;
+            }
+        }
+    }
+
+    /// <summary>Completions by this address inside the trailing hour, pruning older entries as it goes
+    /// so the map cannot grow without bound.</summary>
+    /// <param name="clientIp">The caller's address.</param>
+    private int CountCompletions(string clientIp)
+    {
+        if (!_completionsByIp.TryGetValue(clientIp, out var stamps))
+        {
+            return 0;
+        }
+
+        var cutoff = timeProvider.GetUtcNow().AddHours(-1);
+        lock (stamps)
+        {
+            stamps.RemoveAll(stamp => stamp < cutoff);
+            if (stamps.Count == 0)
+            {
+                _completionsByIp.TryRemove(clientIp, out _);
+            }
+
+            return stamps.Count;
+        }
+    }
+```
+
+- [ ] **Step 6: Run the full store suite**
+
+Run: `dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~SessionStore"`
+Expected: PASS — 13 from Task 4 plus 10 here. Task 4's `TryCreate_ReturnsCreatedSessionWithDistinctIds` must still pass unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/RustPlusApi.CredentialsWeb/Sessions/SessionStore.cs tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs
+git commit -m "feat(web): bound sessions by global, per-IP and pairing-slot caps"
+```
+
+---
+
+### Task 6: Expiry sweeper
+
+**Files:**
+- Create: `apps/RustPlusApi.CredentialsWeb/Sessions/SessionSweeper.cs`
+- Test: `tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs`
+
+**Interfaces:**
+- Consumes: `SessionStore` (Tasks 4-5).
+- Produces: `internal sealed class SessionSweeper(SessionStore store, TimeProvider timeProvider) : BackgroundService`, ticking every 30 seconds and calling `SessionStore.SweepExpired`.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs`:
+
+```csharp
+using Microsoft.Extensions.Time.Testing;
+using RustPlusApi.CredentialsWeb;
+using RustPlusApi.CredentialsWeb.Sessions;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SessionSweeperTests
+{
+    [Fact]
+    public async Task ExecuteAsync_RemovesExpiredSessionsOnTick()
+    {
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero));
+        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        using var store = new SessionStore(options, time);
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        using var sweeper = new SessionSweeper(store, time);
+        await sweeper.StartAsync(CancellationToken.None);
+
+        time.Advance(TimeSpan.FromMinutes(6));
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (store.TryGet(session!.SessionId, out _))
+        {
+            timeout.Token.ThrowIfCancellationRequested();
+            await Task.Delay(20, timeout.Token);
+        }
+
+        await sweeper.StopAsync(CancellationToken.None);
+        Assert.Equal(0, store.Count);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_LeavesLiveSessionsAlone()
+    {
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero));
+        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        using var store = new SessionStore(options, time);
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        using var sweeper = new SessionSweeper(store, time);
+        await sweeper.StartAsync(CancellationToken.None);
+
+        time.Advance(TimeSpan.FromMinutes(1));
+        await Task.Delay(100);
+
+        await sweeper.StopAsync(CancellationToken.None);
+        Assert.True(store.TryGet(session!.SessionId, out _));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~SessionSweeperTests"`
+Expected: FAIL — `SessionSweeper` does not exist.
+
+- [ ] **Step 3: Write SessionSweeper**
+
+`PeriodicTimer` takes a `TimeProvider`, which is what makes this testable with `FakeTimeProvider.Advance`.
+
+`apps/RustPlusApi.CredentialsWeb/Sessions/SessionSweeper.cs`:
+
+```csharp
+using Microsoft.Extensions.Hosting;
+
+namespace RustPlusApi.CredentialsWeb.Sessions;
+
+/// <summary>Disposes sessions past their TTL, which is what actually bounds how long an MCS socket
+/// and a set of credentials can live in memory.</summary>
+/// <param name="store">The registry to sweep.</param>
+/// <param name="timeProvider">Clock, injected so the interval is testable.</param>
+internal sealed class SessionSweeper(SessionStore store, TimeProvider timeProvider) : BackgroundService
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(30);
+
+    /// <inheritdoc/>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(Interval, timeProvider);
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                store.SweepExpired();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown.
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~SessionSweeperTests"`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/RustPlusApi.CredentialsWeb/Sessions/SessionSweeper.cs tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
+git commit -m "feat(web): sweep expired sessions on a background timer"
+```
+
+---
+
+### Task 7: Upstream seam and the registration flow
+
+The reordered `4 → 1,2,3 → 5` sequence, behind an interface so no test ever touches Google or Facepunch.
+
+**Files:**
+- Create: `apps/RustPlusApi.CredentialsWeb/Upstream/IRegistrationSteps.cs`
+- Create: `apps/RustPlusApi.CredentialsWeb/Upstream/LiveRegistrationSteps.cs`
+- Create: `apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs`
+- Create: `tests/RustPlusApi.CredentialsWeb.UnitTests/FakeRegistrationSteps.cs`
+- Test: `tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowTests.cs`
+
+**Interfaces:**
+- Consumes: `AppOptions` (Task 1); `SessionEvent` and payload records (Task 2); `Session`, `SessionState` (Task 3); `SessionStore` (Tasks 4-5).
+- Produces:
+  - `internal interface IRegistrationSteps` with `Task<Credentials> AcquireDeviceCredentialsAsync(CancellationToken)`, `Task RegisterWithCompanionAsync(string steamToken, string expoPushToken, CancellationToken)`, `Task<ServerPairing> WaitForPairingAsync(Credentials credentials, CancellationToken)`.
+  - `internal sealed class LiveRegistrationSteps(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory) : IRegistrationSteps`, `[ExcludeFromCodeCoverage]`, exposing `internal const string HttpClientName = "upstream"`.
+  - `internal sealed class CredentialFlow(IRegistrationSteps steps, SessionStore store, AppOptions options, TimeProvider timeProvider, ILogger<CredentialFlow> logger)` with `internal Task CompleteRegistrationAsync(Session session, SteamLoginResult login, CancellationToken cancellationToken)`.
+
+- [ ] **Step 1: Write the test double**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/FakeRegistrationSteps.cs`:
+
+```csharp
+using RustPlusApi.CredentialsWeb.Upstream;
+using RustPlusApi.Fcm.Data;
+using RustPlusApi.Fcm.Registration;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+/// <summary>Records what the flow asked for, and lets each step be made to fail or hang.</summary>
+internal sealed class FakeRegistrationSteps : IRegistrationSteps
+{
+    internal List<string> Calls { get; } = [];
+
+    internal Credentials CredentialsToReturn { get; set; } = new()
+    {
+        Gcm = new Gcm { AndroidId = 1, SecurityToken = 2 },
+        Fcm = new FcmToken { Token = "fcm-token" },
+        ExpoPushToken = "ExponentPushToken[fake]"
+    };
+
+    internal Exception? AcquireFailure { get; set; }
+
+    internal Exception? CompanionFailure { get; set; }
+
+    internal Exception? PairingFailure { get; set; }
+
+    internal ServerPairing PairingToReturn { get; set; } = new()
+    {
+        Ip = "10.0.0.1",
+        Port = 28082,
+        PlayerId = 76561198249527954,
+        PlayerToken = 987654321,
+        Name = "Test Server"
+    };
+
+    /// <summary>When set, the pairing wait blocks until this is signalled or cancelled.</summary>
+    internal TaskCompletionSource PairingGate { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    internal bool PairingWaitsForGate { get; set; }
+
+    internal string? SteamTokenSeen { get; private set; }
+
+    public Task<Credentials> AcquireDeviceCredentialsAsync(CancellationToken cancellationToken)
+    {
+        Calls.Add(nameof(AcquireDeviceCredentialsAsync));
+        return AcquireFailure is not null
+            ? Task.FromException<Credentials>(AcquireFailure)
+            : Task.FromResult(CredentialsToReturn);
+    }
+
+    public Task RegisterWithCompanionAsync(string steamToken, string expoPushToken, CancellationToken cancellationToken)
+    {
+        Calls.Add(nameof(RegisterWithCompanionAsync));
+        SteamTokenSeen = steamToken;
+        return CompanionFailure is not null ? Task.FromException(CompanionFailure) : Task.CompletedTask;
+    }
+
+    public async Task<ServerPairing> WaitForPairingAsync(Credentials credentials, CancellationToken cancellationToken)
+    {
+        Calls.Add(nameof(WaitForPairingAsync));
+
+        if (PairingFailure is not null)
+        {
+            throw PairingFailure;
+        }
+
+        if (PairingWaitsForGate)
+        {
+            await PairingGate.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return PairingToReturn;
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowTests.cs`:
+
+```csharp
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using RustPlusApi.CredentialsWeb;
+using RustPlusApi.CredentialsWeb.Flow;
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.Fcm.Registration;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class CredentialFlowTests
+{
+    private static readonly DateTimeOffset Origin = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    private static SteamLoginResult Login() =>
+        new() { SteamId = 76561198249527954, Token = "steam-token" };
+
+    private sealed record Harness(
+        CredentialFlow Flow,
+        SessionStore Store,
+        FakeRegistrationSteps Steps,
+        FakeTimeProvider Time,
+        AppOptions Options);
+
+    private static Harness NewHarness()
+    {
+        var time = new FakeTimeProvider(Origin);
+        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        var store = new SessionStore(options, time);
+        var steps = new FakeRegistrationSteps();
+        var flow = new CredentialFlow(steps, store, options, time, NullLogger<CredentialFlow>.Instance);
+        return new Harness(flow, store, steps, time, options);
+    }
+
+    /// <summary>Drains the buffered events. The stream is open-ended while the session lives, so a
+    /// short window is what stops the enumeration.</summary>
+    private static async Task<List<SessionEvent>> EventsOfAsync(Session session)
+    {
+        var received = new List<SessionEvent>();
+        using var window = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        try
+        {
+            await foreach (var item in session.Events.SubscribeAsync(window.Token))
+            {
+                received.Add(item);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected: the window closed.
+        }
+
+        return received;
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_RunsStepsInTheReorderedSequence()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        Assert.Equal(
+            [nameof(FakeRegistrationSteps.AcquireDeviceCredentialsAsync), nameof(FakeRegistrationSteps.RegisterWithCompanionAsync)],
+            h.Steps.Calls);
+        Assert.Equal("steam-token", h.Steps.SteamTokenSeen);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_ReachesReadyAndStoresCredentials()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        Assert.Equal(SessionState.Ready, session!.State);
+        Assert.NotNull(session.Credentials);
+        Assert.Equal(Origin.Add(h.Options.SessionTtl), session.ExpiresAt);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_DropsTheSteamTokenOnSuccess()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        Assert.Null(session!.SteamToken);
+        Assert.Equal(76561198249527954UL, session.SteamId);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_PublishesCredentialsWithSteamIdAsString()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        var events = await EventsOfAsync(session!);
+        var payload = Assert.IsType<CredentialsPayload>(
+            Assert.Single(events, e => e.Type == "credentials").Data);
+
+        Assert.Equal("76561198249527954", payload.SteamId);
+        Assert.Contains("ExponentPushToken", payload.ConfigJson, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_RecordsACompletionForTheAddress()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Options.MaxCompletionsPerIpPerHour = 1;
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+        h.Store.Remove(session!.SessionId);
+
+        Assert.False(h.Store.TryCreate("203.0.113.7", out _, out var failure));
+        Assert.Equal(SessionCreateFailure.HourlyLimit, failure);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_FailsWhenDeviceRegistrationThrows()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Steps.AcquireFailure = new HttpRequestException("upstream down");
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        Assert.Equal(SessionState.Failed, session!.State);
+        Assert.Null(session.SteamToken);
+
+        var events = await EventsOfAsync(session);
+        var error = Assert.IsType<ErrorPayload>(Assert.Single(events, e => e.Type == "error").Data);
+        Assert.DoesNotContain("upstream down", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_FailsWhenCompanionRegistrationThrows()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Steps.CompanionFailure = new HttpRequestException("rejected");
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        Assert.Equal(SessionState.Failed, session!.State);
+        Assert.Null(session.SteamToken);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_FailsWhenExpoTokenIsMissing()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Steps.CredentialsToReturn = new RustPlusApi.Fcm.Data.Credentials { ExpoPushToken = null };
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        Assert.Equal(SessionState.Failed, session!.State);
+        Assert.DoesNotContain(nameof(FakeRegistrationSteps.RegisterWithCompanionAsync), h.Steps.Calls);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_StaysQuietWhenCancelled()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Steps.AcquireFailure = new OperationCanceledException();
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        var events = await EventsOfAsync(session!);
+        Assert.DoesNotContain(events, e => e.Type == "error");
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~CredentialFlowTests"`
+Expected: FAIL — `CredentialFlow` and `IRegistrationSteps` do not exist.
+
+- [ ] **Step 4: Write the upstream seam**
+
+`apps/RustPlusApi.CredentialsWeb/Upstream/IRegistrationSteps.cs`:
+
+```csharp
+using RustPlusApi.Fcm.Data;
+using RustPlusApi.Fcm.Registration;
+
+namespace RustPlusApi.CredentialsWeb.Upstream;
+
+/// <summary>The app's seam over the four live-network classes in RustPlusApi.Fcm.Registration, so the
+/// flow can be tested without reaching Google, Expo or Facepunch.</summary>
+internal interface IRegistrationSteps
+{
+    /// <summary>Steps 1-3: GCM check-in, Firebase install, FCM register, Expo token.</summary>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    Task<Credentials> AcquireDeviceCredentialsAsync(CancellationToken cancellationToken);
+
+    /// <summary>Step 5: register the device's Expo token with Rust Companion.</summary>
+    /// <param name="steamToken">The Steam auth token from the Facepunch callback.</param>
+    /// <param name="expoPushToken">The Expo token from <see cref="AcquireDeviceCredentialsAsync"/>.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    Task RegisterWithCompanionAsync(string steamToken, string expoPushToken, CancellationToken cancellationToken);
+
+    /// <summary>Step 6: hold an MCS socket until an in-game pairing push arrives.</summary>
+    /// <param name="credentials">Credentials from <see cref="AcquireDeviceCredentialsAsync"/>.</param>
+    /// <param name="cancellationToken">Token to cancel the wait.</param>
+    Task<ServerPairing> WaitForPairingAsync(Credentials credentials, CancellationToken cancellationToken);
+}
+```
+
+`apps/RustPlusApi.CredentialsWeb/Upstream/LiveRegistrationSteps.cs`:
+
+```csharp
+using RustPlusApi.Fcm.Data;
+using RustPlusApi.Fcm.Registration;
+using RustPlusApi.Fcm.Registration.Steps;
+using System.Diagnostics.CodeAnalysis;
+
+namespace RustPlusApi.CredentialsWeb.Upstream;
+
+/// <summary>The real implementation, delegating to RustPlusApi.Fcm.Registration.</summary>
+/// <param name="httpClientFactory">Source of clients. A factory rather than a captured
+/// <see cref="HttpClient"/> because this type is a singleton, and a singleton-held client never
+/// picks up DNS changes.</param>
+/// <param name="loggerFactory">Passed to <see cref="PairingListener"/> so its skip paths are visible.</param>
+[ExcludeFromCodeCoverage(Justification =
+    "Live-network seam: every member drives Google, Expo, Facepunch or the MCS socket and cannot be "
+    + "validated offline. All logic above it is tested against IRegistrationSteps.")]
+internal sealed class LiveRegistrationSteps(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory)
+    : IRegistrationSteps
+{
+    /// <summary>Named client used for every upstream call.</summary>
+    internal const string HttpClientName = "upstream";
+
+    /// <inheritdoc/>
+    public async Task<Credentials> AcquireDeviceCredentialsAsync(CancellationToken cancellationToken)
+    {
+        var client = httpClientFactory.CreateClient(HttpClientName);
+        var (gcm, fcmToken) = await new AndroidFcmRegister(client)
+            .RegisterAsync(cancellationToken).ConfigureAwait(false);
+        var expoToken = await new ExpoPushClient(client)
+            .GetTokenAsync(fcmToken, cancellationToken).ConfigureAwait(false);
+
+        return new Credentials
+        {
+            Gcm = gcm,
+            Fcm = new FcmToken { Token = fcmToken },
+            ExpoPushToken = expoToken
+        };
+    }
+
+    /// <inheritdoc/>
+    public Task RegisterWithCompanionAsync(
+        string steamToken,
+        string expoPushToken,
+        CancellationToken cancellationToken) =>
+        new RustCompanionClient(httpClientFactory.CreateClient(HttpClientName))
+            .RegisterAsync(steamToken, expoPushToken, cancellationToken: cancellationToken);
+
+    /// <inheritdoc/>
+    public async Task<ServerPairing> WaitForPairingAsync(
+        Credentials credentials,
+        CancellationToken cancellationToken)
+    {
+        using var listener = new PairingListener(
+            credentials,
+            loggerFactory: loggerFactory,
+            httpClient: httpClientFactory.CreateClient(HttpClientName));
+
+        return await listener.WaitForServerPairingAsync(cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+- [ ] **Step 5: Write CredentialFlow**
+
+Two rules encoded here are load-bearing. The Steam token is dropped the instant step 5 returns, whether it succeeded or threw. And the `error` event carries a fixed message per step, never `ex.Message` — an upstream exception can embed response content, and that content reaches the browser.
+
+`apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs`:
+
+```csharp
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.CredentialsWeb.Upstream;
+using RustPlusApi.Fcm.Registration;
+using System.Globalization;
+
+namespace RustPlusApi.CredentialsWeb.Flow;
+
+/// <summary>Drives the credential flow in the order 4 → 1,2,3 → 5, so that a real Steam login gates
+/// every upstream call. An unauthenticated visitor costs one dictionary entry and nothing else.</summary>
+/// <param name="steps">The upstream seam.</param>
+/// <param name="store">The session registry, for completion accounting and pairing slots.</param>
+/// <param name="options">TTLs and caps.</param>
+/// <param name="timeProvider">Clock.</param>
+/// <param name="logger">Diagnostics. Never receives a secret.</param>
+internal sealed class CredentialFlow(
+    IRegistrationSteps steps,
+    SessionStore store,
+    AppOptions options,
+    TimeProvider timeProvider,
+    ILogger<CredentialFlow> logger)
+{
+    /// <summary>Runs steps 1-3 then 5 for a session whose Steam login has just landed.</summary>
+    /// <param name="session">The session the callback belonged to.</param>
+    /// <param name="login">The parsed callback result.</param>
+    /// <param name="cancellationToken">Token to cancel the flow.</param>
+    internal async Task CompleteRegistrationAsync(
+        Session session,
+        SteamLoginResult login,
+        CancellationToken cancellationToken)
+    {
+        session.SetSteamLogin(login);
+        session.Advance(SessionState.Authenticated, Deadline(options.SessionTtl));
+        session.Advance(SessionState.Registering, Deadline(options.SessionTtl));
+
+        var step = "device registration";
+
+        try
+        {
+            var credentials = await steps.AcquireDeviceCredentialsAsync(cancellationToken).ConfigureAwait(false);
+
+            // Pattern rather than string.IsNullOrEmpty so the compiler sees the non-null narrowing.
+            if (credentials.ExpoPushToken is not { Length: > 0 })
+            {
+                throw new InvalidOperationException("Device registration returned no Expo push token.");
+            }
+
+            step = "Rust Companion registration";
+            var steamToken = session.SteamToken
+                ?? throw new InvalidOperationException("The session carries no Steam token.");
+
+            await steps.RegisterWithCompanionAsync(steamToken, credentials.ExpoPushToken, cancellationToken)
+                .ConfigureAwait(false);
+
+            session.ClearSteamToken();
+            session.SetCredentials(credentials);
+            store.RecordCompletion(session.ClientIp);
+            session.Advance(SessionState.Ready, Deadline(options.SessionTtl));
+
+            session.Events.Publish(new SessionEvent("credentials", new CredentialsPayload(
+                session.SteamId.ToString(CultureInfo.InvariantCulture),
+                CredentialsStore.Serialize(credentials))));
+        }
+        catch (OperationCanceledException)
+        {
+            // The session was disposed or the host is shutting down. Nothing to report.
+            session.ClearSteamToken();
+        }
+#pragma warning disable CA1031 // Any upstream failure must land the session in Failed rather than crash the host.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            session.ClearSteamToken();
+            logger.LogError(ex, "Credential flow failed during {Step} for session {SessionId}.",
+                step, session.SessionId);
+
+            session.Advance(SessionState.Failed, Deadline(options.SessionTtl));
+            session.Events.Publish(new SessionEvent("error", new ErrorPayload(
+                $"Something went wrong during {step}. Start over — nothing was saved.")));
+        }
+    }
+
+    /// <summary>Now plus <paramref name="ttl"/>, from the injected clock.</summary>
+    /// <param name="ttl">How long the session should live from now.</param>
+    private DateTimeOffset Deadline(TimeSpan ttl) => timeProvider.GetUtcNow().Add(ttl);
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~CredentialFlowTests"`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/RustPlusApi.CredentialsWeb/Upstream/ apps/RustPlusApi.CredentialsWeb/Flow/ tests/RustPlusApi.CredentialsWeb.UnitTests/FakeRegistrationSteps.cs tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowTests.cs
+git commit -m "feat(web): run the credential flow Steam-first behind a testable upstream seam"
+```
+
+---
+
+### Task 8: The pairing continuation
+
+Step 6, the opt-in half. This is the only path that holds a socket, so it is also the only path that takes a pairing slot — and it must release that slot on every exit, including cancellation.
+
+**Files:**
+- Modify: `apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs`
+- Test: `tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowPairingTests.cs`
+
+**Interfaces:**
+- Consumes: everything from Task 7.
+- Produces, added to `CredentialFlow`: `internal Task WaitForPairingAsync(Session session, CancellationToken cancellationToken)`. Assumes the caller already holds a pairing slot from `SessionStore.TryAcquirePairingSlot` and releases it before returning.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowPairingTests.cs`:
+
+```csharp
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using RustPlusApi.CredentialsWeb;
+using RustPlusApi.CredentialsWeb.Flow;
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.Fcm.Registration;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class CredentialFlowPairingTests
+{
+    private static readonly DateTimeOffset Origin = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    private static async Task<(CredentialFlow Flow, SessionStore Store, FakeRegistrationSteps Steps, Session Session)>
+        ReadySessionAsync(Action<AppOptions>? configure = null)
+    {
+        var time = new FakeTimeProvider(Origin);
+        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        configure?.Invoke(options);
+        var store = new SessionStore(options, time);
+        var steps = new FakeRegistrationSteps();
+        var flow = new CredentialFlow(steps, store, options, time, NullLogger<CredentialFlow>.Instance);
+
+        store.TryCreate("203.0.113.7", out var session, out _);
+        await flow.CompleteRegistrationAsync(
+            session!,
+            new SteamLoginResult { SteamId = 76561198249527954, Token = "steam-token" },
+            CancellationToken.None);
+
+        steps.Calls.Clear();
+        return (flow, store, steps, session!);
+    }
+
+    /// <summary>Drains the buffered events; the short window is what ends the open-ended stream.</summary>
+    private static async Task<List<SessionEvent>> EventsOfAsync(Session session)
+    {
+        var received = new List<SessionEvent>();
+        using var window = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        try
+        {
+            await foreach (var item in session.Events.SubscribeAsync(window.Token))
+            {
+                received.Add(item);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected: the window closed.
+        }
+
+        return received;
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_ReachesPairedAndPublishesTheFourValues()
+    {
+        var (flow, store, _, session) = await ReadySessionAsync();
+        using var _s = store;
+        store.TryAcquirePairingSlot();
+
+        await flow.WaitForPairingAsync(session, CancellationToken.None);
+
+        Assert.Equal(SessionState.Paired, session.State);
+
+        var events = await EventsOfAsync(session);
+        var payload = Assert.IsType<PairedPayload>(Assert.Single(events, e => e.Type == "paired").Data);
+
+        Assert.Equal("10.0.0.1", payload.Ip);
+        Assert.Equal(28082, payload.Port);
+        Assert.Equal("76561198249527954", payload.PlayerId);
+        Assert.Equal(987654321, payload.PlayerToken);
+        Assert.Equal("Test Server", payload.Name);
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_ReleasesThePairingSlotOnSuccess()
+    {
+        var (flow, store, _, session) = await ReadySessionAsync();
+        using var _s = store;
+        store.TryAcquirePairingSlot();
+
+        await flow.WaitForPairingAsync(session, CancellationToken.None);
+
+        Assert.Equal(0, store.ActivePairings);
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_MovesToAwaitingPairingWithThePairingTtl()
+    {
+        var (flow, store, steps, session) = await ReadySessionAsync(o => o.PairingTtl = TimeSpan.FromMinutes(10));
+        using var _s = store;
+        steps.PairingWaitsForGate = true;
+        store.TryAcquirePairingSlot();
+
+        var pending = flow.WaitForPairingAsync(session, CancellationToken.None);
+        while (session.State != SessionState.AwaitingPairing)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.Equal(Origin.AddMinutes(10), session.ExpiresAt);
+
+        steps.PairingGate.SetResult();
+        await pending;
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_ReleasesTheSlotWhenTheWaitFails()
+    {
+        var (flow, store, steps, session) = await ReadySessionAsync();
+        using var _s = store;
+        steps.PairingFailure = new InvalidOperationException("socket died");
+        store.TryAcquirePairingSlot();
+
+        await flow.WaitForPairingAsync(session, CancellationToken.None);
+
+        Assert.Equal(0, store.ActivePairings);
+        Assert.Equal(SessionState.Failed, session.State);
+
+        var events = await EventsOfAsync(session);
+        var error = Assert.IsType<ErrorPayload>(Assert.Single(events, e => e.Type == "error").Data);
+        Assert.DoesNotContain("socket died", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_ReturnsToReadyAndReleasesTheSlotWhenCancelled()
+    {
+        var (flow, store, steps, session) = await ReadySessionAsync();
+        using var _s = store;
+        steps.PairingWaitsForGate = true;
+        store.TryAcquirePairingSlot();
+
+        using var cancellation = new CancellationTokenSource();
+        var pending = flow.WaitForPairingAsync(session, cancellation.Token);
+        while (session.State != SessionState.AwaitingPairing)
+        {
+            await Task.Delay(10);
+        }
+
+        await cancellation.CancelAsync();
+        await pending;
+
+        Assert.Equal(0, store.ActivePairings);
+        Assert.Equal(SessionState.Ready, session.State);
+
+        var events = await EventsOfAsync(session);
+        Assert.Contains(events, e => e.Type == "expired");
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_CanBeRetriedAfterATimeout()
+    {
+        var (flow, store, steps, session) = await ReadySessionAsync();
+        using var _s = store;
+        steps.PairingWaitsForGate = true;
+        store.TryAcquirePairingSlot();
+
+        using var cancellation = new CancellationTokenSource();
+        var pending = flow.WaitForPairingAsync(session, cancellation.Token);
+        while (session.State != SessionState.AwaitingPairing)
+        {
+            await Task.Delay(10);
+        }
+
+        await cancellation.CancelAsync();
+        await pending;
+
+        // The second attempt must be accepted: this is what the "retry without redoing the Steam
+        // login" promise actually depends on.
+        steps.PairingWaitsForGate = false;
+        Assert.True(store.TryAcquirePairingSlot());
+        await flow.WaitForPairingAsync(session, CancellationToken.None);
+
+        Assert.Equal(SessionState.Paired, session.State);
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_RefusesWhenTheSessionIsNotReady()
+    {
+        var (flow, store, steps, session) = await ReadySessionAsync();
+        using var _s = store;
+        session.Advance(SessionState.Failed, Origin.AddMinutes(15));
+        store.TryAcquirePairingSlot();
+
+        await flow.WaitForPairingAsync(session, CancellationToken.None);
+
+        Assert.Empty(steps.Calls);
+        Assert.Equal(0, store.ActivePairings);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~CredentialFlowPairingTests"`
+Expected: FAIL — `CredentialFlow.WaitForPairingAsync` does not exist.
+
+- [ ] **Step 3: Add WaitForPairingAsync to CredentialFlow**
+
+The `finally` is the point of the method: a slot leaked here permanently shrinks the instance's pairing capacity, and nothing would ever report it.
+
+```csharp
+    /// <summary>Step 6: hold an MCS socket until a pairing push arrives, the TTL runs out, or the
+    /// session is disposed. The caller must already hold a pairing slot; this method always
+    /// releases it.</summary>
+    /// <param name="session">A session in <see cref="SessionState.Ready"/>.</param>
+    /// <param name="cancellationToken">Token to abandon the wait.</param>
+    internal async Task WaitForPairingAsync(Session session, CancellationToken cancellationToken)
+    {
+        if (session.State != SessionState.Ready || session.Credentials is not { } credentials)
+        {
+            store.ReleasePairingSlot();
+            return;
+        }
+
+        session.Advance(SessionState.AwaitingPairing, Deadline(options.PairingTtl));
+
+        try
+        {
+            var pairing = await steps.WaitForPairingAsync(credentials, cancellationToken).ConfigureAwait(false);
+
+            session.SetPairing(pairing);
+            session.Advance(SessionState.Paired, Deadline(options.SessionTtl));
+            session.Events.Publish(new SessionEvent("paired", new PairedPayload(
+                pairing.Ip,
+                pairing.Port,
+                pairing.PlayerId.ToString(CultureInfo.InvariantCulture),
+                pairing.PlayerToken,
+                pairing.Name)));
+        }
+        catch (OperationCanceledException)
+        {
+            // Back to Ready, not a terminal state: the credentials are still good, so the visitor
+            // can start another pairing wait without repeating the Steam login.
+            session.Advance(SessionState.Ready, Deadline(options.SessionTtl));
+            session.Events.Publish(new SessionEvent("expired", null));
+        }
+#pragma warning disable CA1031 // A failed socket must land the session in Failed rather than crash the host.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            logger.LogError(ex, "Pairing wait failed for session {SessionId}.", session.SessionId);
+            session.Advance(SessionState.Failed, Deadline(options.SessionTtl));
+            session.Events.Publish(new SessionEvent("error", new ErrorPayload(
+                "The pairing listener stopped unexpectedly. Your credentials are still valid — "
+                + "try the pairing step again.")));
+        }
+        finally
+        {
+            // A leaked slot permanently shrinks this instance's pairing capacity and nothing reports it.
+            store.ReleasePairingSlot();
+        }
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~CredentialFlowPairing"`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Run the whole suite so far**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests`
+Expected: PASS, all tests from Tasks 1-8.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/RustPlusApi.CredentialsWeb/Flow/CredentialFlow.cs tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowPairingTests.cs
+git commit -m "feat(web): add the opt-in pairing continuation with slot accounting"
+```
+
+---
+
+### Task 9: Session creation endpoint and host wiring
+
+The first endpoint, plus the DI graph everything else hangs off. This is also where the reverse-proxy trap gets closed: without `ForwardedHeaders`, every visitor behind a proxy presents as the proxy and shares one per-IP bucket.
+
+**Files:**
+- Modify: `apps/RustPlusApi.CredentialsWeb/Program.cs`
+- Create: `apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs`
+- Create: `apps/RustPlusApi.CredentialsWeb/Endpoints/ClientAddress.cs`
+- Create: `tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialsWebFactory.cs`
+- Create: `tests/RustPlusApi.CredentialsWeb.UnitTests/AssemblyInfo.cs`
+- Test: `tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEndpointTests.cs`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-8.
+- Produces:
+  - `internal sealed record CreateSessionResponse(string SessionId, string LoginUrl)` — serialized as `{"sessionId":…,"loginUrl":…}`.
+  - `internal static class ClientAddress` with `internal static string Of(HttpContext context)`.
+  - `internal static class SessionEndpoints` with `internal static void MapSessionEndpoints(this IEndpointRouteBuilder app)`.
+  - Test harness `CredentialsWebFactory : WebApplicationFactory<Program>` exposing `Steps` (a `FakeRegistrationSteps`) and `Time` (a `FakeTimeProvider`).
+
+- [ ] **Step 1: Write the test harness**
+
+Configuration is read in `Program.cs` *before* `builder.Build()`, and `WebApplicationFactory`'s configuration hooks only apply during `Build()`. Environment variables are therefore the only way to inject settings that the pre-`Build()` validation will see.
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialsWebFactory.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Time.Testing;
+using RustPlusApi.CredentialsWeb.Upstream;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+/// <summary>Boots the real app with the upstream seam and the clock replaced.</summary>
+internal sealed class CredentialsWebFactory : WebApplicationFactory<Program>
+{
+    internal const string BaseUrl = "https://creds.example.org";
+
+    private static readonly DateTimeOffset Origin = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    internal CredentialsWebFactory(IDictionary<string, string>? settings = null)
+    {
+        // Program.cs binds configuration before builder.Build(), which is earlier than any
+        // WebApplicationFactory configuration hook runs — so these must be environment variables.
+        SetEnvironment("CredentialsWeb__PublicBaseUrl", BaseUrl);
+        foreach (var (key, value) in settings ?? new Dictionary<string, string>())
+        {
+            SetEnvironment(key, value);
+        }
+    }
+
+    internal FakeRegistrationSteps Steps { get; } = new();
+
+    internal FakeTimeProvider Time { get; } = new(Origin);
+
+    private List<string> EnvironmentKeys { get; } = [];
+
+    /// <inheritdoc/>
+    protected override void ConfigureWebHost(IWebHostBuilder builder) =>
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<IRegistrationSteps>();
+            services.AddSingleton<IRegistrationSteps>(Steps);
+            services.RemoveAll<TimeProvider>();
+            services.AddSingleton<TimeProvider>(Time);
+        });
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            foreach (var key in EnvironmentKeys)
+            {
+                Environment.SetEnvironmentVariable(key, null);
+            }
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void SetEnvironment(string key, string value)
+    {
+        Environment.SetEnvironmentVariable(key, value);
+        EnvironmentKeys.Add(key);
+    }
+}
+```
+
+- [ ] **Step 1b: Disable test parallelization**
+
+`CredentialsWebFactory` sets **process-global** environment variables, because that is the only
+channel `Program.cs` reads before `builder.Build()`. xUnit runs test classes in parallel by
+default, so two factories with different settings would clobber each other and the endpoint tests
+would fail intermittently and unreproducibly. Serialize the assembly.
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/AssemblyInfo.cs`:
+
+```csharp
+using Xunit;
+
+// CredentialsWebFactory configures the app through process-global environment variables — the only
+// channel Program.cs reads before builder.Build(), which is earlier than any WebApplicationFactory
+// hook runs. Parallel classes would overwrite each other's settings, so the assembly runs serially.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEndpointTests.cs`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using RustPlusApi.CredentialsWeb.Endpoints;
+using RustPlusApi.CredentialsWeb.Sessions;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SessionEndpointTests
+{
+    [Fact]
+    public async Task CreateSession_ReturnsSessionIdAndFacepunchLoginUrl()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadFromJsonAsync<CreateSessionResponse>();
+
+        Assert.NotNull(body);
+        Assert.Matches("^[0-9a-f]{32}$", body.SessionId);
+        Assert.StartsWith(
+            "https://companion-rust.facepunch.com/login?returnUrl=",
+            body.LoginUrl,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            Uri.EscapeDataString($"{CredentialsWebFactory.BaseUrl}/callback/"),
+            body.LoginUrl,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CreateSession_ReturnsADifferentReturnTokenEachTime()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+
+        var first = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+        var firstBody = await first.Content.ReadFromJsonAsync<CreateSessionResponse>();
+        var second = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+        var secondBody = await second.Content.ReadFromJsonAsync<CreateSessionResponse>();
+
+        Assert.NotEqual(firstBody!.LoginUrl, secondBody!.LoginUrl);
+    }
+
+    [Fact]
+    public async Task CreateSession_TheLoginUrlNeverCarriesTheSessionId()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+        var body = await response.Content.ReadFromJsonAsync<CreateSessionResponse>();
+
+        Assert.DoesNotContain(body!.SessionId, body.LoginUrl, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CreateSession_EvictsThisAddressesAbandonedCreatedSession()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var store = factory.Services.GetRequiredService<SessionStore>();
+
+        var first = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+        var firstBody = await first.Content.ReadFromJsonAsync<CreateSessionResponse>();
+
+        var second = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+        second.EnsureSuccessStatusCode();
+
+        Assert.False(store.TryGet(firstBody!.SessionId, out _));
+        Assert.Equal(1, store.Count);
+    }
+
+    [Fact]
+    public async Task CreateSession_Returns429WithASelfHostPointer_WhenTheGlobalCapIsFull()
+    {
+        using var factory = new CredentialsWebFactory(
+            new Dictionary<string, string> { ["CredentialsWeb__MaxConcurrentSessions"] = "1" });
+        using var client = factory.CreateClient();
+
+        // Occupy the only slot from a different address, and move it out of Created so the
+        // eviction rule cannot reclaim it.
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryCreate("198.51.100.1", out var occupant, out _);
+        occupant!.Advance(SessionState.Authenticated, factory.Time.GetUtcNow().AddMinutes(15));
+
+        var response = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("docker run", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Responses_CarryTheSecurityHeaders()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+
+        Assert.Equal("no-referrer", response.Headers.GetValues("Referrer-Policy").Single());
+        Assert.Equal("nosniff", response.Headers.GetValues("X-Content-Type-Options").Single());
+        Assert.Contains("no-store", response.Headers.CacheControl!.ToString(), StringComparison.Ordinal);
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~SessionEndpointTests"`
+Expected: FAIL — 404 for `/api/sessions`, and `CreateSessionResponse` does not exist.
+
+- [ ] **Step 4: Write ClientAddress**
+
+`apps/RustPlusApi.CredentialsWeb/Endpoints/ClientAddress.cs`:
+
+```csharp
+namespace RustPlusApi.CredentialsWeb.Endpoints;
+
+/// <summary>Resolves the caller's address for per-IP accounting.</summary>
+internal static class ClientAddress
+{
+    /// <summary>The remote address, already rewritten by the forwarded-headers middleware when the
+    /// instance is configured with known proxies. Falls back to a constant so accounting still
+    /// happens (conservatively, as one shared bucket) rather than silently disappearing.</summary>
+    /// <param name="context">The current request.</param>
+    internal static string Of(HttpContext context) =>
+        context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+}
+```
+
+- [ ] **Step 5: Write SessionEndpoints**
+
+`apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs`:
+
+```csharp
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.Fcm.Registration.Steps;
+
+namespace RustPlusApi.CredentialsWeb.Endpoints;
+
+/// <summary>What the browser needs to start a flow.</summary>
+/// <param name="SessionId">The handle for the event stream and follow-up calls.</param>
+/// <param name="LoginUrl">The Facepunch login URL to send the visitor to.</param>
+internal sealed record CreateSessionResponse(string SessionId, string LoginUrl);
+
+/// <summary>Session lifecycle endpoints.</summary>
+internal static class SessionEndpoints
+{
+    private const string OverCapacityMessage =
+        "This instance is at capacity. Try again in a few minutes — or run your own: "
+        + "docker run -p 8080:8080 ghcr.io/handys11/rustplusapi-credentials";
+
+    /// <summary>Maps <c>POST /api/sessions</c>.</summary>
+    /// <param name="app">The route builder.</param>
+    internal static void MapSessionEndpoints(this IEndpointRouteBuilder app) =>
+        app.MapPost("/api/sessions", (HttpContext context, SessionStore store, AppOptions options) =>
+        {
+            if (!store.TryCreate(ClientAddress.Of(context), out var session, out _))
+            {
+                return Results.Json(new ErrorPayload(OverCapacityMessage), statusCode: 429);
+            }
+
+            var returnUrl = $"{options.PublicBaseUrl}/callback/{session.ReturnToken}";
+            return Results.Ok(new CreateSessionResponse(
+                session.SessionId,
+                SteamLoginService.BuildLoginUrl(returnUrl)));
+        });
+}
+```
+
+- [ ] **Step 6: Write the security headers middleware**
+
+`apps/RustPlusApi.CredentialsWeb/Security/SecurityHeaders.cs`:
+
+```csharp
+namespace RustPlusApi.CredentialsWeb.Security;
+
+/// <summary>Response headers that back the page's trust claims: no referrer leakage, no caching of
+/// anything that carries a credential, and a content policy admitting no third-party origin — which
+/// is also what keeps the client a single auditable file.</summary>
+internal static class SecurityHeaders
+{
+    private const string ContentSecurityPolicy =
+        "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; "
+        + "connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'";
+
+    /// <summary>Adds the headers to every response.</summary>
+    /// <param name="app">The application pipeline.</param>
+    internal static void UseSecurityHeaders(this IApplicationBuilder app) =>
+        app.Use(async (context, next) =>
+        {
+            context.Response.OnStarting(() =>
+            {
+                var headers = context.Response.Headers;
+                headers.ContentSecurityPolicy = ContentSecurityPolicy;
+                headers["Referrer-Policy"] = "no-referrer";
+                headers.XContentTypeOptions = "nosniff";
+                headers.CacheControl = "no-store";
+                return Task.CompletedTask;
+            });
+
+            await next(context).ConfigureAwait(false);
+        });
+}
+```
+
+- [ ] **Step 7: Wire up Program.cs**
+
+Replace the body of `Program.cs` between `builder.Services.AddSingleton(options);` and `await app.RunAsync();`:
+
+```csharp
+builder.Services.AddSingleton(options);
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<SessionStore>();
+builder.Services.AddSingleton<CredentialFlow>();
+builder.Services.AddHostedService<SessionSweeper>();
+builder.Services.AddHttpClient(LiveRegistrationSteps.HttpClientName);
+builder.Services.AddSingleton<IRegistrationSteps>(serviceProvider => new LiveRegistrationSteps(
+    serviceProvider.GetRequiredService<IHttpClientFactory>(),
+    serviceProvider.GetRequiredService<ILoggerFactory>()));
+
+// Without this, every visitor behind a reverse proxy presents as the proxy and shares one per-IP
+// bucket, silently voiding the caps. Configured too loosely it is worse: trusting X-Forwarded-For
+// from anyone lets a caller spoof their way past the limits. So the operator must name their proxy
+// explicitly, and with none named the headers are ignored.
+builder.Services.Configure<ForwardedHeadersOptions>(forwarded =>
+{
+    forwarded.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    foreach (var proxy in options.KnownProxies)
+    {
+        forwarded.KnownProxies.Add(IPAddress.Parse(proxy));
+    }
+});
+
+var app = builder.Build();
+
+app.UseForwardedHeaders();
+app.UseSecurityHeaders();
+app.UseDefaultFiles();
+app.UseStaticFiles();
+
+app.MapSessionEndpoints();
+
+await app.RunAsync();
+return 0;
+```
+
+Add the usings at the top of `Program.cs`:
+
+```csharp
+using Microsoft.AspNetCore.HttpOverrides;
+using System.Net;
+using RustPlusApi.CredentialsWeb;
+using RustPlusApi.CredentialsWeb.Endpoints;
+using RustPlusApi.CredentialsWeb.Flow;
+using RustPlusApi.CredentialsWeb.Security;
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.CredentialsWeb.Upstream;
+using System.Diagnostics.CodeAnalysis;
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~SessionEndpointTests"`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/RustPlusApi.CredentialsWeb/ tests/RustPlusApi.CredentialsWeb.UnitTests/
+git commit -m "feat(web): add session creation endpoint, DI wiring and security headers"
+```
+
+---
+
+### Task 10: The Facepunch callback endpoint
+
+The security-critical route. Three things must hold: the response is a 302 so no history entry carries the token, the redirect target puts the session handle in a fragment so it never reaches a server log, and a replayed callback URL finds nothing.
+
+**Files:**
+- Create: `apps/RustPlusApi.CredentialsWeb/Endpoints/CallbackEndpoints.cs`
+- Modify: `apps/RustPlusApi.CredentialsWeb/Program.cs`
+- Test: `tests/RustPlusApi.CredentialsWeb.UnitTests/CallbackEndpointTests.cs`
+
+**Interfaces:**
+- Consumes: `SessionStore`, `CredentialFlow`, `AppOptions`.
+- Produces: `internal static class CallbackEndpoints` with `internal static void MapCallbackEndpoints(this IEndpointRouteBuilder app)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/CallbackEndpointTests.cs`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using RustPlusApi.CredentialsWeb.Sessions;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class CallbackEndpointTests
+{
+    private static HttpClient NoRedirectClient(CredentialsWebFactory factory) =>
+        factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+    private static Session NewSession(CredentialsWebFactory factory)
+    {
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryCreate("203.0.113.7", out var session, out _);
+        return session!;
+    }
+
+    private static Uri CallbackUri(string returnToken) =>
+        new($"/callback/{returnToken}?steamId=76561198249527954&token=steam-token", UriKind.Relative);
+
+    [Fact]
+    public async Task Callback_Redirects302ToTheFragmentCarryingTheSessionId()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = NoRedirectClient(factory);
+        var session = NewSession(factory);
+
+        var response = await client.GetAsync(CallbackUri(session.ReturnToken));
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Equal($"/#session={session.SessionId}", response.Headers.Location!.ToString());
+    }
+
+    [Fact]
+    public async Task Callback_DrivesTheFlowToReady()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = NoRedirectClient(factory);
+        var session = NewSession(factory);
+
+        await client.GetAsync(CallbackUri(session.ReturnToken));
+        await session.BackgroundWork;
+
+        Assert.Equal(SessionState.Ready, session.State);
+        Assert.Equal("steam-token", factory.Steps.SteamTokenSeen);
+        Assert.Null(session.SteamToken);
+    }
+
+    [Fact]
+    public async Task Callback_Returns404_ForAnUnknownReturnToken()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = NoRedirectClient(factory);
+
+        var response = await client.GetAsync(CallbackUri("0123456789abcdef0123456789abcdef"));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Callback_Returns404_WhenReplayed()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = NoRedirectClient(factory);
+        var session = NewSession(factory);
+
+        var first = await client.GetAsync(CallbackUri(session.ReturnToken));
+        var second = await client.GetAsync(CallbackUri(session.ReturnToken));
+
+        Assert.Equal(HttpStatusCode.Found, first.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, second.StatusCode);
+    }
+
+    [Fact]
+    public async Task Callback_WithNoToken_FailsTheSessionButStillRedirects()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = NoRedirectClient(factory);
+        var session = NewSession(factory);
+
+        var response = await client.GetAsync(
+            new Uri($"/callback/{session.ReturnToken}?steamId=76561198249527954", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Equal($"/#session={session.SessionId}", response.Headers.Location!.ToString());
+        Assert.Equal(SessionState.Failed, session.State);
+        Assert.Empty(factory.Steps.Calls);
+    }
+
+    [Fact]
+    public async Task Callback_WithANonNumericSteamId_FailsTheSession()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = NoRedirectClient(factory);
+        var session = NewSession(factory);
+
+        await client.GetAsync(
+            new Uri($"/callback/{session.ReturnToken}?steamId=not-a-number&token=steam-token", UriKind.Relative));
+
+        Assert.Equal(SessionState.Failed, session.State);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~CallbackEndpointTests"`
+Expected: FAIL — 404 for every case, because the route does not exist.
+
+- [ ] **Step 3: Write CallbackEndpoints**
+
+`apps/RustPlusApi.CredentialsWeb/Endpoints/CallbackEndpoints.cs`:
+
+```csharp
+using RustPlusApi.CredentialsWeb.Flow;
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.Fcm.Registration.Steps;
+
+namespace RustPlusApi.CredentialsWeb.Endpoints;
+
+/// <summary>The Facepunch redirect target.</summary>
+internal static class CallbackEndpoints
+{
+    /// <summary>Maps <c>GET /callback/{returnToken}</c>.</summary>
+    /// <param name="app">The route builder.</param>
+    internal static void MapCallbackEndpoints(this IEndpointRouteBuilder app) =>
+        app.MapGet("/callback/{returnToken}", (
+            string returnToken,
+            HttpContext context,
+            SessionStore store,
+            CredentialFlow flow,
+            AppOptions options) =>
+        {
+            // Single-use: a callback URL replayed from browser history finds nothing, and an
+            // unknown token is indistinguishable from a consumed one.
+            if (!store.TryConsumeReturnToken(returnToken, out var session))
+            {
+                return Results.NotFound();
+            }
+
+            // 302 rather than 200: a redirect leaves no back-button entry, so the token-bearing URL
+            // never becomes one. The session handle rides in the fragment, which browsers never send
+            // to a server and which therefore cannot reach an access log or a Referer header.
+            var redirect = Results.Redirect($"/#session={session.SessionId}");
+
+            try
+            {
+                var callbackUri = new Uri(
+                    options.PublicBaseUrl + context.Request.Path + context.Request.QueryString);
+                var login = SteamLoginService.ParseCallback(callbackUri);
+
+                session.BackgroundWork = flow.CompleteRegistrationAsync(
+                    session,
+                    login,
+                    session.Lifetime.Token);
+            }
+            catch (InvalidOperationException)
+            {
+                // ParseCallback rejects a callback with no usable token or steamId. The message is
+                // not surfaced: the page says the login did not complete and offers a restart.
+                session.Advance(SessionState.Failed, session.ExpiresAt);
+                session.Events.Publish(new SessionEvent("error", new ErrorPayload(
+                    "The Steam login didn't complete. Start over — nothing was saved.")));
+            }
+
+            return redirect;
+        });
+}
+```
+
+- [ ] **Step 4: Map it in Program.cs**
+
+Add below `app.MapSessionEndpoints();`:
+
+```csharp
+app.MapCallbackEndpoints();
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~CallbackEndpointTests"`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/RustPlusApi.CredentialsWeb/Endpoints/CallbackEndpoints.cs apps/RustPlusApi.CredentialsWeb/Program.cs tests/RustPlusApi.CredentialsWeb.UnitTests/CallbackEndpointTests.cs
+git commit -m "feat(web): handle the Facepunch callback with single-use tokens and a 302"
+```
+
+---
+
+### Task 11: The SSE endpoint
+
+**Files:**
+- Create: `apps/RustPlusApi.CredentialsWeb/Endpoints/EventEndpoints.cs`
+- Modify: `apps/RustPlusApi.CredentialsWeb/Program.cs`
+- Test: `tests/RustPlusApi.CredentialsWeb.UnitTests/EventEndpointTests.cs`
+
+**Interfaces:**
+- Consumes: `SessionStore`, `Session.Events`.
+- Produces: `internal static class EventEndpoints` with `internal static void MapEventEndpoints(this IEndpointRouteBuilder app)`. Wire format is standard SSE: `event: <type>\ndata: <json>\n\n`, camelCase JSON, `{}` when an event carries no payload.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/EventEndpointTests.cs`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using RustPlusApi.CredentialsWeb.Sessions;
+using System.Net;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class EventEndpointTests
+{
+    /// <summary>Reads SSE frames until <paramref name="count"/> <c>event:</c> lines have arrived.</summary>
+    private static async Task<List<string>> ReadEventNamesAsync(HttpClient client, string sessionId, int count)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var response = await client.GetAsync(
+            new Uri($"/api/sessions/{sessionId}/events", UriKind.Relative),
+            HttpCompletionOption.ResponseHeadersRead,
+            timeout.Token);
+
+        response.EnsureSuccessStatusCode();
+
+        var names = new List<string>();
+        await using var stream = await response.Content.ReadAsStreamAsync(timeout.Token);
+        using var reader = new StreamReader(stream);
+
+        while (names.Count < count)
+        {
+            var line = await reader.ReadLineAsync(timeout.Token);
+            if (line is null)
+            {
+                break;
+            }
+
+            if (line.StartsWith("event: ", StringComparison.Ordinal))
+            {
+                names.Add(line["event: ".Length..]);
+            }
+        }
+
+        return names;
+    }
+
+    private static Session NewSession(CredentialsWebFactory factory)
+    {
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryCreate("203.0.113.7", out var session, out _);
+        return session!;
+    }
+
+    [Fact]
+    public async Task Events_Returns404_ForAnUnknownSession()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(
+            new Uri("/api/sessions/0123456789abcdef0123456789abcdef/events", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Events_UsesTheEventStreamContentType()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var session = NewSession(factory);
+        session.Advance(SessionState.Authenticated, DateTimeOffset.MaxValue);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var response = await client.GetAsync(
+            new Uri($"/api/sessions/{session.SessionId}/events", UriKind.Relative),
+            HttpCompletionOption.ResponseHeadersRead,
+            timeout.Token);
+
+        Assert.Equal("text/event-stream", response.Content.Headers.ContentType!.MediaType);
+    }
+
+    [Fact]
+    public async Task Events_ReplaysEventsPublishedBeforeTheStreamOpened()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var session = NewSession(factory);
+        session.Advance(SessionState.Authenticated, DateTimeOffset.MaxValue);
+        session.Advance(SessionState.Registering, DateTimeOffset.MaxValue);
+
+        var names = await ReadEventNamesAsync(client, session.SessionId, 2);
+
+        Assert.Equal(["step", "step"], names);
+    }
+
+    [Fact]
+    public async Task Events_ReplaysTheSameHistoryToAReconnectingClient()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var session = NewSession(factory);
+        session.Advance(SessionState.Authenticated, DateTimeOffset.MaxValue);
+
+        var first = await ReadEventNamesAsync(client, session.SessionId, 1);
+        var second = await ReadEventNamesAsync(client, session.SessionId, 1);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public async Task Events_CarriesTheJsonPayload()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var session = NewSession(factory);
+        session.Advance(SessionState.Registering, DateTimeOffset.MaxValue);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var response = await client.GetAsync(
+            new Uri($"/api/sessions/{session.SessionId}/events", UriKind.Relative),
+            HttpCompletionOption.ResponseHeadersRead,
+            timeout.Token);
+
+        await using var stream = await response.Content.ReadAsStreamAsync(timeout.Token);
+        using var reader = new StreamReader(stream);
+
+        await reader.ReadLineAsync(timeout.Token);
+        var dataLine = await reader.ReadLineAsync(timeout.Token);
+
+        Assert.Equal("""data: {"state":"Registering"}""", dataLine);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~EventEndpointTests"`
+Expected: FAIL — the route does not exist.
+
+- [ ] **Step 3: Write EventEndpoints**
+
+`apps/RustPlusApi.CredentialsWeb/Endpoints/EventEndpoints.cs`:
+
+```csharp
+using RustPlusApi.CredentialsWeb.Sessions;
+using System.Text.Json;
+
+namespace RustPlusApi.CredentialsWeb.Endpoints;
+
+/// <summary>The server-to-client push channel. One-directional by design: the only thing the server
+/// ever tells the browser is where the flow has got to.</summary>
+internal static class EventEndpoints
+{
+    /// <summary>Maps <c>GET /api/sessions/{sessionId}/events</c>.</summary>
+    /// <param name="app">The route builder.</param>
+    internal static void MapEventEndpoints(this IEndpointRouteBuilder app) =>
+        app.MapGet("/api/sessions/{sessionId}/events", async (
+            string sessionId,
+            HttpContext context,
+            SessionStore store,
+            CancellationToken cancellationToken) =>
+        {
+            if (!store.TryGet(sessionId, out var session))
+            {
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                return;
+            }
+
+            context.Response.ContentType = "text/event-stream";
+            // Tells nginx not to buffer the stream; without it a proxy can hold events for minutes.
+            context.Response.Headers["X-Accel-Buffering"] = "no";
+            await context.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+            await foreach (var sessionEvent in session.Events
+                               .SubscribeAsync(cancellationToken)
+                               .ConfigureAwait(false))
+            {
+                var json = sessionEvent.Data is null
+                    ? "{}"
+                    : JsonSerializer.Serialize(sessionEvent.Data, JsonSerializerOptions.Web);
+
+                await context.Response
+                    .WriteAsync($"event: {sessionEvent.Type}\ndata: {json}\n\n", cancellationToken)
+                    .ConfigureAwait(false);
+                await context.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+        });
+}
+```
+
+- [ ] **Step 4: Map it in Program.cs**
+
+Add below `app.MapCallbackEndpoints();`:
+
+```csharp
+app.MapEventEndpoints();
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~EventEndpointTests"`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/RustPlusApi.CredentialsWeb/Endpoints/EventEndpoints.cs apps/RustPlusApi.CredentialsWeb/Program.cs tests/RustPlusApi.CredentialsWeb.UnitTests/EventEndpointTests.cs
+git commit -m "feat(web): stream session progress over server-sent events"
+```
+
+---
+
+### Task 12: The pairing endpoint
+
+**Files:**
+- Modify: `apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs`
+- Test: `tests/RustPlusApi.CredentialsWeb.UnitTests/PairingEndpointTests.cs`
+
+**Interfaces:**
+- Consumes: `SessionStore.TryAcquirePairingSlot`, `CredentialFlow.WaitForPairingAsync`.
+- Produces: `POST /api/sessions/{sessionId}/pairing` → 202 when started, 404 unknown session, 409 when the session is not `Ready`, 429 when the pairing cap is full.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/PairingEndpointTests.cs`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using RustPlusApi.CredentialsWeb.Sessions;
+using System.Net;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class PairingEndpointTests
+{
+    private static Uri PairingUri(string sessionId) =>
+        new($"/api/sessions/{sessionId}/pairing", UriKind.Relative);
+
+    /// <summary>Runs a session all the way to Ready through the real callback route.</summary>
+    private static async Task<Session> ReadySessionAsync(CredentialsWebFactory factory)
+    {
+        using var client = factory.CreateClient(
+            new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        await client.GetAsync(new Uri(
+            $"/callback/{session!.ReturnToken}?steamId=76561198249527954&token=steam-token",
+            UriKind.Relative));
+        await session.BackgroundWork;
+
+        factory.Steps.Calls.Clear();
+        return session;
+    }
+
+    [Fact]
+    public async Task Pairing_Returns404_ForAnUnknownSession()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(PairingUri("0123456789abcdef0123456789abcdef"), null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Pairing_Returns409_WhenTheSessionIsNotReady()
+    {
+        using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        var response = await client.PostAsync(PairingUri(session!.SessionId), null);
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Pairing_Returns202AndStartsTheWait()
+    {
+        using var factory = new CredentialsWebFactory();
+        factory.Steps.PairingWaitsForGate = true;
+        var session = await ReadySessionAsync(factory);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(PairingUri(session.SessionId), null);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        while (session.State != SessionState.AwaitingPairing)
+        {
+            await Task.Delay(10);
+        }
+
+        factory.Steps.PairingGate.SetResult();
+        await session.BackgroundWork;
+        Assert.Equal(SessionState.Paired, session.State);
+    }
+
+    [Fact]
+    public async Task Pairing_Returns429_WhenThePairingCapIsFull()
+    {
+        using var factory = new CredentialsWebFactory(
+            new Dictionary<string, string> { ["CredentialsWeb__MaxConcurrentPairings"] = "1" });
+        var session = await ReadySessionAsync(factory);
+        using var client = factory.CreateClient();
+
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryAcquirePairingSlot();
+
+        var response = await client.PostAsync(PairingUri(session.SessionId), null);
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+        Assert.Empty(factory.Steps.Calls);
+    }
+
+    [Fact]
+    public async Task Pairing_ReleasesTheSlotOnceTheWaitFinishes()
+    {
+        using var factory = new CredentialsWebFactory();
+        var session = await ReadySessionAsync(factory);
+        using var client = factory.CreateClient();
+
+        await client.PostAsync(PairingUri(session.SessionId), null);
+        await session.BackgroundWork;
+
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        Assert.Equal(0, store.ActivePairings);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~PairingEndpointTests"`
+Expected: FAIL — the route does not exist.
+
+- [ ] **Step 3: Add the endpoint**
+
+In `SessionEndpoints`, add the second constant and convert `MapSessionEndpoints` from an expression body to a block that maps both routes:
+
+```csharp
+    private const string PairingBusyMessage =
+        "This instance is already holding as many pairing listeners as it allows. Try again in a "
+        + "few minutes — or run your own: docker run -p 8080:8080 ghcr.io/handys11/rustplusapi-credentials";
+
+    /// <summary>Maps <c>POST /api/sessions</c> and <c>POST /api/sessions/{sessionId}/pairing</c>.</summary>
+    /// <param name="app">The route builder.</param>
+    internal static void MapSessionEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/sessions", (HttpContext context, SessionStore store, AppOptions options) =>
+        {
+            if (!store.TryCreate(ClientAddress.Of(context), out var session, out _))
+            {
+                return Results.Json(new ErrorPayload(OverCapacityMessage), statusCode: 429);
+            }
+
+            var returnUrl = $"{options.PublicBaseUrl}/callback/{session.ReturnToken}";
+            return Results.Ok(new CreateSessionResponse(
+                session.SessionId,
+                SteamLoginService.BuildLoginUrl(returnUrl)));
+        });
+
+        app.MapPost("/api/sessions/{sessionId}/pairing", (
+            string sessionId,
+            SessionStore store,
+            CredentialFlow flow) =>
+        {
+            if (!store.TryGet(sessionId, out var session))
+            {
+                return Results.NotFound();
+            }
+
+            if (session.State != SessionState.Ready)
+            {
+                return Results.Conflict(new ErrorPayload(
+                    "This session is not ready to wait for a pairing."));
+            }
+
+            // The slot is taken here rather than inside the flow so that a refusal is a plain 429
+            // with nothing started; CredentialFlow.WaitForPairingAsync always releases it.
+            if (!store.TryAcquirePairingSlot())
+            {
+                return Results.Json(new ErrorPayload(PairingBusyMessage), statusCode: 429);
+            }
+
+            session.BackgroundWork = flow.WaitForPairingAsync(session, session.Lifetime.Token);
+            return Results.Accepted();
+        });
+    }
+```
+
+Add `using RustPlusApi.CredentialsWeb.Flow;` to the file's usings.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~PairingEndpointTests"`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs tests/RustPlusApi.CredentialsWeb.UnitTests/PairingEndpointTests.cs
+git commit -m "feat(web): add the opt-in pairing endpoint behind the pairing cap"
+```
+
+---
+
+### Task 13: The promise test — secrets never reach a log
+
+The test that defends the trust section of the spec. Without it, "never logged" is a comment rather than a property.
+
+**Files:**
+- Create: `tests/RustPlusApi.CredentialsWeb.UnitTests/CapturingLoggerProvider.cs`
+- Modify: `tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialsWebFactory.cs`
+- Test: `tests/RustPlusApi.CredentialsWeb.UnitTests/SecretsAreNeverLoggedTests.cs`
+
+**Interfaces:**
+- Consumes: the whole app.
+- Produces: `internal sealed class CapturingLoggerProvider : ILoggerProvider` with `internal IReadOnlyList<string> Records { get; }`; `CredentialsWebFactory.Logs` exposing it.
+
+- [ ] **Step 1: Write the capturing provider**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/CapturingLoggerProvider.cs`:
+
+```csharp
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+/// <summary>Captures every log record the app writes, at every level, so a test can assert on what
+/// is absent from them.</summary>
+internal sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    private readonly List<string> _records = [];
+
+    /// <summary>Formatted messages, each with its exception appended.</summary>
+    internal IReadOnlyList<string> Records
+    {
+        get
+        {
+            lock (_records)
+            {
+                return _records.ToArray();
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public ILogger CreateLogger(string categoryName) => new CapturingLogger(_records, categoryName);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        // Nothing to release.
+    }
+
+    private sealed class CapturingLogger(List<string> records, string category) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var line = $"{category}: {formatter(state, exception)} {exception}";
+            lock (records)
+            {
+                records.Add(line);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Expose it from the factory**
+
+In `CredentialsWebFactory`, add the property and extend `ConfigureWebHost`:
+
+```csharp
+    internal CapturingLoggerProvider Logs { get; } = new();
+
+    /// <inheritdoc/>
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureLogging(logging =>
+        {
+            // Trace, deliberately: the point is to prove the secret is absent even when everything
+            // the app is willing to emit is captured.
+            logging.SetMinimumLevel(LogLevel.Trace);
+            logging.AddProvider(Logs);
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<IRegistrationSteps>();
+            services.AddSingleton<IRegistrationSteps>(Steps);
+            services.RemoveAll<TimeProvider>();
+            services.AddSingleton<TimeProvider>(Time);
+        });
+    }
+```
+
+Add `using Microsoft.Extensions.Logging;` to the factory's usings.
+
+- [ ] **Step 3: Write the failing test**
+
+`tests/RustPlusApi.CredentialsWeb.UnitTests/SecretsAreNeverLoggedTests.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.Fcm.Registration;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SecretsAreNeverLoggedTests
+{
+    private const string SteamTokenSentinel = "SENTINEL-STEAM-TOKEN-b3a1f0c2";
+    private const int PlayerTokenSentinel = 1928374650;
+
+    private static async Task<(CredentialsWebFactory Factory, Session Session)> RunFullFlowAsync()
+    {
+        var factory = new CredentialsWebFactory();
+        factory.Steps.PairingToReturn = new ServerPairing
+        {
+            Ip = "10.0.0.1",
+            Port = 28082,
+            PlayerId = 76561198249527954,
+            PlayerToken = PlayerTokenSentinel,
+            Name = "Test Server"
+        };
+
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        await client.GetAsync(new Uri(
+            $"/callback/{session!.ReturnToken}?steamId=76561198249527954&token={SteamTokenSentinel}",
+            UriKind.Relative));
+        await session.BackgroundWork;
+
+        await client.PostAsync(new Uri($"/api/sessions/{session.SessionId}/pairing", UriKind.Relative), null);
+        await session.BackgroundWork;
+
+        return (factory, session);
+    }
+
+    [Fact]
+    public async Task TheHarnessActuallyCapturesLogs()
+    {
+        // Guards against the whole suite passing vacuously because nothing was ever captured.
+        var (factory, _) = await RunFullFlowAsync();
+        using var _f = factory;
+
+        Assert.NotEmpty(factory.Logs.Records);
+    }
+
+    [Fact]
+    public async Task TheSteamTokenNeverReachesALogRecord()
+    {
+        var (factory, _) = await RunFullFlowAsync();
+        using var _f = factory;
+
+        Assert.DoesNotContain(
+            factory.Logs.Records,
+            record => record.Contains(SteamTokenSentinel, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TheCallbackQueryStringNeverReachesALogRecord()
+    {
+        var (factory, _) = await RunFullFlowAsync();
+        using var _f = factory;
+
+        Assert.DoesNotContain(
+            factory.Logs.Records,
+            record => record.Contains("token=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ThePlayerTokenNeverReachesALogRecord()
+    {
+        var (factory, session) = await RunFullFlowAsync();
+        using var _f = factory;
+
+        Assert.Equal(SessionState.Paired, session.State);
+        Assert.DoesNotContain(
+            factory.Logs.Records,
+            record => record.Contains(
+                PlayerTokenSentinel.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TheExpoPushTokenNeverReachesALogRecord()
+    {
+        var (factory, _) = await RunFullFlowAsync();
+        using var _f = factory;
+
+        Assert.DoesNotContain(
+            factory.Logs.Records,
+            record => record.Contains("ExponentPushToken", StringComparison.Ordinal));
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `dtk dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests --filter "FullyQualifiedName~SecretsAreNeverLogged"`
+Expected: PASS, 5 tests.
+
+If `TheCallbackQueryStringNeverReachesALogRecord` fails, the `Microsoft.AspNetCore.Hosting.Diagnostics` filter added in Task 1 is missing or misspelled — that filter is the only thing suppressing the "Request starting … ?steamId=…&token=…" line, and it is written before any middleware could redact it. Do not fix this by weakening the test.
+
+If `TheSteamTokenNeverReachesALogRecord` fails inside an exception, an upstream client has embedded a response body in its exception message. In that case, replace the `logger.LogError(ex, …)` calls in `CredentialFlow` with `logger.LogError("… {ExceptionType}", ex.GetType().Name)` rather than dropping the assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/RustPlusApi.CredentialsWeb.UnitTests/
+git commit -m "test(web): assert no credential ever reaches a log record"
+```
+
+---
+
+### Task 14: The page
+
+One HTML file, one stylesheet, one script, no build step and no third-party origin — which is what makes the CSP in Task 9 possible and what lets a security-conscious visitor read the whole client before trusting it with a Steam login.
+
+**Files:**
+- Create: `apps/RustPlusApi.CredentialsWeb/wwwroot/index.html`
+- Create: `apps/RustPlusApi.CredentialsWeb/wwwroot/app.css`
+- Create: `apps/RustPlusApi.CredentialsWeb/wwwroot/app.js`
+
+**Interfaces:**
+- Consumes: `POST /api/sessions`, `GET /callback/{returnToken}` (indirectly, via the redirect), `GET /api/sessions/{id}/events`, `POST /api/sessions/{id}/pairing`.
+- Produces: nothing other tasks consume.
+
+- [ ] **Step 1: Write index.html**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Rust+ credentials</title>
+    <link rel="stylesheet" href="app.css">
+</head>
+<body>
+<main>
+    <h1>Get your Rust+ credentials</h1>
+
+    <section id="intro">
+        <p>
+            Sign in through Steam, then pair in game. You end up with the four values a Rust+ client
+            needs, and a <code>rustplus.config.json</code> you can download.
+        </p>
+        <details open>
+            <summary>What this server sees, and what it keeps</summary>
+            <ul>
+                <li>Your Steam auth token reaches this server, because Facepunch sends it here as a
+                    query parameter and nothing can change that. It is dropped the moment your device
+                    is registered.</li>
+                <li>Nothing is written to disk or to a database. Everything lives in memory and is
+                    discarded when your session ends or the process restarts.</li>
+                <li>No credential is written to any log. The web server's request logging is turned
+                    off precisely because it would record that query parameter.</li>
+                <li>Your <code>playerToken</code> is full access to your Rust+ account. Treat it like
+                    a password and don't paste it anywhere public.</li>
+                <li>Prefer not to trust someone else's server? <a href="https://github.com/HandyS11/RustPlusApi">Run your own.</a></li>
+            </ul>
+        </details>
+        <button id="start" type="button">Sign in with Steam</button>
+    </section>
+
+    <section id="progress" hidden>
+        <h2>Working…</h2>
+        <p id="status">Registering a device with Google and Rust Companion.</p>
+    </section>
+
+    <section id="ready" hidden>
+        <h2>Credentials ready</h2>
+        <p>Signed in as <code id="steam-id"></code>.</p>
+        <button id="download" type="button">Download rustplus.config.json</button>
+        <h3>Optional: get your pairing values</h3>
+        <p>
+            To get <code>ip</code>, <code>port</code>, <code>playerId</code> and
+            <code>playerToken</code>, this server has to hold a connection open to Google while you
+            pair in game. Start it only when you're ready to alt-tab into Rust.
+        </p>
+        <button id="pair" type="button">Wait for my pairing</button>
+        <p id="pair-note"></p>
+    </section>
+
+    <section id="waiting" hidden>
+        <h2>Waiting for your pairing</h2>
+        <p>Open Rust, join a server, and choose <strong>Pair with Server</strong>.</p>
+    </section>
+
+    <section id="paired" hidden>
+        <h2>Paired</h2>
+        <dl>
+            <dt>Server</dt><dd id="server-name"></dd>
+            <dt>IP</dt><dd id="pair-ip"></dd>
+            <dt>Port</dt><dd id="pair-port"></dd>
+            <dt>Player ID</dt><dd id="pair-player-id"></dd>
+            <dt>Player token</dt><dd id="pair-player-token"></dd>
+        </dl>
+        <pre id="snippet"></pre>
+        <button id="download-paired" type="button">Download rustplus.config.json</button>
+    </section>
+
+    <section id="failed" hidden>
+        <h2>Something went wrong</h2>
+        <p id="error"></p>
+        <button id="restart" type="button">Start over</button>
+    </section>
+</main>
+<script src="app.js"></script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Write app.css**
+
+```css
+:root {
+    color-scheme: light dark;
+    --bg: #fbfbfa;
+    --fg: #1d1c1a;
+    --muted: #5c5952;
+    --line: #d9d6cf;
+    --accent: #b4552d;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #171614;
+        --fg: #ecebe7;
+        --muted: #a19d94;
+        --line: #35322d;
+        --accent: #e07a4c;
+    }
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font: 16px/1.6 system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+main {
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 3rem 1.25rem 6rem;
+}
+
+h1 { font-size: 1.75rem; margin-bottom: 1.5rem; }
+h2 { font-size: 1.25rem; }
+h3 { font-size: 1rem; margin-top: 2rem; }
+
+section { border-top: 1px solid var(--line); padding-top: 1.5rem; margin-top: 1.5rem; }
+section:first-of-type { border-top: none; margin-top: 0; padding-top: 0; }
+
+details {
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    margin: 1.5rem 0;
+}
+
+summary { cursor: pointer; font-weight: 600; }
+details ul { margin: 0.75rem 0 0; padding-left: 1.1rem; color: var(--muted); }
+details li { margin-bottom: 0.5rem; }
+
+button {
+    font: inherit;
+    font-weight: 600;
+    color: #fff;
+    background: var(--accent);
+    border: none;
+    border-radius: 6px;
+    padding: 0.6rem 1.1rem;
+    cursor: pointer;
+}
+
+button:disabled { opacity: 0.5; cursor: default; }
+
+code, pre {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.9em;
+}
+
+pre {
+    background: color-mix(in srgb, var(--fg) 6%, transparent);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 0.9rem;
+    overflow-x: auto;
+}
+
+dl { display: grid; grid-template-columns: max-content 1fr; gap: 0.4rem 1.25rem; }
+dt { color: var(--muted); }
+dd { margin: 0; font-family: ui-monospace, Menlo, Consolas, monospace; word-break: break-all; }
+
+a { color: var(--accent); }
+```
+
+- [ ] **Step 3: Write app.js**
+
+The session handle is read from the URL fragment first and from `sessionStorage` second. The fragment is what carries the handle back from the callback redirect, and it also lets the Steam login be completed in a different browser from the one that started the flow.
+
+```javascript
+"use strict";
+
+const SESSION_KEY = "rustplus-credentials-session";
+
+const view = {
+    intro: document.getElementById("intro"),
+    progress: document.getElementById("progress"),
+    ready: document.getElementById("ready"),
+    waiting: document.getElementById("waiting"),
+    paired: document.getElementById("paired"),
+    failed: document.getElementById("failed")
+};
+
+let sessionId = null;
+let configJson = null;
+
+function show(name) {
+    for (const [key, element] of Object.entries(view)) {
+        element.hidden = key !== name;
+    }
+}
+
+function fail(message) {
+    document.getElementById("error").textContent = message;
+    show("failed");
+}
+
+function readSessionId() {
+    const match = /^#session=([0-9a-f]{32})$/.exec(location.hash);
+    if (match) {
+        // Drop the fragment so a shared or bookmarked URL does not carry the session handle.
+        history.replaceState({}, "", location.pathname);
+        sessionStorage.setItem(SESSION_KEY, match[1]);
+        return match[1];
+    }
+    return sessionStorage.getItem(SESSION_KEY);
+}
+
+function download(name, text) {
+    const url = URL.createObjectURL(new Blob([text], { type: "application/json" }));
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = name;
+    link.click();
+    URL.revokeObjectURL(url);
+}
+
+function onStep(payload) {
+    if (payload.state === "AwaitingPairing") {
+        show("waiting");
+    } else if (payload.state === "Registering" || payload.state === "Authenticated") {
+        show("progress");
+    }
+}
+
+function onCredentials(payload) {
+    configJson = payload.configJson;
+    document.getElementById("steam-id").textContent = payload.steamId;
+    show("ready");
+}
+
+function onPaired(payload) {
+    document.getElementById("server-name").textContent = payload.name ?? "(unnamed)";
+    document.getElementById("pair-ip").textContent = payload.ip;
+    document.getElementById("pair-port").textContent = payload.port;
+    document.getElementById("pair-player-id").textContent = payload.playerId;
+    document.getElementById("pair-player-token").textContent = payload.playerToken;
+    document.getElementById("snippet").textContent =
+        "new RustPlus(new RustPlusConnection(\"" + payload.ip + "\", " + payload.port +
+        ", " + payload.playerId + ", " + payload.playerToken + "));";
+    show("paired");
+}
+
+function listen(id) {
+    const source = new EventSource("/api/sessions/" + id + "/events");
+
+    source.addEventListener("step", e => onStep(JSON.parse(e.data)));
+    source.addEventListener("credentials", e => onCredentials(JSON.parse(e.data)));
+    source.addEventListener("paired", e => { onPaired(JSON.parse(e.data)); source.close(); });
+    source.addEventListener("error", e => {
+        // A named "error" event carries our payload; a transport error has no data and
+        // EventSource reconnects on its own, so it is not surfaced.
+        if (e.data) {
+            fail(JSON.parse(e.data).message);
+            source.close();
+        }
+    });
+    source.addEventListener("expired", () => {
+        // Not a failure: the session is back in Ready, so the stream stays open and the visitor
+        // can start another wait without repeating the Steam login.
+        document.getElementById("pair").disabled = false;
+        document.getElementById("pair-note").textContent =
+            "No pairing arrived in time. Your credentials are still valid — try again when you're in game.";
+        show("ready");
+    });
+}
+
+async function start() {
+    const button = document.getElementById("start");
+    button.disabled = true;
+
+    const response = await fetch("/api/sessions", { method: "POST" });
+    if (!response.ok) {
+        const body = await response.json().catch(() => ({ message: "This instance is busy." }));
+        fail(body.message);
+        return;
+    }
+
+    const body = await response.json();
+    sessionStorage.setItem(SESSION_KEY, body.sessionId);
+    location.href = body.loginUrl;
+}
+
+async function pair() {
+    const button = document.getElementById("pair");
+    button.disabled = true;
+
+    const response = await fetch("/api/sessions/" + sessionId + "/pairing", { method: "POST" });
+    if (!response.ok) {
+        const body = await response.json().catch(() => ({ message: "Could not start the pairing wait." }));
+        fail(body.message);
+        button.disabled = false;
+    }
+}
+
+document.getElementById("start").addEventListener("click", start);
+document.getElementById("pair").addEventListener("click", pair);
+document.getElementById("download").addEventListener("click",
+    () => download("rustplus.config.json", configJson));
+document.getElementById("download-paired").addEventListener("click",
+    () => download("rustplus.config.json", configJson));
+document.getElementById("restart").addEventListener("click", () => {
+    sessionStorage.removeItem(SESSION_KEY);
+    location.href = "/";
+});
+
+sessionId = readSessionId();
+if (sessionId) {
+    show("progress");
+    listen(sessionId);
+} else {
+    show("intro");
+}
+```
+
+- [ ] **Step 4: Run the app and walk the flow by hand**
+
+```bash
+dotnet run --project apps/RustPlusApi.CredentialsWeb \
+  -- --CredentialsWeb:PublicBaseUrl=http://localhost:5000 --CredentialsWeb:AllowInsecureBaseUrl=true
+```
+
+Open `http://localhost:5000`. Expected: the intro renders, the trust panel is open by default, and "Sign in with Steam" navigates to `companion-rust.facepunch.com`. Do not complete a real login here — the end-to-end run belongs to Task 17's verification.
+
+- [ ] **Step 5: Verify the whole suite still passes**
+
+Run: `dotnet test tests/RustPlusApi.CredentialsWeb.UnitTests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/RustPlusApi.CredentialsWeb/wwwroot/
+git commit -m "feat(web): add the single-page client with an explicit trust disclosure"
+```
+
+---
+
+### Task 15: Container image and the deployment footguns
+
+**Files:**
+- Create: `apps/RustPlusApi.CredentialsWeb/Dockerfile`
+- Create: `apps/RustPlusApi.CredentialsWeb/docker-compose.yml`
+- Create: `apps/RustPlusApi.CredentialsWeb/Caddyfile.example`
+- Create: `.dockerignore`
+
+**Interfaces:**
+- Consumes: the built app.
+- Produces: an image exposing port 8080, run as a non-root user.
+
+- [ ] **Step 1: Write .dockerignore**
+
+The build context is the repository root, because `ProjectReference`, `Directory.Build.props` and `Directory.Packages.props` all live above the app.
+
+`.dockerignore` at the repository root:
+
+```
+**/bin/
+**/obj/
+**/TestResults/
+**/.git/
+**/.idea/
+**/.vs/
+docs/_site/
+rustplus.config.json
+```
+
+`rustplus.config.json` is listed because it holds real credentials on a developer machine and must never enter an image layer.
+
+- [ ] **Step 2: Write the Dockerfile**
+
+```dockerfile
+# Build context is the repository root:
+#   docker build -f apps/RustPlusApi.CredentialsWeb/Dockerfile -t rustplusapi-credentials .
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY Directory.Build.props Directory.Packages.props NuGet.config ./
+COPY src/ src/
+COPY apps/ apps/
+
+RUN dotnet publish apps/RustPlusApi.CredentialsWeb/RustPlusApi.CredentialsWeb.csproj \
+    --configuration Release \
+    --output /app
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+
+# The aspnet image ships a non-root user; APP_UID is its id.
+USER $APP_UID
+
+ENV ASPNETCORE_HTTP_PORTS=8080
+EXPOSE 8080
+
+COPY --from=build /app .
+ENTRYPOINT ["dotnet", "RustPlusApi.CredentialsWeb.dll"]
+```
+
+- [ ] **Step 3: Write docker-compose.yml**
+
+This file is copyable documentation, not a supported second install path. It exists because the two settings most likely to be got wrong — the read-only filesystem and the proxy trust list — are easier to show than to describe.
+
+```yaml
+services:
+  credentials:
+    image: ghcr.io/handys11/rustplusapi-credentials:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:8080"
+    environment:
+      # Must be the externally reachable origin, with no trailing slash. This is the value
+      # Facepunch redirects back to, so it cannot be inferred from what Kestrel sees.
+      CredentialsWeb__PublicBaseUrl: "https://creds.example.org"
+      # Per-IP limits are silently void unless the proxy's address is trusted here: without it
+      # every visitor presents as the proxy and shares one bucket. Set this to the proxy's address
+      # on the container network, and never to a host you do not control. Leave it unset when the
+      # app is reached directly, so X-Forwarded-For from a caller is ignored.
+      CredentialsWeb__KnownProxies__0: "172.18.0.2"
+    # Enforces "nothing is written to disk" at the runtime level rather than by intent.
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+```
+
+- [ ] **Step 4: Write Caddyfile.example**
+
+The default access log of every common reverse proxy records the full request line, including the query — which is where the Steam auth token is. This is the single most likely way a careful self-hoster still ends up leaking one.
+
+```
+# Example only. The important part is the log format: the default one records the full URI,
+# including the ?steamId=…&token=… that Facepunch appends to the callback.
+creds.example.org {
+	reverse_proxy 127.0.0.1:8080
+
+	log {
+		output file /var/log/caddy/creds.log
+		# Drop the query string entirely. Without this filter the Steam auth token is written
+		# to disk on every successful login.
+		format filter {
+			request>uri query {
+				delete steamId
+				delete token
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 5: Build and smoke-test the image**
+
+```bash
+docker build -f apps/RustPlusApi.CredentialsWeb/Dockerfile -t rustplusapi-credentials .
+docker run --rm -p 8080:8080 \
+  -e CredentialsWeb__PublicBaseUrl=http://localhost:8080 \
+  -e CredentialsWeb__AllowInsecureBaseUrl=true \
+  rustplusapi-credentials
+```
+
+Then, in another shell:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/
+curl -s -X POST http://localhost:8080/api/sessions
+```
+
+Expected: `200`, then a JSON body with `sessionId` and a `loginUrl` beginning
+`https://companion-rust.facepunch.com/login?returnUrl=`.
+
+- [ ] **Step 6: Verify the insecure-base-url guard in the container**
+
+```bash
+docker run --rm -e CredentialsWeb__PublicBaseUrl=http://localhost:8080 rustplusapi-credentials
+```
+
+Expected: the container exits non-zero, printing a configuration error that names
+`CredentialsWeb:AllowInsecureBaseUrl`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .dockerignore apps/RustPlusApi.CredentialsWeb/Dockerfile apps/RustPlusApi.CredentialsWeb/docker-compose.yml apps/RustPlusApi.CredentialsWeb/Caddyfile.example
+git commit -m "feat(web): containerize the app with safe proxy and logging examples"
+```
+
+---
+
+### Task 16: Coverage split and pipelines
+
+The library's 95/90 gate is computed from a merged report across every assembly. Dropping a web app into that merge would quietly lower the bar the *library* has to clear. This task splits the report in two and holds both halves to the same 95/90.
+
+**Files:**
+- Modify: `tools/coverage/check_threshold.py`
+- Modify: `tools/coverage/report.sh`
+- Modify: `.github/workflows/CI.yml`
+- Modify: `.github/workflows/CD.yml`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `check_threshold.py <line_min> <branch_min> [report_path]`; two merged reports at `TestResults/merged` (libraries) and `TestResults/merged-web` (the app).
+
+- [ ] **Step 1: Let check_threshold.py take a report path**
+
+In `tools/coverage/check_threshold.py`, replace the usage block and the hard-coded report path:
+
+```python
+if len(sys.argv) not in (3, 4):
+    print("Usage: check_threshold.py <line_min> <branch_min> [report_path]")
+    sys.exit(2)
+
+line_min, branch_min = float(sys.argv[1]), float(sys.argv[2])
+report = sys.argv[3] if len(sys.argv) == 4 else 'TestResults/merged/Cobertura.xml'
+```
+
+Also update the module docstring's second paragraph to read:
+
+```
+Reads a merged Cobertura report produced by ReportGenerator (by default
+TestResults/merged/Cobertura.xml, the union across every library test project
+and TFM) and checks its overall line-rate and branch-rate against the floors.
+```
+
+- [ ] **Step 2: Split the local report script**
+
+Replace everything in `tools/coverage/report.sh` from the `dotnet tool run reportgenerator` line to the end with:
+
+```bash
+dotnet tool restore
+
+# Two reports, two gates. The library gate must stay exactly what it was before the web app
+# existed: merging a net10.0-only ASP.NET app into it would lower the bar the libraries clear.
+dotnet tool run reportgenerator -- \
+  "-reports:TestResults/**/coverage.opencover.xml" \
+  "-targetdir:TestResults/merged" \
+  "-assemblyfilters:-RustPlusApi.CredentialsWeb" \
+  "-reporttypes:Cobertura"
+
+dotnet tool run reportgenerator -- \
+  "-reports:TestResults/**/coverage.opencover.xml" \
+  "-targetdir:TestResults/merged-web" \
+  "-assemblyfilters:+RustPlusApi.CredentialsWeb" \
+  "-reporttypes:Cobertura"
+
+python3 - <<'PY'
+import xml.etree.ElementTree as ET
+for label, path in (('libraries', 'TestResults/merged/Cobertura.xml'),
+                    ('web app  ', 'TestResults/merged-web/Cobertura.xml')):
+    root = ET.parse(path).getroot()
+    line = float(root.attrib['line-rate']) * 100
+    branch = float(root.attrib['branch-rate']) * 100
+    print(f"{label} -> line={line:.2f}% branch={branch:.2f}%")
+    for cls in root.iter('class'):
+        name = cls.attrib.get('name', '?')
+        lr = float(cls.attrib.get('line-rate', '1')) * 100
+        br = float(cls.attrib.get('branch-rate', '1')) * 100
+        if lr < 100 or br < 100:
+            print(f"  line={lr:6.2f}% branch={br:6.2f}%  {name}")
+PY
+
+python3 tools/coverage/check_threshold.py 95 90
+python3 tools/coverage/check_threshold.py 95 90 TestResults/merged-web/Cobertura.xml
+```
+
+- [ ] **Step 3: Split the CI gate**
+
+In `.github/workflows/CI.yml`, replace the "Merge coverage reports" and "Enforce coverage threshold" steps with:
+
+```yaml
+    - name: Merge coverage reports (libraries)
+      run: >
+        dotnet tool run reportgenerator --
+        "-reports:${{ github.workspace }}/TestResults/**/coverage.opencover.xml"
+        "-targetdir:${{ github.workspace }}/TestResults/merged"
+        "-assemblyfilters:-RustPlusApi.CredentialsWeb"
+        "-reporttypes:Cobertura"
+
+    - name: Merge coverage reports (web app)
+      run: >
+        dotnet tool run reportgenerator --
+        "-reports:${{ github.workspace }}/TestResults/**/coverage.opencover.xml"
+        "-targetdir:${{ github.workspace }}/TestResults/merged-web"
+        "-assemblyfilters:+RustPlusApi.CredentialsWeb"
+        "-reporttypes:Cobertura"
+
+    - name: Enforce coverage threshold (libraries)
+      # Merged aggregate across every library test project and both TFMs (ReportGenerator union).
+      # The web app is filtered out so it cannot dilute the libraries' number.
+      # Metric: ReportGenerator-merged Cobertura line-rate/branch-rate.
+      # Gate floor: line 95 / branch 90 — keep in sync with docs/development/testing.md.
+      working-directory: ${{ github.workspace }}
+      run: python3 tools/coverage/check_threshold.py 95 90
+
+    - name: Enforce coverage threshold (web app)
+      # Same floor. The app can meet it because its two untestable regions — host wiring and the
+      # live-network adapter — are [ExcludeFromCodeCoverage] with justifications.
+      working-directory: ${{ github.workspace }}
+      run: python3 tools/coverage/check_threshold.py 95 90 TestResults/merged-web/Cobertura.xml
+```
+
+- [ ] **Step 4: Publish the image from CD**
+
+In `.github/workflows/CD.yml`, add a second job after `build-and-deploy`:
+
+```yaml
+  publish-image:
+    runs-on: ubuntu-latest
+    needs: build-and-deploy
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v7
+
+    - name: Resolve Version from Tag
+      run: |
+        VERSION="${GITHUB_REF_NAME#v}"
+        echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+        if [[ "$VERSION" == *-* ]]; then
+          echo "IS_PRERELEASE=true" >> "$GITHUB_ENV"
+        else
+          echo "IS_PRERELEASE=false" >> "$GITHUB_ENV"
+        fi
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Compute image tags
+      run: |
+        TAGS="ghcr.io/${{ github.repository_owner }}/rustplusapi-credentials:$VERSION"
+        # 'latest' only follows stable releases, so a prerelease never becomes the default pull.
+        if [[ "$IS_PRERELEASE" == "false" ]]; then
+          TAGS="$TAGS,ghcr.io/${{ github.repository_owner }}/rustplusapi-credentials:latest"
+        fi
+        echo "TAGS=$TAGS" >> "$GITHUB_ENV"
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: apps/RustPlusApi.CredentialsWeb/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ env.TAGS }}
+```
+
+The repository owner is lowercased by GHCR automatically; `HandyS11` resolves to `handys11`, matching the `docker run` line quoted in the 429 messages and the README.
+
+- [ ] **Step 5: Verify the split locally**
+
+Run: `tools/coverage/report.sh`
+Expected: two summary blocks — `libraries` and `web app` — followed by two `[OK]` lines. If the web app's line is below 95, the gap report above it names the class; add tests rather than lowering the floor, or `[ExcludeFromCodeCoverage]` with a justification if the code is genuinely a live-network path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/coverage/ .github/workflows/
+git commit -m "ci: gate library and web-app coverage separately, publish the container image"
+```
+
+---
+
+### Task 17: Documentation and end-to-end verification
+
+**Files:**
+- Create: `apps/RustPlusApi.CredentialsWeb/README.md`
+- Modify: `docs/articles/credentials.md`
+- Modify: `docs/articles/getting-started.md`
+- Modify: `docs/articles/troubleshooting.md`
+- Modify: `docs/development/testing.md`
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: the finished app.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the self-host README**
+
+`apps/RustPlusApi.CredentialsWeb/README.md`:
+
+````markdown
+# Rust+ credentials website
+
+A single-page web app that walks a visitor from nothing to working Rust+ credentials. It is both a
+self-host starter and the code behind the public instance.
+
+## Run it
+
+```bash
+docker run -p 8080:8080 \
+  -e CredentialsWeb__PublicBaseUrl=https://creds.example.org \
+  ghcr.io/handys11/rustplusapi-credentials
+```
+
+`PublicBaseUrl` is **required** and must be the externally reachable origin, with no trailing
+slash. It cannot be inferred: it is the URL Facepunch redirects the browser back to, and behind a
+reverse proxy that is not what Kestrel sees. The app refuses to start if it is not `https`, unless
+you set `CredentialsWeb__AllowInsecureBaseUrl=true` for local development.
+
+For local development without a container:
+
+```bash
+dotnet run --project apps/RustPlusApi.CredentialsWeb \
+  -- --CredentialsWeb:PublicBaseUrl=http://localhost:5000 --CredentialsWeb:AllowInsecureBaseUrl=true
+```
+
+## Two things that will bite you behind a reverse proxy
+
+**Your access log will record Steam auth tokens.** Facepunch appends the token to the callback URL
+as a query parameter. The app itself never logs it — request logging is switched off for exactly
+this reason — but your proxy's default log format records the full request line. Filter the query
+before it reaches disk; `Caddyfile.example` in this directory shows how.
+
+**Your per-IP limits will silently do nothing.** Without `ForwardedHeaders` configured with the
+proxy's address in `CredentialsWeb__KnownProxies__0`, every visitor presents as the proxy and
+shares one bucket. Configured too loosely, anyone can spoof `X-Forwarded-For` past the limits.
+With none set, forwarded headers are ignored — the right default when the app is reached directly.
+See `docker-compose.yml`.
+
+## Configuration
+
+All settings live under the `CredentialsWeb` section (`CredentialsWeb__Name` as an environment
+variable, `--CredentialsWeb:Name` on the command line).
+
+| Setting | Default | What it does |
+|---|---|---|
+| `PublicBaseUrl` | *(required)* | Externally reachable origin, no trailing slash |
+| `AllowInsecureBaseUrl` | `false` | Permits a non-https base URL. Development only |
+| `KnownProxies__0`, `__1`, … | *(empty)* | Reverse proxy addresses whose `X-Forwarded-For` is trusted |
+| `MaxConcurrentSessions` | `200` | Global cap on live sessions |
+| `MaxConcurrentPairings` | `50` | Global cap on live MCS sockets |
+| `MaxCompletionsPerIpPerHour` | `5` | Rolling per-IP cap on completed flows |
+| `CreatedTtl` | `00:05:00` | Lifetime of a session before the Steam login |
+| `SessionTtl` | `00:15:00` | Lifetime of a session after it |
+| `PairingTtl` | `00:10:00` | How long an MCS socket is held |
+
+## What it does with credentials
+
+- **In memory only.** No database, no session cache, no disk. A restart wipes everything.
+- **The Steam auth token is dropped** the moment your device is registered with Rust Companion.
+- **Nothing is logged.** Asserted by `SecretsAreNeverLoggedTests`, not just intended.
+- **The callback responds 302**, so the token-bearing URL never becomes a browser history entry,
+  and the session handle travels in a URL fragment, which browsers never send to a server.
+- **The server does see the token** in the request line. Facepunch decides the callback shape and
+  nothing can change that; the design minimises its lifetime rather than pretending otherwise.
+
+## Flow
+
+The steps run in the order `4 → 1,2,3 → 5`, not the console app's `1,2,3 → 4 → 5`. Putting the
+Steam login first means an anonymous visitor cannot trigger Google device registrations: they cost
+one dictionary entry with a five-minute TTL and nothing else. Step 6, the pairing wait, is an
+opt-in continuation because it is the only step that holds a socket open.
+````
+
+- [ ] **Step 2: Update the user-facing docs**
+
+- `docs/articles/credentials.md`: add a section at the top presenting the website as the recommended
+  route (`docker run` line plus the public instance URL), and keep the existing
+  `RustPlus.Register.ConsoleApp` walkthrough below it as the local route. Update the Mermaid
+  sequence diagram to show the browser redirecting to the app's own `/callback/<nonce>` rather than
+  to `localhost:3000`.
+- `docs/articles/getting-started.md`: point at the website first, then the console app.
+- `docs/articles/troubleshooting.md`: add a "Credentials website" section with three entries —
+  *"The callback returns 404"* (the return token is single-use; a refreshed or bookmarked callback
+  URL will always 404, start over); *"I get a 429"* (the instance is at capacity or you have run
+  too many flows this hour; wait, or self-host); *"The pairing never arrives"* (the wait is capped
+  at `PairingTtl`; press Pair with Server while the page says it is waiting; the credentials stay
+  valid, so retry the pairing step rather than the whole flow).
+- `README.md` (root): one paragraph linking the public instance and the self-host image.
+
+- [ ] **Step 3: Update the developer docs**
+
+- `docs/development/testing.md`: add a "Credentials web app" subsection recording that the app is
+  gated separately at the same 95/90 via `TestResults/merged-web`, and listing its two coverage
+  exclusions with their justifications — `Program` (host wiring) and `LiveRegistrationSteps`
+  (live-network seam). Note the app is `net10.0` only and therefore outside multi-TFM parity.
+- `CLAUDE.md`: add `apps/RustPlusApi.CredentialsWeb` to the package-layering section, describing it
+  as a net10.0-only ASP.NET Core app that consumes `RustPlusApi.Fcm.Registration`'s public API,
+  reorders the flow to `4 → 1,2,3 → 5`, and is excluded from the netstandard2.0 parity story. Add
+  the two-gate coverage note to the Commands section.
+
+- [ ] **Step 4: Full verification**
+
+```bash
+dotnet build RustPlusApi.sln
+dotnet test RustPlusApi.sln
+tools/coverage/report.sh
+dotnet tool restore && dotnet jb cleanupcode RustPlusApi.sln --profile="ReformatAndReorder"
+git diff --exit-code
+```
+
+Expected: a clean build with no warnings; every test passing on both TFM hosts; both coverage gates
+`[OK]`; and `git diff --exit-code` returning 0, proving the formatter changed nothing.
+
+- [ ] **Step 5: Live end-to-end run**
+
+This is the only step that proves the thing works, and it is also the outstanding verification the
+spec records as an open assumption. Deploy the image behind a real `https` hostname you control,
+then:
+
+1. Complete the flow in a browser: Steam login, credentials shown, `rustplus.config.json` downloads.
+2. Confirm the redirect landed on **your external hostname** — this closes the last unproven
+   assumption from the 2026-09-02 spec.
+3. Opt into the pairing step, pair in game, and confirm the four values appear.
+4. Construct a `RustPlus` client from those four values and confirm it connects.
+5. Grep the container logs and the proxy access log for the Steam token and the `playerToken`.
+   Expected: no match in either.
+
+Record the outcome in the spec's *Assumptions to re-verify* section.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/RustPlusApi.CredentialsWeb/README.md docs/ README.md CLAUDE.md
+git commit -m "docs: document the credentials website for self-hosters and contributors"
+```

--- a/docs/superpowers/plans/2026-09-03-credential-acquisition-website.md
+++ b/docs/superpowers/plans/2026-09-03-credential-acquisition-website.md
@@ -2634,8 +2634,12 @@ public sealed class CredentialFlowPairingTests
         store.TryAcquirePairingSlot();
 
         var pending = flow.WaitForPairingAsync(session, CancellationToken.None);
+        // Bounded: a regression that never reaches AwaitingPairing must fail as an assertion,
+        // not park a foreground thread and hang the test process.
+        using var reachTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         while (session.State != SessionState.AwaitingPairing)
         {
+            Assert.False(reachTimeout.IsCancellationRequested, "The flow never reached AwaitingPairing.");
             await Task.Delay(10);
         }
 
@@ -2673,8 +2677,12 @@ public sealed class CredentialFlowPairingTests
 
         using var cancellation = new CancellationTokenSource();
         var pending = flow.WaitForPairingAsync(session, cancellation.Token);
+        // Bounded: a regression that never reaches AwaitingPairing must fail as an assertion,
+        // not park a foreground thread and hang the test process.
+        using var reachTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         while (session.State != SessionState.AwaitingPairing)
         {
+            Assert.False(reachTimeout.IsCancellationRequested, "The flow never reached AwaitingPairing.");
             await Task.Delay(10);
         }
 
@@ -2698,8 +2706,12 @@ public sealed class CredentialFlowPairingTests
 
         using var cancellation = new CancellationTokenSource();
         var pending = flow.WaitForPairingAsync(session, cancellation.Token);
+        // Bounded: a regression that never reaches AwaitingPairing must fail as an assertion,
+        // not park a foreground thread and hang the test process.
+        using var reachTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         while (session.State != SessionState.AwaitingPairing)
         {
+            Assert.False(reachTimeout.IsCancellationRequested, "The flow never reached AwaitingPairing.");
             await Task.Delay(10);
         }
 
@@ -3725,8 +3737,12 @@ public sealed class PairingEndpointTests
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
+        // Bounded: a regression that never reaches AwaitingPairing must fail as an assertion,
+        // not park a foreground thread and hang the test process.
+        using var reachTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         while (session.State != SessionState.AwaitingPairing)
         {
+            Assert.False(reachTimeout.IsCancellationRequested, "The flow never reached AwaitingPairing.");
             await Task.Delay(10);
         }
 

--- a/docs/superpowers/plans/2026-09-03-credential-acquisition-website.md
+++ b/docs/superpowers/plans/2026-09-03-credential-acquisition-website.md
@@ -886,7 +886,7 @@ public sealed class SessionTests
     {
         using var session = NewSession();
 
-        session.SetSteamLogin(new SteamLoginResult { SteamId = 76561198249527954, Token = "steam-token" });
+        session.SetSteamLogin(new SteamLoginResult(76561198249527954, "steam-token"));
 
         Assert.Equal(76561198249527954UL, session.SteamId);
         Assert.Equal("steam-token", session.SteamToken);
@@ -896,7 +896,7 @@ public sealed class SessionTests
     public void ClearSteamToken_DropsTokenButKeepsSteamId()
     {
         using var session = NewSession();
-        session.SetSteamLogin(new SteamLoginResult { SteamId = 76561198249527954, Token = "steam-token" });
+        session.SetSteamLogin(new SteamLoginResult(76561198249527954, "steam-token"));
 
         session.ClearSteamToken();
 
@@ -933,7 +933,7 @@ public sealed class SessionTests
     public void Dispose_ClearsSecretsAndCancelsLifetime()
     {
         var session = NewSession();
-        session.SetSteamLogin(new SteamLoginResult { SteamId = 1, Token = "steam-token" });
+        session.SetSteamLogin(new SteamLoginResult(1, "steam-token"));
         session.SetCredentials(new Credentials { ExpoPushToken = "expo-token" });
         session.SetPairing(new ServerPairing { Ip = "10.0.0.1", Port = 1, PlayerId = 1, PlayerToken = 2 });
 
@@ -2564,7 +2564,7 @@ public sealed class CredentialFlowPairingTests
         store.TryCreate("203.0.113.7", out var session, out _);
         await flow.CompleteRegistrationAsync(
             session!,
-            new SteamLoginResult { SteamId = 76561198249527954, Token = "steam-token" },
+            new SteamLoginResult(76561198249527954, "steam-token"),
             CancellationToken.None);
 
         steps.Calls.Clear();

--- a/docs/superpowers/specs/2026-09-02-browser-agnostic-steam-login-design.md
+++ b/docs/superpowers/specs/2026-09-02-browser-agnostic-steam-login-design.md
@@ -52,9 +52,19 @@ The path of `returnUrl` is preserved and the query is appended to it.
   was verified. Nothing suggests an allowlist — the value passes through opaquely — but the
   website spec depends on `https://` working and should confirm it.
 
-  **Outcome (2026-09-03): still open.** The live run used the default port 3000 over `http://`
-  on loopback, so neither half of this assumption was exercised. The website spec still depends
-  on an external `https://` return URL being accepted and must confirm it.
+  **Outcome (verified 2026-09-03).** Both halves confirmed, and the host question largely closed:
+
+  - `https://localhost:7443/callback/<nonce>` completed a real Steam login end to end and received
+    `steamId` plus a 193-character `token` — so the `https` scheme and a non-3000 port are proven.
+  - An external host (`https://rustplus-creds.example.org/callback/abc123XYZ`) was reflected
+    verbatim by `GET /login` and accepted by `POST /login`, which 302'd to Steam OpenID with no
+    validation error. There is no allowlist at either gate; the value rides inside the encrypted
+    `state` blob exactly as loopback does.
+
+  Not conclusively proven: the final `/signin-steam` hop to an external hostname, which would
+  require `/signin-steam` to deliberately re-validate a value it receives encrypted. Tracked in
+  `2026-09-03-credential-acquisition-website-design.md` for re-confirmation against the first
+  staging deployment.
 
 ## Design
 

--- a/docs/superpowers/specs/2026-09-03-credential-acquisition-website-design.md
+++ b/docs/superpowers/specs/2026-09-03-credential-acquisition-website-design.md
@@ -153,9 +153,15 @@ token-bearing URL never becomes one. This is strictly better than the library's 
 lands on a 200 and scrubs the query afterwards with `history.replaceState`.
 
 **The redirect target carries the session in a fragment (`/#session=…`).** Fragments are never sent
-to the server, so the session handle stays out of access logs and `Referer` headers entirely. It
-also makes the flow work when the Steam login is completed in a *different* browser from the one
-holding the SSE stream — a phone, say — mirroring the library's headless story at no cost.
+to the server, so the session handle stays out of the *callback* log line and out of `Referer`
+headers. It does **not** stay out of access logs entirely: the client immediately opens
+`GET /api/sessions/{sessionId}/events` to attach the SSE stream, which puts the handle in the
+request path of every such request, and a default access-log format records that. The handle is
+the sole authenticator for a stream that replays the full credentials payload, so an operator
+following the Caddyfile example must redact the session path too, not just `steamId` and `token` —
+see `Caddyfile.example`. It also makes the flow work when the Steam login is completed in a
+*different* browser from the one holding the SSE stream — a phone, say — mirroring the library's
+headless story at no cost.
 
 **No endpoint returns the credentials.** They arrive once over SSE; the page assembles
 `rustplus.config.json` client-side as a `Blob` for download. One less route serving secrets.
@@ -247,12 +253,13 @@ A `PeriodicTimer` background service sweeps expired sessions and disposes their 
 requests get a 429 whose body says "try again shortly — or run your own instance", with the
 `docker run` line.
 
-**Eviction, not rejection, for abandoned sessions.** A one-session-per-IP cap would otherwise lock a
-user out for five minutes because they closed the tab and started over — the single most likely
-thing a confused first-time visitor does. So `POST /api/sessions` from an IP that already holds a
-session in `Created` state **evicts** the old one and issues a new one. An IP holding a session past
-`Created` — one where real upstream work has been done — gets the 429 instead; that session is
-resumable via its `sessionId`, so there is nothing to start over.
+**Eviction, not rejection, for abandoned or dead sessions.** A one-session-per-IP cap would otherwise
+lock a user out for minutes over an attempt that cannot be resumed — the single most likely thing a
+confused first-time visitor runs into. So `POST /api/sessions` from an IP that already holds a
+session in `Created` **or** `Failed` state **evicts** the old one and issues a new one: `Created`
+never touched upstream, and `Failed` is terminal, so neither has anything left to resume. An IP
+holding a session in any other state — one where real, still-live upstream work has been done — gets
+the 429 instead; that session is resumable via its `sessionId`, so there is nothing to start over.
 
 Captcha was rejected: a third-party script tag would undermine the single-auditable-file property
 that the trust story leans on, and it adds a Cloudflare dependency plus a knob self-hosters must be
@@ -274,7 +281,8 @@ be correct in the shipped compose file and called out in the README.
 | Any of steps 1,2,3,5 fails upstream | Session → `Failed` with a step-named message over SSE. Credentials already acquired are dropped, not retried automatically. |
 | Pairing push never arrives before TTL | Socket disposed, pairing slot released, session returns to `Ready` and an `expired` event is emitted. The page offers to retry the pairing step without redoing the Steam login. |
 | SSE stream drops | Client reconnects with the same `sessionId` and resumes; server-side state and the MCS socket are untouched. |
-| Any cap exceeded | 429 with the self-host pointer. |
+| Global or hourly cap exceeded | 429 with the self-host pointer. |
+| This address already holds a resumable session | 429 pointing back at that session instead — not the self-host pointer, since capacity was never the problem. |
 | `PublicBaseUrl` missing or not `https` | Startup fails with a message naming the setting and the escape hatch. |
 
 ## Testing

--- a/docs/superpowers/specs/2026-09-03-credential-acquisition-website-design.md
+++ b/docs/superpowers/specs/2026-09-03-credential-acquisition-website-design.md
@@ -1,0 +1,369 @@
+# Credential-acquisition website
+
+**Date:** 2026-09-03
+**Status:** Approved, not yet implemented
+**Scope:** A new `apps/RustPlusApi.CredentialsWeb` project — a single-page web app that acquires
+Rust+ credentials. Two audiences: a self-host starter anyone can deploy, and a public instance.
+Consumes `RustPlusApi.Fcm.Registration` as-is; **no library change is required**.
+
+## Problem
+
+Acquiring Rust+ credentials today means cloning the repo, installing the .NET SDK and running
+`samples/RustPlus.Register.ConsoleApp`. That is a large amount of friction for a user whose actual
+goal is four values: `ip`, `port`, `playerId`, `playerToken`.
+
+PR #118 removed the Chrome requirement and, deliberately, exposed the seam a website consumes:
+
+```csharp
+public static string BuildLoginUrl(string returnUrl);              // SteamLoginService
+public static SteamLoginResult ParseCallback(Uri callbackUri);     // SteamLoginService
+```
+
+## Why this cannot be a static page
+
+Of the six steps in the flow, only one runs in the browser:
+
+| Step | Where it must run | Why |
+|---|---|---|
+| 1–3. GCM check-in → Firebase → FCM register → Expo token | Backend | protobuf POSTs to `android.clients.google.com`; no CORS |
+| 4. Steam login | Browser redirect | Same mechanism local and hosted |
+| 5. Rust Companion register | Backend | No CORS |
+| 6. Wait for the in-game pairing push | Backend | Raw TLS socket to `mtalk.google.com:5228` |
+
+Step 6 in particular means the backend holds a **live MCS connection per waiting visitor** while
+they alt-tab into Rust and press "Pair with Server". That requires a real server→client push
+channel, and on a public instance it is the scarce resource the whole abuse model is built around.
+
+## Verification log (2026-09-03)
+
+The hosted design depends on Facepunch honouring a `returnUrl` that is not `http://localhost:3000`.
+The 2026-09-02 spec left this open. Three probes closed it:
+
+1. **External `https` host reflected.** `GET https://companion-rust.facepunch.com/login?returnUrl=
+   https%3A%2F%2Frustplus-creds.example.org%2Fcallback%2Fabc123XYZ` → `200`, with the value echoed
+   verbatim into the hidden `returnUrl` input, host, scheme and path segment intact.
+2. **External `https` host accepted at the OpenID kickoff.** `POST /login` with that `returnUrl` and
+   the antiforgery token → `302` to `steamcommunity.com/openid/login`, with
+   `openid.realm=https://companion-rust.facepunch.com` and
+   `return_to=…/signin-steam?state=<encrypted>`. No validation error at either gate. The `returnUrl`
+   travels inside the encrypted `state` blob exactly as it does for loopback.
+3. **`https` scheme and a non-3000 port honoured end to end.** A throwaway Kestrel listener on
+   `https://localhost:7443/callback/<128-bit nonce>` received the post-Steam redirect with
+   `steamId` and a 193-character `token`, path nonce matching. Real Steam login, real credentials.
+
+**Conclusion:** `https`, arbitrary ports and path nonces are proven. An external non-loopback
+hostname is not conclusively proven end to end, but probes 1 and 2 show there is no gate left that
+could plausibly enforce one — `/signin-steam` would have to deliberately re-validate a value it
+receives encrypted. Re-confirm against the first staging deployment; see *Assumptions to re-verify*.
+
+The 2026-09-02 spec's "Assumptions to re-verify" section is amended with these outcomes.
+
+## Decisions
+
+**In this repo, as a new top-level `apps/` project.** Not `samples/` — "sample" undersells something
+hosted publicly and deployed by strangers, and `samples/` is outside the coverage and CD story. Not
+a separate repo — colocation makes the app a canary that breaks loudly in CI when an upstream
+Google/Facepunch step regresses, keeps one clone for self-hosters, and keeps the app version-locked
+to the packages it demonstrates. Cost: the app is net10.0-only, so it sits outside the
+netstandard2.0 multi-TFM parity story that governs `src/`.
+
+**Minimal API + a hand-written static page + SSE.** The entire client is one readable file, which
+matters disproportionately for a page that handles full Rust+ account access: a security-conscious
+user can audit it. SSE is one-directional — exactly the shape of the problem, where the only
+server→client event is "your pairing arrived" — survives proxies and reconnects for free.
+Rejected: Blazor Server (heavy dependency for one page; circuit reconnection semantics complicate
+the bounding story rather than simplify it; an opaque client defeats the audit argument) and
+WebSockets (bidirectional capability that buys nothing here, at the cost of manual reconnect logic).
+
+**Steps 1–5 always; step 6 as an opt-in continuation.** The default path ends at "you have
+credentials and your device is registered", which touches no long-lived socket. The page then offers
+"wait for my pairing" as a clearly-labelled next step. Framing it as a continuation rather than an
+upfront fork matters: at the point of choosing, the user has already seen what they got and can
+judge whether they need more.
+
+**In-memory sessions, reconnectable, hard TTL.** Nothing touches disk or a database, so "never
+persisted" is literally true and a process restart wipes everything by construction. A session id in
+`sessionStorage` lets an SSE drop reconnect and resume the same wait — which matters because the
+drop happens precisely when the user alt-tabs into fullscreen Rust. Rejected: dying with the SSE
+stream (a blip costs a fresh Steam login) and a Redis/SQLite store (directly contradicts the promise
+the page makes).
+
+**Docker as the documented default, `dotnet run` for contributors.** Headline install is one
+`docker run` against a multi-arch image published to `ghcr.io`.
+
+**Steam-first ordering plus tiered caps; no captcha.** See below.
+
+## Flow ordering
+
+Step 4 has no dependency on steps 1–3; step 5 needs both the Steam token and the Expo token.
+So `4 → 1,2,3 → 5` is a valid order, and the app uses it.
+
+This is the load-bearing abuse decision. Under the console app's `1,2,3 → 4 → 5` ordering, an
+anonymous visitor triggers real Google device registrations before proving they are anyone — the
+cheapest thing for an attacker to burn would be the resource the project least controls. Under
+Steam-first, an unauthenticated visitor costs one dictionary entry with a five-minute TTL and
+nothing else.
+
+The reordering lives in the app's own `CredentialFlow`. `FcmRegistration.RegisterWithRustPlusAsync`,
+which bundles the interactive login with the Companion registration, is untouched and remains the
+local/console path. The app calls the public step classes directly:
+`SteamLoginService.BuildLoginUrl`/`ParseCallback`, `AndroidFcmRegister`, `ExpoPushClient`,
+`RustCompanionClient`, `PairingListener`.
+
+## Architecture
+
+```
+apps/RustPlusApi.CredentialsWeb/
+    Program.cs                 minimal API wiring
+    Sessions/                  Session, SessionStore, SessionOptions, sweeper
+    Flow/                      CredentialFlow — orchestrates 4→1,2,3→5 and optional 6
+    Upstream/                  adapter interface over the four live-network classes
+    wwwroot/                   index.html, app.js, app.css — no build step, no npm
+    Dockerfile
+tests/RustPlusApi.CredentialsWeb.UnitTests/
+```
+
+`net10.0` only, `IsPackable=false`, `ProjectReference` to `RustPlusApi.Fcm.Registration`.
+
+### Two ids per session
+
+Both 128-bit, from `RandomNumberGenerator`.
+
+- **`returnToken`** — appears only in the `returnUrl` path. Identifies which session an inbound
+  Facepunch callback belongs to. **Single-use**: consumed and invalidated on first callback, so a
+  callback URL replayed from browser history hits a dead route.
+- **`sessionId`** — the handle the browser uses for the SSE stream and subsequent calls. Never
+  appears in any `returnUrl`.
+
+Separating them means the value that necessarily travels through Facepunch and lands in logs is not
+the value that grants access to the session's events.
+
+### Endpoints
+
+| Route | Behaviour |
+|---|---|
+| `GET /` | The single page. Static. |
+| `POST /api/sessions` | Creates an empty session. Returns `{ sessionId, loginUrl }` where `loginUrl = SteamLoginService.BuildLoginUrl($"{PublicBaseUrl}/callback/{returnToken}")`. Touches nothing upstream. |
+| `GET /callback/{returnToken}` | Facepunch's redirect target. `SteamLoginService.ParseCallback` → stash in session → start `1,2,3` then `5` in the background → **302** to `/#session={sessionId}`. |
+| `GET /api/sessions/{id}/events` | SSE. Emits `step`, `credentials`, `paired`, `error`, `expired`. Opened by the client immediately after `POST /api/sessions`, before the user leaves for Steam, so progress streams the moment the callback lands. |
+| `POST /api/sessions/{id}/pairing` | Opt-in step 6. Opens the `PairingListener`. |
+
+**The callback responds 302, not 200.** A redirect leaves no back-button history entry, so the
+token-bearing URL never becomes one. This is strictly better than the library's local flow, which
+lands on a 200 and scrubs the query afterwards with `history.replaceState`.
+
+**The redirect target carries the session in a fragment (`/#session=…`).** Fragments are never sent
+to the server, so the session handle stays out of access logs and `Referer` headers entirely. It
+also makes the flow work when the Steam login is completed in a *different* browser from the one
+holding the SSE stream — a phone, say — mirroring the library's headless story at no cost.
+
+**No endpoint returns the credentials.** They arrive once over SSE; the page assembles
+`rustplus.config.json` client-side as a `Blob` for download. One less route serving secrets.
+
+### State machine
+
+`Created` → `Authenticated` (Steam callback) → `Registering` (steps 1,2,3) → `Ready` (step 5 done;
+credentials shown, download offered) → optionally `AwaitingPairing` → `Paired`. `Failed` is
+reachable from anywhere.
+
+There is deliberately **no terminal `Expired` state**. A pairing wait that times out returns the
+session to `Ready` and emits an `expired` event — which is what makes the retry promised in the
+error-handling table actually possible, since the pairing endpoint only accepts a `Ready` session.
+A session that outlives its own TTL is removed by the sweeper rather than parked in a state nobody
+can observe.
+
+### What the page hands back
+
+- On `Ready`: `rustplus.config.json` as a download, plus the values rendered on-page.
+- On `Paired`: the four values (`ip`, `port`, `playerId`, `playerToken`) and a copyable
+  `new RustPlus(new RustPlusConnection(...))` line, matching what the console sample prints.
+
+## Trust and secret handling
+
+The page transits the user's Steam auth token, their FCM credentials, and ultimately their
+`playerToken` — which is full Rust+ account access. Facepunch's own login page carries an HTML
+comment warning not to share it.
+
+### Lifetimes
+
+| Secret | Lives | Dropped |
+|---|---|---|
+| Steam auth token | Session object, in memory | Immediately after step 5 succeeds. Reference nulled; never retained for display. |
+| FCM / GCM / Expo credentials | Session, in memory | Session disposal (TTL or completion) |
+| `playerToken` | Session, in memory, only across the `Ready`→`Paired` window | Session disposal |
+
+### Never logged
+
+Request logging is suppressed for `/callback/{returnToken}` specifically. ASP.NET Core logs the path
+**and query** at Information by default, which would write the Steam token straight into stdout.
+This gets an explicit test (below), not just a code comment.
+
+Also: `Referrer-Policy: no-referrer`; a CSP admitting no third-party origins; `Cache-Control:
+no-store` on every dynamic response.
+
+### Never persisted
+
+No database, no session cache, no disk. The container runs with a read-only root filesystem, which
+turns the promise into something the runtime enforces rather than something the code intends.
+
+### The honest admission
+
+The server **does** see the Steam token in the request line, because Facepunch decides the callback
+shape and nothing in this design can change that. The tempting fix — respond 200 and have JavaScript
+POST the token as a request body — buys nothing, because the GET already carried it, and costs the
+302's history benefit. So the design mitigates rather than eliminates: minimum lifetime, no logging,
+no persistence, no history entry. This is stated plainly on the page, not only in this document.
+
+### The gap outside the app's control
+
+A default nginx or Caddy access log records the full request line including the query. A
+self-hoster who does everything else right can still end up with Steam tokens in `/var/log`. This
+gets a prominent README section with a worked log-format snippet, and the public instance is
+configured accordingly.
+
+### Startup refuses to run insecurely
+
+`PublicBaseUrl` must be `https://` or the app exits, with a single explicit
+`--allow-insecure-base-url` escape hatch for localhost development. `PublicBaseUrl` is required
+rather than inferred: behind a reverse proxy the externally-reachable address is not what Kestrel
+sees, and `returnUrl` must be the external one.
+
+## Bounding
+
+All counters in memory, all knobs configurable, defaults tuned for self-host; the values below are
+the public instance's.
+
+| Knob | Public default | Rationale |
+|---|---|---|
+| Global concurrent sessions | 200 | Memory backstop |
+| Global concurrent pairings (MCS sockets) | 50 | The genuinely scarce resource |
+| Active sessions per IP | 1 | One human, one flow (see eviction rule below) |
+| Completed flows per IP per hour | 5 | Bounds Google device registrations |
+| TTL — `Created` (pre-Steam) | 5 min | Cheapest state to spam, shortest leash |
+| TTL — authenticated session | 15 min | |
+| TTL — pairing wait | 10 min | Bounds socket hold time |
+
+A `PeriodicTimer` background service sweeps expired sessions and disposes their sockets. Over-cap
+requests get a 429 whose body says "try again shortly — or run your own instance", with the
+`docker run` line.
+
+**Eviction, not rejection, for abandoned sessions.** A one-session-per-IP cap would otherwise lock a
+user out for five minutes because they closed the tab and started over — the single most likely
+thing a confused first-time visitor does. So `POST /api/sessions` from an IP that already holds a
+session in `Created` state **evicts** the old one and issues a new one. An IP holding a session past
+`Created` — one where real upstream work has been done — gets the 429 instead; that session is
+resumable via its `sessionId`, so there is nothing to start over.
+
+Captcha was rejected: a third-party script tag would undermine the single-auditable-file property
+that the trust story leans on, and it adds a Cloudflare dependency plus a knob self-hosters must be
+able to switch off. Steam-first ordering already makes the expensive resources cost a real Steam
+account. Revisit if distributed abuse actually materialises.
+
+**Proxy trap.** Per-IP limits are worthless behind a reverse proxy unless `ForwardedHeaders` is
+configured with `KnownProxies` — otherwise every visitor presents as the proxy and shares one
+bucket. Configured the other way, anyone can spoof `X-Forwarded-For` to dodge the limits. This must
+be correct in the shipped compose file and called out in the README.
+
+## Error handling
+
+| Case | Behaviour |
+|---|---|
+| Callback `returnToken` unknown or already consumed | 404. No information about whether the token ever existed. |
+| Callback missing or blank `token` | `ParseCallback` throws; session → `Failed`; the page shows "the Steam login didn't complete — start over". |
+| Facepunch changes the callback contract | Same path as above; the `InvalidOperationException` message already points at `RegistrationConstants`. |
+| Any of steps 1,2,3,5 fails upstream | Session → `Failed` with a step-named message over SSE. Credentials already acquired are dropped, not retried automatically. |
+| Pairing push never arrives before TTL | Socket disposed, pairing slot released, session returns to `Ready` and an `expired` event is emitted. The page offers to retry the pairing step without redoing the Steam login. |
+| SSE stream drops | Client reconnects with the same `sessionId` and resumes; server-side state and the MCS socket are untouched. |
+| Any cap exceeded | 429 with the self-host pointer. |
+| `PublicBaseUrl` missing or not `https` | Startup fails with a message naming the setting and the escape hatch. |
+
+## Testing
+
+**The coverage gate needs an adjustment.** `tools/coverage/report.sh` runs the whole solution and
+gates the *merged* aggregate at line 95 / branch 90. Adding a web app would drag that number down
+and quietly weaken the **library's** gate. Fix: filter the app assembly out of the merged report so
+the library gate stays byte-for-byte what it is today, and add a second gate for the app in the same
+script, held to the **same line 95 / branch 90**. The app can meet that bar because the two
+untestable regions — `Program.cs` wiring and the upstream adapter — are `[ExcludeFromCodeCoverage]`
+with justifications, leaving `SessionStore`, `CredentialFlow` and the endpoint handlers, all of
+which are ordinary unit-testable code. This matches the repo's existing posture: everything is
+expected at 100/100 minus a justified exclusion list.
+
+**Testability seam.** The app defines a thin adapter interface over the four live-network classes
+and `CredentialFlow` depends on that, so flow tests never touch Google or Facepunch. The adapter
+implementation is `[ExcludeFromCodeCoverage]` with per-member justifications, following the
+convention already documented in `docs/development/testing.md`. No interfaces are added to the
+shipped library.
+
+Covered:
+
+- `SessionStore` — TTL expiry per state, sweeper disposal, single-use `returnToken`, replay
+  rejection, every cap, per-IP accounting
+- Callback — unknown token → 404, missing `token` → `Failed`, correct 302 target, replay → 404
+- Startup validation — non-`https` `PublicBaseUrl` refuses to boot; the escape hatch works
+- SSE — event sequence per state transition; reconnect resumes the same session
+- `CredentialFlow` — the `4→1,2,3→5` ordering, and that a failure at each step lands in `Failed`
+
+**The promise test.** Drive a full callback through `WebApplicationFactory` with a capturing
+`ILoggerProvider`, and assert the Steam token and the `playerToken` appear in **no** log record.
+This is the test that defends the trust section rather than merely documenting it.
+
+The app is net10.0-only, so its test project targets `net10.0` alone — the multi-TFM parity
+requirement applies to `src/` and does not extend here.
+
+## Packaging and CD
+
+- Multi-stage `Dockerfile`, non-root user, read-only root filesystem.
+- `CI.yml` builds and tests the new project.
+- `CD.yml` gains a job publishing a multi-arch (amd64/arm64) image to `ghcr.io` on release, tagged
+  with the release tag and `latest`.
+- A minimal `docker-compose.yml` and a worked Caddy snippet ship as **copyable documentation**, not
+  as a supported second install path. Rationale: the two worst self-host footguns — a default access
+  log that leaks Steam tokens, and `ForwardedHeaders` misconfiguration that silently voids per-IP
+  limits — are both configuration mistakes that a paragraph of prose will not reliably prevent.
+
+## Documentation fallout
+
+| File | Change |
+|---|---|
+| `apps/RustPlusApi.CredentialsWeb/README.md` | New. Self-host guide: `docker run` one-liner, `PublicBaseUrl`, the proxy log-format snippet, the `ForwardedHeaders` warning, every config knob. |
+| `docs/articles/credentials.md` | Add the website as the recommended route; keep the console app as the local one. |
+| `docs/articles/troubleshooting.md` | New section: callback 404s, 429s, the pairing push not arriving. |
+| `docs/articles/getting-started.md` | Point at the website first. |
+| `README.md` (root) | Mention the public instance and the self-host image. |
+| `CLAUDE.md` | Add the `apps/` layer to the architecture description, and note it is outside the multi-TFM parity story. |
+| `docs/development/testing.md` | Document the app's coverage gate and its exclusion justifications. |
+| `docs/superpowers/specs/2026-09-02-browser-agnostic-steam-login-design.md` | Amend "Assumptions to re-verify" with the 2026-09-03 verification log above. |
+
+## Out of scope
+
+- Accounts, logins or any notion of a returning user.
+- Any UI for managing or retrieving past credentials.
+- Storing a credential server-side beyond the session TTL.
+- Changes to `RustPlusApi.Fcm.Registration` or any other shipped package.
+- The Rust+ client functionality itself — the site stops at the four pairing values.
+
+## Assumptions to re-verify
+
+- **An external non-loopback `https` hostname completes the round trip.** Probes 1 and 2 show no
+  validation gate exists that could reject one, and probe 3 proves the scheme and port. Confirm
+  against the first staging deployment before the public instance is announced. If it fails, the
+  self-host starter still works on `https://localhost` and the public instance is the only casualty.
+- **`PairingListener` reliably surfaces the first pairing push after a fresh registration.** A prior
+  investigation found the first push could be missed; four fixes landed. The website makes this
+  user-visible in a way the console app did not — a missed first push reads as "the site is broken".
+  Validate during implementation with a real pairing.
+
+## Success criteria
+
+1. A visitor with no .NET installed completes the flow in a browser and downloads a working
+   `rustplus.config.json`.
+2. The same visitor opts into the pairing step, pairs in game, and gets four values that
+   successfully construct a working `RustPlus` connection.
+3. The promise test passes: no Steam token and no `playerToken` appears in any log record.
+4. `docker run -p 8080:8080 ghcr.io/handys11/rustplusapi-credentials` serves the app on a machine
+   with no .NET SDK.
+5. Startup refuses a non-`https` `PublicBaseUrl` without the escape hatch.
+6. Every cap in the bounding table is enforced and covered by a test.
+7. `dtk dotnet build` is clean under `TreatWarningsAsErrors`; `dotnet jb cleanupcode` produces no diff;
+   `tools/coverage/report.sh` passes both the unchanged library gate and the new app gate.

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/AppOptionsValidatorTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/AppOptionsValidatorTests.cs
@@ -5,7 +5,10 @@ namespace RustPlusApi.CredentialsWeb.UnitTests;
 
 public sealed class AppOptionsValidatorTests
 {
-    private static AppOptions Valid() => new() { PublicBaseUrl = "https://creds.example.org" };
+    private static AppOptions Valid() => new()
+    {
+        PublicBaseUrl = "https://creds.example.org"
+    };
 
     [Fact]
     public void Validate_ReturnsNull_ForHttpsBaseUrl()

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/AppOptionsValidatorTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/AppOptionsValidatorTests.cs
@@ -1,0 +1,117 @@
+using RustPlusApi.CredentialsWeb;
+using Xunit;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class AppOptionsValidatorTests
+{
+    private static AppOptions Valid() => new() { PublicBaseUrl = "https://creds.example.org" };
+
+    [Fact]
+    public void Validate_ReturnsNull_ForHttpsBaseUrl()
+    {
+        Assert.Null(AppOptionsValidator.Validate(Valid()));
+    }
+
+    [Fact]
+    public void Validate_Rejects_BlankBaseUrl()
+    {
+        var options = Valid();
+        options.PublicBaseUrl = "   ";
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("PublicBaseUrl", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_Rejects_HttpBaseUrl()
+    {
+        var options = Valid();
+        options.PublicBaseUrl = "http://creds.example.org";
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("AllowInsecureBaseUrl", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_Allows_HttpBaseUrl_WhenEscapeHatchSet()
+    {
+        var options = Valid();
+        options.PublicBaseUrl = "http://localhost:8080";
+        options.AllowInsecureBaseUrl = true;
+
+        Assert.Null(AppOptionsValidator.Validate(options));
+    }
+
+    [Fact]
+    public void Validate_Rejects_BaseUrlWithTrailingSlash()
+    {
+        var options = Valid();
+        options.PublicBaseUrl = "https://creds.example.org/";
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("trailing", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_Rejects_NonAbsoluteBaseUrl()
+    {
+        var options = Valid();
+        options.PublicBaseUrl = "creds.example.org";
+
+        Assert.NotNull(AppOptionsValidator.Validate(options));
+    }
+
+    [Fact]
+    public void Validate_Rejects_AKnownProxyThatIsNotAnIpAddress()
+    {
+        var options = Valid();
+        options.KnownProxies.Add("proxy.example.org");
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("KnownProxies", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_Accepts_AKnownProxyIpAddress()
+    {
+        var options = Valid();
+        options.KnownProxies.Add("172.18.0.2");
+
+        Assert.Null(AppOptionsValidator.Validate(options));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_Rejects_NonPositiveSessionLimit(int limit)
+    {
+        var options = Valid();
+        options.MaxConcurrentSessions = limit;
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("MaxConcurrentSessions", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_Rejects_NonPositiveTtl()
+    {
+        var options = Valid();
+        options.SessionTtl = TimeSpan.Zero;
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("SessionTtl", error, StringComparison.Ordinal);
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/AppOptionsValidatorTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/AppOptionsValidatorTests.cs
@@ -114,4 +114,52 @@ public sealed class AppOptionsValidatorTests
         Assert.NotNull(error);
         Assert.Contains("SessionTtl", error, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void Validate_Rejects_NonPositivePairingLimit()
+    {
+        var options = Valid();
+        options.MaxConcurrentPairings = 0;
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("MaxConcurrentPairings", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_Rejects_NonPositiveCompletionsPerIpPerHour()
+    {
+        var options = Valid();
+        options.MaxCompletionsPerIpPerHour = 0;
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("MaxCompletionsPerIpPerHour", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_Rejects_NonPositiveCreatedTtl()
+    {
+        var options = Valid();
+        options.CreatedTtl = TimeSpan.Zero;
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("CreatedTtl", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_Rejects_NonPositivePairingTtl()
+    {
+        var options = Valid();
+        options.PairingTtl = TimeSpan.Zero;
+
+        var error = AppOptionsValidator.Validate(options);
+
+        Assert.NotNull(error);
+        Assert.Contains("PairingTtl", error, StringComparison.Ordinal);
+    }
 }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/AssemblyInfo.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+// CredentialsWebFactory configures the app through process-global environment variables — the only
+// channel Program.cs reads before builder.Build(), which is earlier than any WebApplicationFactory
+// hook runs. Parallel classes would overwrite each other's settings, so the assembly runs serially.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/CallbackEndpointTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/CallbackEndpointTests.cs
@@ -1,5 +1,7 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
+using RustPlusApi.CredentialsWeb.Endpoints;
 using RustPlusApi.CredentialsWeb.Sessions;
 using Xunit;
 
@@ -103,5 +105,57 @@ public sealed class CallbackEndpointTests
             new Uri($"/callback/{session.ReturnToken}?steamId=not-a-number&token=steam-token", UriKind.Relative));
 
         Assert.Equal(SessionState.Failed, session.State);
+    }
+
+    [Fact]
+    public async Task Callback_WithAMalformedCallback_ExtendsTheSessionExpiryPastItsOriginalCreatedTtl()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = NoRedirectClient(factory);
+        var session = NewSession(factory);
+        var originalExpiry = session.ExpiresAt;
+
+        await client.GetAsync(
+            new Uri($"/callback/{session.ReturnToken}?steamId=76561198249527954", UriKind.Relative));
+
+        // A real Steam round-trip (2FA included) can consume most of the short CreatedTtl the session
+        // was created with. A Failed transition that kept that original expiry would risk the sweeper
+        // removing the session — and its error event — before the visitor's browser reads it back. So
+        // this must use the same SessionTtl-based deadline as every other Failed transition.
+        Assert.True(
+            session.ExpiresAt > originalExpiry,
+            $"Expected the expiry to move past {originalExpiry:O}, but it stayed at {session.ExpiresAt:O}.");
+    }
+
+    [Fact]
+    public void TryParseSteamLogin_ReturnsTrue_ForAWellFormedCallback()
+    {
+        var parsed = CallbackEndpoints.TryParseSteamLogin(
+            CredentialsWebFactory.BaseUrl,
+            new PathString("/callback/abc123"),
+            new QueryString("?steamId=76561198249527954&token=steam-token"),
+            out var login);
+
+        Assert.True(parsed);
+        Assert.NotNull(login);
+        Assert.Equal(76561198249527954UL, login.SteamId);
+        Assert.Equal("steam-token", login.Token);
+    }
+
+    [Fact]
+    public void TryParseSteamLogin_ReturnsFalse_WhenBuildingTheUriThrowsUriFormatException()
+    {
+        // A malformed host is unreachable through a real request — PublicBaseUrl is validated
+        // absolute at startup, and Kestrel has already rejected anything that would leave the path or
+        // query URI-illegal by the time a request is accepted. Forcing it here, directly against the
+        // extracted method, is the only way to exercise this branch without a contrived HTTP test.
+        var parsed = CallbackEndpoints.TryParseSteamLogin(
+            "https://exa mple.org",
+            new PathString("/callback/abc123"),
+            new QueryString("?steamId=76561198249527954&token=steam-token"),
+            out var login);
+
+        Assert.False(parsed);
+        Assert.Null(login);
     }
 }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/CallbackEndpointTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/CallbackEndpointTests.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using RustPlusApi.CredentialsWeb.Sessions;
+using Xunit;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class CallbackEndpointTests
+{
+    private static HttpClient NoRedirectClient(CredentialsWebFactory factory) =>
+        factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+    private static Session NewSession(CredentialsWebFactory factory)
+    {
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryCreate("203.0.113.7", out var session, out _);
+        return session!;
+    }
+
+    private static Uri CallbackUri(string returnToken) =>
+        new($"/callback/{returnToken}?steamId=76561198249527954&token=steam-token", UriKind.Relative);
+
+    [Fact]
+    public async Task Callback_Redirects302ToTheFragmentCarryingTheSessionId()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = NoRedirectClient(factory);
+        var session = NewSession(factory);
+
+        var response = await client.GetAsync(CallbackUri(session.ReturnToken));
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Equal($"/#session={session.SessionId}", response.Headers.Location!.ToString());
+    }
+
+    [Fact]
+    public async Task Callback_DrivesTheFlowToReady()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = NoRedirectClient(factory);
+        var session = NewSession(factory);
+
+        await client.GetAsync(CallbackUri(session.ReturnToken));
+        await session.BackgroundWork;
+
+        Assert.Equal(SessionState.Ready, session.State);
+        Assert.Equal("steam-token", factory.Steps.SteamTokenSeen);
+        Assert.Null(session.SteamToken);
+    }
+
+    [Fact]
+    public async Task Callback_Returns404_ForAnUnknownReturnToken()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = NoRedirectClient(factory);
+
+        var response = await client.GetAsync(CallbackUri("0123456789abcdef0123456789abcdef"));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Callback_Returns404_WhenReplayed()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = NoRedirectClient(factory);
+        var session = NewSession(factory);
+
+        var first = await client.GetAsync(CallbackUri(session.ReturnToken));
+        var second = await client.GetAsync(CallbackUri(session.ReturnToken));
+
+        Assert.Equal(HttpStatusCode.Found, first.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, second.StatusCode);
+    }
+
+    [Fact]
+    public async Task Callback_WithNoToken_FailsTheSessionButStillRedirects()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = NoRedirectClient(factory);
+        var session = NewSession(factory);
+
+        var response = await client.GetAsync(
+            new Uri($"/callback/{session.ReturnToken}?steamId=76561198249527954", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Equal($"/#session={session.SessionId}", response.Headers.Location!.ToString());
+        Assert.Equal(SessionState.Failed, session.State);
+        Assert.Empty(factory.Steps.Calls);
+    }
+
+    [Fact]
+    public async Task Callback_WithANonNumericSteamId_FailsTheSession()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = NoRedirectClient(factory);
+        var session = NewSession(factory);
+
+        await client.GetAsync(
+            new Uri($"/callback/{session.ReturnToken}?steamId=not-a-number&token=steam-token", UriKind.Relative));
+
+        Assert.Equal(SessionState.Failed, session.State);
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/CapturingLoggerProvider.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/CapturingLoggerProvider.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Logging;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+/// <summary>Captures every log record the app writes, at every level, so a test can assert on what
+/// is absent from them.</summary>
+internal sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    private readonly List<string> _records = [];
+
+    /// <summary>Formatted messages, each with its exception appended.</summary>
+    internal IReadOnlyList<string> Records
+    {
+        get
+        {
+            lock (_records)
+            {
+                return _records.ToArray();
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public ILogger CreateLogger(string categoryName) => new CapturingLogger(_records, categoryName);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        // Nothing to release.
+    }
+
+    private sealed class CapturingLogger(List<string> records, string category) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var line = $"{category}: {formatter(state, exception)} {exception}";
+            lock (records)
+            {
+                records.Add(line);
+            }
+        }
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowPairingTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowPairingTests.cs
@@ -16,7 +16,10 @@ public sealed class CredentialFlowPairingTests
         ReadySessionAsync(Action<AppOptions>? configure = null)
     {
         var time = new FakeTimeProvider(Origin);
-        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        var options = new AppOptions
+        {
+            PublicBaseUrl = "https://creds.example.org"
+        };
         configure?.Invoke(options);
         var store = new SessionStore(options, time);
         var steps = new FakeRegistrationSteps();

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowPairingTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowPairingTests.cs
@@ -331,4 +331,61 @@ public sealed class CredentialFlowPairingTests
         Assert.Empty(steps.Calls);
         Assert.Equal(0, store.ActivePairings);
     }
+
+    [Fact]
+    public async Task WaitForPairingAsync_RefusesOnceTheSessionHasBeenDisposed()
+    {
+        // Disposal drops the credentials but leaves State alone, so a session removed between the
+        // endpoint's advisory Ready check and this call still reads Ready here. The claim refuses on
+        // the missing credentials instead of opening a socket with nothing to pair against — and
+        // reads them under the session's own lock, so they cannot be nulled between check and use.
+        var (flow, store, steps, session) = await ReadySessionAsync();
+        using var _s = store;
+        store.Remove(session.SessionId);
+        store.TryAcquirePairingSlot();
+
+        await flow.WaitForPairingAsync(session, CancellationToken.None);
+
+        Assert.Equal(SessionState.Ready, session.State);
+        Assert.Empty(steps.Calls);
+        Assert.Equal(0, store.ActivePairings);
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_LetsOnlyOneOfTwoConcurrentWaitsClaimTheSession()
+    {
+        // Two POSTs to /api/sessions/{sessionId}/pairing for one session — two tabs on the same
+        // handle, or a retried request — both clear the endpoint's advisory Ready check and both
+        // land here. A Ready check followed by a separate Advance let both through, so both opened
+        // an MCS socket against the same credentials and whichever finished last overwrote the
+        // other's outcome: a timeout dropping an already-Paired session back to Ready with a
+        // spurious `expired` event, or a socket error flipping it to Failed.
+        // Session.TryClaimForPairing is what now holds the session to a single wait.
+        var (flow, store, steps, session) = await ReadySessionAsync();
+        using var _s = store;
+        steps.PairingWaitsForGate = true;
+        Assert.True(store.TryAcquirePairingSlot());
+        Assert.True(store.TryAcquirePairingSlot());
+
+        // CA2025: both tasks are awaited below, well before `_s`/`store` are disposed at method end.
+#pragma warning disable CA2025
+        var winner = flow.WaitForPairingAsync(session, CancellationToken.None);
+        var loser = flow.WaitForPairingAsync(session, CancellationToken.None);
+#pragma warning restore CA2025
+
+        // The claim runs before the first await, so the second dispatch has already lost by the time
+        // it hands its task back: nothing started, and its slot handed straight back.
+        await loser;
+
+        Assert.Equal(SessionState.AwaitingPairing, session.State);
+        Assert.Equal(1, store.ActivePairings);
+        Assert.Single(steps.Calls);
+
+        // The winner still finishes normally: one socket, one outcome, nothing to overwrite it.
+        steps.PairingGate.SetResult();
+        await winner;
+
+        Assert.Equal(SessionState.Paired, session.State);
+        Assert.Equal(0, store.ActivePairings);
+    }
 }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowPairingTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowPairingTests.cs
@@ -100,8 +100,12 @@ public sealed class CredentialFlowPairingTests
 #pragma warning disable CA2025
         var pending = flow.WaitForPairingAsync(session, CancellationToken.None);
 #pragma warning restore CA2025
+        // Bounded: a regression that never reaches AwaitingPairing must fail as an assertion,
+        // not park a foreground thread and hang the test process.
+        using var reachTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         while (session.State != SessionState.AwaitingPairing)
         {
+            Assert.False(reachTimeout.IsCancellationRequested, "The flow never reached AwaitingPairing.");
             await Task.Delay(10);
         }
 
@@ -143,8 +147,12 @@ public sealed class CredentialFlowPairingTests
 #pragma warning disable CA2025
         var pending = flow.WaitForPairingAsync(session, cancellation.Token);
 #pragma warning restore CA2025
+        // Bounded: a regression that never reaches AwaitingPairing must fail as an assertion,
+        // not park a foreground thread and hang the test process.
+        using var reachTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         while (session.State != SessionState.AwaitingPairing)
         {
+            Assert.False(reachTimeout.IsCancellationRequested, "The flow never reached AwaitingPairing.");
             await Task.Delay(10);
         }
 
@@ -172,8 +180,12 @@ public sealed class CredentialFlowPairingTests
 #pragma warning disable CA2025
         var pending = flow.WaitForPairingAsync(session, cancellation.Token);
 #pragma warning restore CA2025
+        // Bounded: a regression that never reaches AwaitingPairing must fail as an assertion,
+        // not park a foreground thread and hang the test process.
+        using var reachTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         while (session.State != SessionState.AwaitingPairing)
         {
+            Assert.False(reachTimeout.IsCancellationRequested, "The flow never reached AwaitingPairing.");
             await Task.Delay(10);
         }
 

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowPairingTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowPairingTests.cs
@@ -1,0 +1,205 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using RustPlusApi.CredentialsWeb;
+using RustPlusApi.CredentialsWeb.Flow;
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.Fcm.Registration;
+using Xunit;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class CredentialFlowPairingTests
+{
+    private static readonly DateTimeOffset Origin = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    private static async Task<(CredentialFlow Flow, SessionStore Store, FakeRegistrationSteps Steps, Session Session)>
+        ReadySessionAsync(Action<AppOptions>? configure = null)
+    {
+        var time = new FakeTimeProvider(Origin);
+        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        configure?.Invoke(options);
+        var store = new SessionStore(options, time);
+        var steps = new FakeRegistrationSteps();
+        var flow = new CredentialFlow(steps, store, options, time, NullLogger<CredentialFlow>.Instance);
+
+        store.TryCreate("203.0.113.7", out var session, out _);
+        await flow.CompleteRegistrationAsync(
+            session!,
+            new SteamLoginResult(76561198249527954, "steam-token"),
+            CancellationToken.None);
+
+        steps.Calls.Clear();
+        return (flow, store, steps, session!);
+    }
+
+    /// <summary>Drains the buffered events; the short window is what ends the open-ended stream.</summary>
+    /// <param name="session">The session whose event stream is drained.</param>
+    private static async Task<List<SessionEvent>> EventsOfAsync(Session session)
+    {
+        var received = new List<SessionEvent>();
+        using var window = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        try
+        {
+            await foreach (var item in session.Events.SubscribeAsync(window.Token))
+            {
+                received.Add(item);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected: the window closed.
+        }
+
+        return received;
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_ReachesPairedAndPublishesTheFourValues()
+    {
+        var (flow, store, _, session) = await ReadySessionAsync();
+        using var _s = store;
+        store.TryAcquirePairingSlot();
+
+        await flow.WaitForPairingAsync(session, CancellationToken.None);
+
+        Assert.Equal(SessionState.Paired, session.State);
+
+        var events = await EventsOfAsync(session);
+        var payload = Assert.IsType<PairedPayload>(Assert.Single(events, e => e.Type == "paired").Data);
+
+        Assert.Equal("10.0.0.1", payload.Ip);
+        Assert.Equal(28082, payload.Port);
+        Assert.Equal("76561198249527954", payload.PlayerId);
+        Assert.Equal(987654321, payload.PlayerToken);
+        Assert.Equal("Test Server", payload.Name);
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_ReleasesThePairingSlotOnSuccess()
+    {
+        var (flow, store, _, session) = await ReadySessionAsync();
+        using var _s = store;
+        store.TryAcquirePairingSlot();
+
+        await flow.WaitForPairingAsync(session, CancellationToken.None);
+
+        Assert.Equal(0, store.ActivePairings);
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_MovesToAwaitingPairingWithThePairingTtl()
+    {
+        var (flow, store, steps, session) = await ReadySessionAsync(o => o.PairingTtl = TimeSpan.FromMinutes(10));
+        using var _s = store;
+        steps.PairingWaitsForGate = true;
+        store.TryAcquirePairingSlot();
+
+        // CA2025: the task is deliberately observed mid-flight (polling for AwaitingPairing) before
+        // being awaited below, which happens well before `_s`/`store` are disposed at method end.
+#pragma warning disable CA2025
+        var pending = flow.WaitForPairingAsync(session, CancellationToken.None);
+#pragma warning restore CA2025
+        while (session.State != SessionState.AwaitingPairing)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.Equal(Origin.AddMinutes(10), session.ExpiresAt);
+
+        steps.PairingGate.SetResult();
+        await pending;
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_ReleasesTheSlotWhenTheWaitFails()
+    {
+        var (flow, store, steps, session) = await ReadySessionAsync();
+        using var _s = store;
+        steps.PairingFailure = new InvalidOperationException("socket died");
+        store.TryAcquirePairingSlot();
+
+        await flow.WaitForPairingAsync(session, CancellationToken.None);
+
+        Assert.Equal(0, store.ActivePairings);
+        Assert.Equal(SessionState.Failed, session.State);
+
+        var events = await EventsOfAsync(session);
+        var error = Assert.IsType<ErrorPayload>(Assert.Single(events, e => e.Type == "error").Data);
+        Assert.DoesNotContain("socket died", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_ReturnsToReadyAndReleasesTheSlotWhenCancelled()
+    {
+        var (flow, store, steps, session) = await ReadySessionAsync();
+        using var _s = store;
+        steps.PairingWaitsForGate = true;
+        store.TryAcquirePairingSlot();
+
+        using var cancellation = new CancellationTokenSource();
+
+        // CA2025: awaited below, well before `cancellation` or `_s`/`store` are disposed.
+#pragma warning disable CA2025
+        var pending = flow.WaitForPairingAsync(session, cancellation.Token);
+#pragma warning restore CA2025
+        while (session.State != SessionState.AwaitingPairing)
+        {
+            await Task.Delay(10);
+        }
+
+        await cancellation.CancelAsync();
+        await pending;
+
+        Assert.Equal(0, store.ActivePairings);
+        Assert.Equal(SessionState.Ready, session.State);
+
+        var events = await EventsOfAsync(session);
+        Assert.Contains(events, e => e.Type == "expired");
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_CanBeRetriedAfterATimeout()
+    {
+        var (flow, store, steps, session) = await ReadySessionAsync();
+        using var _s = store;
+        steps.PairingWaitsForGate = true;
+        store.TryAcquirePairingSlot();
+
+        using var cancellation = new CancellationTokenSource();
+
+        // CA2025: awaited below, well before `cancellation` or `_s`/`store` are disposed.
+#pragma warning disable CA2025
+        var pending = flow.WaitForPairingAsync(session, cancellation.Token);
+#pragma warning restore CA2025
+        while (session.State != SessionState.AwaitingPairing)
+        {
+            await Task.Delay(10);
+        }
+
+        await cancellation.CancelAsync();
+        await pending;
+
+        // The second attempt must be accepted: this is what the "retry without redoing the Steam
+        // login" promise actually depends on.
+        steps.PairingWaitsForGate = false;
+        Assert.True(store.TryAcquirePairingSlot());
+        await flow.WaitForPairingAsync(session, CancellationToken.None);
+
+        Assert.Equal(SessionState.Paired, session.State);
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_RefusesWhenTheSessionIsNotReady()
+    {
+        var (flow, store, steps, session) = await ReadySessionAsync();
+        using var _s = store;
+        session.Advance(SessionState.Failed, Origin.AddMinutes(15));
+        store.TryAcquirePairingSlot();
+
+        await flow.WaitForPairingAsync(session, CancellationToken.None);
+
+        Assert.Empty(steps.Calls);
+        Assert.Equal(0, store.ActivePairings);
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowPairingTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowPairingTests.cs
@@ -35,6 +35,33 @@ public sealed class CredentialFlowPairingTests
         return (flow, store, steps, session!);
     }
 
+    /// <summary>Same as <see cref="ReadySessionAsync"/> but also hands back the clock, for tests that
+    /// need to drive the pairing wait's own TimeProvider-based deadline instead of a standalone
+    /// <see cref="CancellationTokenSource"/> that production never constructs.</summary>
+    /// <param name="configure">Optional options tweak.</param>
+    private static async Task<(CredentialFlow Flow, SessionStore Store, FakeRegistrationSteps Steps,
+        Session Session, FakeTimeProvider Time)> ReadySessionWithClockAsync(Action<AppOptions>? configure = null)
+    {
+        var time = new FakeTimeProvider(Origin);
+        var options = new AppOptions
+        {
+            PublicBaseUrl = "https://creds.example.org"
+        };
+        configure?.Invoke(options);
+        var store = new SessionStore(options, time);
+        var steps = new FakeRegistrationSteps();
+        var flow = new CredentialFlow(steps, store, options, time, NullLogger<CredentialFlow>.Instance);
+
+        store.TryCreate("203.0.113.7", out var session, out _);
+        await flow.CompleteRegistrationAsync(
+            session!,
+            new SteamLoginResult(76561198249527954, "steam-token"),
+            CancellationToken.None);
+
+        steps.Calls.Clear();
+        return (flow, store, steps, session!, time);
+    }
+
     /// <summary>Drains the buffered events; the short window is what ends the open-ended stream.</summary>
     /// <param name="session">The session whose event stream is drained.</param>
     private static async Task<List<SessionEvent>> EventsOfAsync(Session session)
@@ -91,9 +118,18 @@ public sealed class CredentialFlowPairingTests
     }
 
     [Fact]
-    public async Task WaitForPairingAsync_MovesToAwaitingPairingWithThePairingTtl()
+    public async Task WaitForPairingAsync_MovesToAwaitingPairingWithTheSessionTtlNotThePairingTtl()
     {
-        var (flow, store, steps, session) = await ReadySessionAsync(o => o.PairingTtl = TimeSpan.FromMinutes(10));
+        // PairingTtl and SessionTtl are deliberately different: if AwaitingPairing's expiry ever
+        // regresses to PairingTtl, the sweeper would reap the session the moment the pairing wait's
+        // own (much shorter) deadline elapses — see
+        // WaitForPairingAsync_SurvivesASweepPastThePairingTtlButBeforeTheSessionTtl below for that
+        // regression caught end to end.
+        var (flow, store, steps, session) = await ReadySessionAsync(o =>
+        {
+            o.PairingTtl = TimeSpan.FromMinutes(10);
+            o.SessionTtl = TimeSpan.FromMinutes(20);
+        });
         using var _s = store;
         steps.PairingWaitsForGate = true;
         store.TryAcquirePairingSlot();
@@ -112,7 +148,7 @@ public sealed class CredentialFlowPairingTests
             await Task.Delay(10);
         }
 
-        Assert.Equal(Origin.AddMinutes(10), session.ExpiresAt);
+        Assert.Equal(Origin.AddMinutes(20), session.ExpiresAt);
 
         steps.PairingGate.SetResult();
         await pending;
@@ -137,18 +173,20 @@ public sealed class CredentialFlowPairingTests
     }
 
     [Fact]
-    public async Task WaitForPairingAsync_ReturnsToReadyAndReleasesTheSlotWhenCancelled()
+    public async Task WaitForPairingAsync_StaysSilentWhenTheSessionIsDisposed()
     {
+        // Production only ever calls this with session.Lifetime.Token (see SessionEndpoints), and
+        // the only way that token is ever cancelled is SessionStore.Remove disposing the session.
+        // A standalone CancellationTokenSource that production never constructs would exercise a
+        // scenario that cannot actually happen, so this drives the real disposal path instead.
         var (flow, store, steps, session) = await ReadySessionAsync();
         using var _s = store;
         steps.PairingWaitsForGate = true;
         store.TryAcquirePairingSlot();
 
-        using var cancellation = new CancellationTokenSource();
-
-        // CA2025: awaited below, well before `cancellation` or `_s`/`store` are disposed.
+        // CA2025: awaited below, well before `_s`/`store` are disposed at method end.
 #pragma warning disable CA2025
-        var pending = flow.WaitForPairingAsync(session, cancellation.Token);
+        var pending = flow.WaitForPairingAsync(session, session.Lifetime.Token);
 #pragma warning restore CA2025
         // Bounded: a regression that never reaches AwaitingPairing must fail as an assertion,
         // not park a foreground thread and hang the test process.
@@ -159,29 +197,32 @@ public sealed class CredentialFlowPairingTests
             await Task.Delay(10);
         }
 
-        await cancellation.CancelAsync();
-        await pending;
+        store.Remove(session.SessionId);
+        using var doneTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await pending.WaitAsync(doneTimeout.Token);
 
+        // Disposal, not a genuine pairing timeout: nothing to report, and nobody is listening to the
+        // now-completed event stream anyway.
         Assert.Equal(0, store.ActivePairings);
-        Assert.Equal(SessionState.Ready, session.State);
-
-        var events = await EventsOfAsync(session);
-        Assert.Contains(events, e => e.Type == "expired");
+        Assert.False(store.TryGet(session.SessionId, out _));
     }
 
     [Fact]
     public async Task WaitForPairingAsync_CanBeRetriedAfterATimeout()
     {
-        var (flow, store, steps, session) = await ReadySessionAsync();
+        // Drives the pairing wait's own TimeProvider-backed deadline — the mechanism production
+        // actually uses to time a pairing wait out — rather than a standalone
+        // CancellationTokenSource cancelled by hand, which production never constructs and which
+        // exercises the (different) disposal path instead of a genuine timeout.
+        var (flow, store, steps, session, time) =
+            await ReadySessionWithClockAsync(o => o.PairingTtl = TimeSpan.FromMinutes(10));
         using var _s = store;
         steps.PairingWaitsForGate = true;
         store.TryAcquirePairingSlot();
 
-        using var cancellation = new CancellationTokenSource();
-
-        // CA2025: awaited below, well before `cancellation` or `_s`/`store` are disposed.
+        // CA2025: awaited below, well before `_s`/`store` are disposed at method end.
 #pragma warning disable CA2025
-        var pending = flow.WaitForPairingAsync(session, cancellation.Token);
+        var pending = flow.WaitForPairingAsync(session, session.Lifetime.Token);
 #pragma warning restore CA2025
         // Bounded: a regression that never reaches AwaitingPairing must fail as an assertion,
         // not park a foreground thread and hang the test process.
@@ -192,14 +233,87 @@ public sealed class CredentialFlowPairingTests
             await Task.Delay(10);
         }
 
-        await cancellation.CancelAsync();
+        time.Advance(TimeSpan.FromMinutes(10) + TimeSpan.FromSeconds(1));
+
+        // Bounded: a regression that never times the wait back out to Ready must fail as an
+        // assertion, not hang the test process.
+        using var settleTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (session.State != SessionState.Ready)
+        {
+            Assert.False(settleTimeout.IsCancellationRequested, "The pairing wait never timed out back to Ready.");
+            await Task.Delay(10);
+        }
+
         await pending;
+        Assert.Equal(0, store.ActivePairings);
+
+        var events = await EventsOfAsync(session);
+        Assert.Contains(events, e => e.Type == "expired");
 
         // The second attempt must be accepted: this is what the "retry without redoing the Steam
         // login" promise actually depends on.
         steps.PairingWaitsForGate = false;
         Assert.True(store.TryAcquirePairingSlot());
-        await flow.WaitForPairingAsync(session, CancellationToken.None);
+        await flow.WaitForPairingAsync(session, session.Lifetime.Token);
+
+        Assert.Equal(SessionState.Paired, session.State);
+    }
+
+    [Fact]
+    public async Task WaitForPairingAsync_SurvivesASweepPastThePairingTtlButBeforeTheSessionTtl()
+    {
+        // This is the regression the whole-branch review found: AwaitingPairing used to carry the
+        // *pairing* wait's TTL as the *session's* own expiry, so the sweeper reaped (and disposed)
+        // the session the moment the pairing wait's own, much shorter, deadline elapsed — long
+        // before the session's real TTL. That made the "retry the pairing wait without redoing the
+        // Steam login" promise (see the design doc's error-handling table, docs/articles/
+        // troubleshooting.md and wwwroot/app.js) impossible: by the time the OperationCanceledException
+        // handler ran, the session was already gone from the store.
+        var (flow, store, steps, session, time) = await ReadySessionWithClockAsync(o =>
+        {
+            o.PairingTtl = TimeSpan.FromMinutes(10);
+            o.SessionTtl = TimeSpan.FromMinutes(15);
+        });
+        using var _s = store;
+        steps.PairingWaitsForGate = true;
+        store.TryAcquirePairingSlot();
+
+        // CA2025: awaited below, well before `_s`/`store` are disposed at method end.
+#pragma warning disable CA2025
+        var pending = flow.WaitForPairingAsync(session, session.Lifetime.Token);
+#pragma warning restore CA2025
+        // Bounded: a regression that never reaches AwaitingPairing must fail as an assertion,
+        // not park a foreground thread and hang the test process.
+        using var reachTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (session.State != SessionState.AwaitingPairing)
+        {
+            Assert.False(reachTimeout.IsCancellationRequested, "The flow never reached AwaitingPairing.");
+            await Task.Delay(10);
+        }
+
+        // Past the pairing wait's own 10-minute deadline, but well inside the session's 15-minute
+        // TTL: the sweeper must not treat this session as expired just because the pairing wait's
+        // own wait timed out.
+        time.Advance(TimeSpan.FromMinutes(11));
+
+        Assert.Equal(0, store.SweepExpired());
+        Assert.True(store.TryGet(session.SessionId, out _), "The session was reaped by the sweeper.");
+
+        // Resumable: let the (already-fired) internal deadline settle the flow back to Ready, then
+        // prove a fresh pairing wait succeeds without redoing the Steam login.
+        using var settleTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (session.State == SessionState.AwaitingPairing)
+        {
+            Assert.False(settleTimeout.IsCancellationRequested, "The pairing wait never settled.");
+            await Task.Delay(10);
+        }
+
+        await pending;
+        Assert.Equal(SessionState.Ready, session.State);
+
+        steps.PairingWaitsForGate = false;
+        Assert.True(store.TryAcquirePairingSlot());
+        await flow.WaitForPairingAsync(session, session.Lifetime.Token);
 
         Assert.Equal(SessionState.Paired, session.State);
     }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowTests.cs
@@ -1,0 +1,200 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using RustPlusApi.CredentialsWeb;
+using RustPlusApi.CredentialsWeb.Flow;
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.Fcm.Registration;
+using Xunit;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class CredentialFlowTests
+{
+    private static readonly DateTimeOffset Origin = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    private static SteamLoginResult Login() =>
+        new(76561198249527954, "steam-token");
+
+    private static Harness NewHarness()
+    {
+        var time = new FakeTimeProvider(Origin);
+        var options = new AppOptions
+        {
+            PublicBaseUrl = "https://creds.example.org"
+        };
+        var store = new SessionStore(options, time);
+        var steps = new FakeRegistrationSteps();
+        var flow = new CredentialFlow(steps, store, options, time, NullLogger<CredentialFlow>.Instance);
+        return new Harness(flow, store, steps, time, options);
+    }
+
+    /// <summary>Drains the buffered events. The stream is open-ended while the session lives, so a
+    /// short window is what stops the enumeration.</summary>
+    /// <param name="session">The session whose event stream is drained.</param>
+    private static async Task<List<SessionEvent>> EventsOfAsync(Session session)
+    {
+        var received = new List<SessionEvent>();
+        using var window = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        try
+        {
+            await foreach (var item in session.Events.SubscribeAsync(window.Token))
+            {
+                received.Add(item);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected: the window closed.
+        }
+
+        return received;
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_RunsStepsInTheReorderedSequence()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        Assert.Equal(
+            [
+                nameof(FakeRegistrationSteps.AcquireDeviceCredentialsAsync),
+                nameof(FakeRegistrationSteps.RegisterWithCompanionAsync)
+            ],
+            h.Steps.Calls);
+        Assert.Equal("steam-token", h.Steps.SteamTokenSeen);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_ReachesReadyAndStoresCredentials()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        Assert.Equal(SessionState.Ready, session!.State);
+        Assert.NotNull(session.Credentials);
+        Assert.Equal(Origin.Add(h.Options.SessionTtl), session.ExpiresAt);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_DropsTheSteamTokenOnSuccess()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        Assert.Null(session!.SteamToken);
+        Assert.Equal(76561198249527954UL, session.SteamId);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_PublishesCredentialsWithSteamIdAsString()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        var events = await EventsOfAsync(session!);
+        var payload = Assert.IsType<CredentialsPayload>(
+            Assert.Single(events, e => e.Type == "credentials").Data);
+
+        Assert.Equal("76561198249527954", payload.SteamId);
+        Assert.Contains("ExponentPushToken", payload.ConfigJson, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_RecordsACompletionForTheAddress()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Options.MaxCompletionsPerIpPerHour = 1;
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+        h.Store.Remove(session!.SessionId);
+
+        Assert.False(h.Store.TryCreate("203.0.113.7", out _, out var failure));
+        Assert.Equal(SessionCreateFailure.HourlyLimit, failure);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_FailsWhenDeviceRegistrationThrows()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Steps.AcquireFailure = new HttpRequestException("upstream down");
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        Assert.Equal(SessionState.Failed, session!.State);
+        Assert.Null(session.SteamToken);
+
+        var events = await EventsOfAsync(session);
+        var error = Assert.IsType<ErrorPayload>(Assert.Single(events, e => e.Type == "error").Data);
+        Assert.DoesNotContain("upstream down", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_FailsWhenCompanionRegistrationThrows()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Steps.CompanionFailure = new HttpRequestException("rejected");
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        Assert.Equal(SessionState.Failed, session!.State);
+        Assert.Null(session.SteamToken);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_FailsWhenExpoTokenIsMissing()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Steps.CredentialsToReturn = new RustPlusApi.Fcm.Data.Credentials
+        {
+            ExpoPushToken = null
+        };
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        Assert.Equal(SessionState.Failed, session!.State);
+        Assert.DoesNotContain(nameof(FakeRegistrationSteps.RegisterWithCompanionAsync), h.Steps.Calls);
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_StaysQuietWhenCancelled()
+    {
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Steps.AcquireFailure = new OperationCanceledException();
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+
+        await h.Flow.CompleteRegistrationAsync(session!, Login(), CancellationToken.None);
+
+        var events = await EventsOfAsync(session!);
+        Assert.DoesNotContain(events, e => e.Type == "error");
+    }
+
+    private sealed record Harness(
+        CredentialFlow Flow,
+        SessionStore Store,
+        FakeRegistrationSteps Steps,
+        FakeTimeProvider Time,
+        AppOptions Options);
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialsWebFactory.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialsWebFactory.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using RustPlusApi.CredentialsWeb.Upstream;
 
@@ -25,6 +26,8 @@ internal sealed class CredentialsWebFactory : WebApplicationFactory<Program>
         }
     }
 
+    internal CapturingLoggerProvider Logs { get; } = new();
+
     internal FakeRegistrationSteps Steps { get; } = new();
 
     internal FakeTimeProvider Time { get; } = new(Origin);
@@ -32,14 +35,22 @@ internal sealed class CredentialsWebFactory : WebApplicationFactory<Program>
     private List<string> EnvironmentKeys { get; } = [];
 
     /// <inheritdoc/>
-    protected override void ConfigureWebHost(IWebHostBuilder builder) =>
-        builder.ConfigureServices(services =>
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureLogging(logging =>
+        {
+            // Trace, deliberately: the point is to prove the secret is absent even when everything
+            // the app is willing to emit is captured.
+            logging.SetMinimumLevel(LogLevel.Trace);
+            logging.AddProvider(Logs);
+        }).ConfigureServices(services =>
         {
             services.RemoveAll<IRegistrationSteps>();
             services.AddSingleton<IRegistrationSteps>(Steps);
             services.RemoveAll<TimeProvider>();
             services.AddSingleton<TimeProvider>(Time);
         });
+    }
 
     /// <inheritdoc/>
     protected override void Dispose(bool disposing)

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialsWebFactory.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialsWebFactory.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Time.Testing;
+using RustPlusApi.CredentialsWeb.Upstream;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+/// <summary>Boots the real app with the upstream seam and the clock replaced.</summary>
+internal sealed class CredentialsWebFactory : WebApplicationFactory<Program>
+{
+    internal const string BaseUrl = "https://creds.example.org";
+
+    private static readonly DateTimeOffset Origin = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    internal CredentialsWebFactory(IDictionary<string, string>? settings = null)
+    {
+        // Program.cs binds configuration before builder.Build(), which is earlier than any
+        // WebApplicationFactory configuration hook runs — so these must be environment variables.
+        SetEnvironment("CredentialsWeb__PublicBaseUrl", BaseUrl);
+        foreach (var (key, value) in settings ?? new Dictionary<string, string>())
+        {
+            SetEnvironment(key, value);
+        }
+    }
+
+    internal FakeRegistrationSteps Steps { get; } = new();
+
+    internal FakeTimeProvider Time { get; } = new(Origin);
+
+    private List<string> EnvironmentKeys { get; } = [];
+
+    /// <inheritdoc/>
+    protected override void ConfigureWebHost(IWebHostBuilder builder) =>
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<IRegistrationSteps>();
+            services.AddSingleton<IRegistrationSteps>(Steps);
+            services.RemoveAll<TimeProvider>();
+            services.AddSingleton<TimeProvider>(Time);
+        });
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            foreach (var key in EnvironmentKeys)
+            {
+                Environment.SetEnvironmentVariable(key, null);
+            }
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void SetEnvironment(string key, string value)
+    {
+        Environment.SetEnvironmentVariable(key, value);
+        EnvironmentKeys.Add(key);
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/EventEndpointTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/EventEndpointTests.cs
@@ -43,6 +43,29 @@ public sealed class EventEndpointTests
         return names;
     }
 
+    /// <summary>Reads one line, turning a timed-out wait into a named assertion failure instead of
+    /// a raw <see cref="OperationCanceledException"/> — so a regression that drops the SSE frame
+    /// terminator (or a separating blank line) fails with a message pointing at what broke, rather
+    /// than a 10-second <c>TaskCanceledException</c> that looks like a hung test.</summary>
+    /// <param name="reader">The stream reader to read a line from.</param>
+    /// <param name="timeoutMessage">What to report if the read never completes in time.</param>
+    /// <param name="cancellationToken">The bounding timeout token.</param>
+    private static async Task<string?> ReadLineOrFailAsync(
+        StreamReader reader,
+        string timeoutMessage,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await reader.ReadLineAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            Assert.Fail(timeoutMessage);
+            return null; // Unreachable: Assert.Fail always throws.
+        }
+    }
+
     private static Session NewSession(CredentialsWebFactory factory)
     {
         var store = factory.Services.GetRequiredService<SessionStore>();
@@ -124,9 +147,11 @@ public sealed class EventEndpointTests
         await using var stream = await response.Content.ReadAsStreamAsync(timeout.Token);
         using var reader = new StreamReader(stream);
 
-        await reader.ReadLineAsync(timeout.Token);
-        var dataLine = await reader.ReadLineAsync(timeout.Token);
-        var terminatorLine = await reader.ReadLineAsync(timeout.Token);
+        await ReadLineOrFailAsync(reader, "The SSE frame's event: line never arrived within 10s.", timeout.Token);
+        var dataLine = await ReadLineOrFailAsync(
+            reader, "The SSE frame's data: line never arrived within 10s.", timeout.Token);
+        var terminatorLine = await ReadLineOrFailAsync(
+            reader, "SSE frame was not terminated by a blank line within 10s.", timeout.Token);
 
         Assert.Equal("""data: {"state":"Registering"}""", dataLine);
         // A dropped blank line is silent: EventSource never dispatches an incomplete frame, so this
@@ -155,7 +180,11 @@ public sealed class EventEndpointTests
         var lines = new List<string?>();
         for (var i = 0; i < 6; i++)
         {
-            lines.Add(await reader.ReadLineAsync(timeout.Token));
+            lines.Add(await ReadLineOrFailAsync(
+                reader,
+                $"Line {i} of the two SSE frames never arrived within 10s — a dropped separator or "
+                + "terminator likely stalled the read.",
+                timeout.Token));
         }
 
         // Pins both frames in full, including the blank line that separates them and the one that

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/EventEndpointTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/EventEndpointTests.cs
@@ -1,0 +1,132 @@
+using Microsoft.Extensions.DependencyInjection;
+using RustPlusApi.CredentialsWeb.Sessions;
+using System.Net;
+using Xunit;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class EventEndpointTests
+{
+    /// <summary>Reads SSE frames until <paramref name="count"/> <c>event:</c> lines have arrived.</summary>
+    /// <param name="client">The client to read the stream with.</param>
+    /// <param name="sessionId">The session whose event stream to open.</param>
+    /// <param name="count">How many <c>event:</c> lines to wait for.</param>
+    /// <returns>The <c>event:</c> names seen, in arrival order.</returns>
+    private static async Task<List<string>> ReadEventNamesAsync(HttpClient client, string sessionId, int count)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var response = await client.GetAsync(
+            new Uri($"/api/sessions/{sessionId}/events", UriKind.Relative),
+            HttpCompletionOption.ResponseHeadersRead,
+            timeout.Token);
+
+        response.EnsureSuccessStatusCode();
+
+        var names = new List<string>();
+        await using var stream = await response.Content.ReadAsStreamAsync(timeout.Token);
+        using var reader = new StreamReader(stream);
+
+        while (names.Count < count)
+        {
+            var line = await reader.ReadLineAsync(timeout.Token);
+            if (line is null)
+            {
+                break;
+            }
+
+            if (line.StartsWith("event: ", StringComparison.Ordinal))
+            {
+                names.Add(line["event: ".Length..]);
+            }
+        }
+
+        return names;
+    }
+
+    private static Session NewSession(CredentialsWebFactory factory)
+    {
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryCreate("203.0.113.7", out var session, out _);
+        return session!;
+    }
+
+    [Fact]
+    public async Task Events_Returns404_ForAnUnknownSession()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(
+            new Uri("/api/sessions/0123456789abcdef0123456789abcdef/events", UriKind.Relative));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Events_UsesTheEventStreamContentType()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var session = NewSession(factory);
+        session.Advance(SessionState.Authenticated, DateTimeOffset.MaxValue);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var response = await client.GetAsync(
+            new Uri($"/api/sessions/{session.SessionId}/events", UriKind.Relative),
+            HttpCompletionOption.ResponseHeadersRead,
+            timeout.Token);
+
+        Assert.Equal("text/event-stream", response.Content.Headers.ContentType!.MediaType);
+    }
+
+    [Fact]
+    public async Task Events_ReplaysEventsPublishedBeforeTheStreamOpened()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var session = NewSession(factory);
+        session.Advance(SessionState.Authenticated, DateTimeOffset.MaxValue);
+        session.Advance(SessionState.Registering, DateTimeOffset.MaxValue);
+
+        var names = await ReadEventNamesAsync(client, session.SessionId, 2);
+
+        Assert.Equal(["step", "step"], names);
+    }
+
+    [Fact]
+    public async Task Events_ReplaysTheSameHistoryToAReconnectingClient()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var session = NewSession(factory);
+        session.Advance(SessionState.Authenticated, DateTimeOffset.MaxValue);
+
+        var first = await ReadEventNamesAsync(client, session.SessionId, 1);
+        var second = await ReadEventNamesAsync(client, session.SessionId, 1);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public async Task Events_CarriesTheJsonPayload()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var session = NewSession(factory);
+        session.Advance(SessionState.Registering, DateTimeOffset.MaxValue);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var response = await client.GetAsync(
+            new Uri($"/api/sessions/{session.SessionId}/events", UriKind.Relative),
+            HttpCompletionOption.ResponseHeadersRead,
+            timeout.Token);
+
+        await using var stream = await response.Content.ReadAsStreamAsync(timeout.Token);
+        using var reader = new StreamReader(stream);
+
+        await reader.ReadLineAsync(timeout.Token);
+        var dataLine = await reader.ReadLineAsync(timeout.Token);
+
+        Assert.Equal("""data: {"state":"Registering"}""", dataLine);
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/EventEndpointTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/EventEndpointTests.cs
@@ -126,7 +126,78 @@ public sealed class EventEndpointTests
 
         await reader.ReadLineAsync(timeout.Token);
         var dataLine = await reader.ReadLineAsync(timeout.Token);
+        var terminatorLine = await reader.ReadLineAsync(timeout.Token);
 
         Assert.Equal("""data: {"state":"Registering"}""", dataLine);
+        // A dropped blank line is silent: EventSource never dispatches an incomplete frame, so this
+        // is the one gap the line-by-line assertions above cannot catch on their own.
+        Assert.Equal(string.Empty, terminatorLine);
+    }
+
+    [Fact]
+    public async Task Events_SeparatesConsecutiveFramesWithABlankLine()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var session = NewSession(factory);
+        session.Advance(SessionState.Authenticated, DateTimeOffset.MaxValue);
+        session.Advance(SessionState.Registering, DateTimeOffset.MaxValue);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var response = await client.GetAsync(
+            new Uri($"/api/sessions/{session.SessionId}/events", UriKind.Relative),
+            HttpCompletionOption.ResponseHeadersRead,
+            timeout.Token);
+
+        await using var stream = await response.Content.ReadAsStreamAsync(timeout.Token);
+        using var reader = new StreamReader(stream);
+
+        var lines = new List<string?>();
+        for (var i = 0; i < 6; i++)
+        {
+            lines.Add(await reader.ReadLineAsync(timeout.Token));
+        }
+
+        // Pins both frames in full, including the blank line that separates them and the one that
+        // terminates the second — a dropped separator would merge the two frames into one that
+        // EventSource cannot parse, which none of the count-based replay tests above would notice.
+        Assert.Equal(
+            new List<string?>
+            {
+                "event: step",
+                """data: {"state":"Authenticated"}""",
+                string.Empty,
+                "event: step",
+                """data: {"state":"Registering"}""",
+                string.Empty
+            },
+            lines);
+    }
+
+    [Fact]
+    public async Task Events_SerializesASteam64PayloadFieldAsAQuotedString()
+    {
+        // Steam64 exceeds Number.MAX_SAFE_INTEGER: an unquoted JSON number would silently corrupt
+        // it in the browser. This is the highest-consequence serialization rule in this endpoint.
+        const string steam64 = "76561198249527954";
+
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var session = NewSession(factory);
+        session.Events.Publish(new SessionEvent("credentials", new CredentialsPayload(steam64, "{}")));
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var response = await client.GetAsync(
+            new Uri($"/api/sessions/{session.SessionId}/events", UriKind.Relative),
+            HttpCompletionOption.ResponseHeadersRead,
+            timeout.Token);
+
+        await using var stream = await response.Content.ReadAsStreamAsync(timeout.Token);
+        using var reader = new StreamReader(stream);
+
+        await reader.ReadLineAsync(timeout.Token);
+        var dataLine = await reader.ReadLineAsync(timeout.Token);
+
+        Assert.Equal($$"""data: {"steamId":"{{steam64}}","configJson":"{}"}""", dataLine);
     }
 }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/FakeRegistrationSteps.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/FakeRegistrationSteps.cs
@@ -1,0 +1,78 @@
+using RustPlusApi.CredentialsWeb.Upstream;
+using RustPlusApi.Fcm.Data;
+using RustPlusApi.Fcm.Registration;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+/// <summary>Records what the flow asked for, and lets each step be made to fail or hang.</summary>
+internal sealed class FakeRegistrationSteps : IRegistrationSteps
+{
+    internal List<string> Calls { get; } = [];
+
+    internal Credentials CredentialsToReturn { get; set; } = new()
+    {
+        Gcm = new Gcm
+        {
+            AndroidId = 1, SecurityToken = 2
+        },
+        Fcm = new FcmToken
+        {
+            Token = "fcm-token"
+        },
+        ExpoPushToken = "ExponentPushToken[fake]"
+    };
+
+    internal Exception? AcquireFailure { get; set; }
+
+    internal Exception? CompanionFailure { get; set; }
+
+    internal Exception? PairingFailure { get; set; }
+
+    internal ServerPairing PairingToReturn { get; set; } = new()
+    {
+        Ip = "10.0.0.1",
+        Port = 28082,
+        PlayerId = 76561198249527954,
+        PlayerToken = 987654321,
+        Name = "Test Server"
+    };
+
+    /// <summary>When set, the pairing wait blocks until this is signalled or cancelled.</summary>
+    internal TaskCompletionSource PairingGate { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    internal bool PairingWaitsForGate { get; set; }
+
+    internal string? SteamTokenSeen { get; private set; }
+
+    public Task<Credentials> AcquireDeviceCredentialsAsync(CancellationToken cancellationToken)
+    {
+        Calls.Add(nameof(AcquireDeviceCredentialsAsync));
+        return AcquireFailure is not null
+            ? Task.FromException<Credentials>(AcquireFailure)
+            : Task.FromResult(CredentialsToReturn);
+    }
+
+    public Task RegisterWithCompanionAsync(string steamToken, string expoPushToken, CancellationToken cancellationToken)
+    {
+        Calls.Add(nameof(RegisterWithCompanionAsync));
+        SteamTokenSeen = steamToken;
+        return CompanionFailure is not null ? Task.FromException(CompanionFailure) : Task.CompletedTask;
+    }
+
+    public async Task<ServerPairing> WaitForPairingAsync(Credentials credentials, CancellationToken cancellationToken)
+    {
+        Calls.Add(nameof(WaitForPairingAsync));
+
+        if (PairingFailure is not null)
+        {
+            throw PairingFailure;
+        }
+
+        if (PairingWaitsForGate)
+        {
+            await PairingGate.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return PairingToReturn;
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/PairingEndpointTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/PairingEndpointTests.cs
@@ -1,0 +1,112 @@
+using Microsoft.Extensions.DependencyInjection;
+using RustPlusApi.CredentialsWeb.Sessions;
+using System.Net;
+using Xunit;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class PairingEndpointTests
+{
+    private static Uri PairingUri(string sessionId) =>
+        new($"/api/sessions/{sessionId}/pairing", UriKind.Relative);
+
+    /// <summary>Runs a session all the way to Ready through the real callback route.</summary>
+    /// <param name="factory">The test host to create a session and client against.</param>
+    private static async Task<Session> ReadySessionAsync(CredentialsWebFactory factory)
+    {
+        using var client = factory.CreateClient(
+            new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        await client.GetAsync(new Uri(
+            $"/callback/{session!.ReturnToken}?steamId=76561198249527954&token=steam-token",
+            UriKind.Relative));
+        await session.BackgroundWork;
+
+        factory.Steps.Calls.Clear();
+        return session;
+    }
+
+    [Fact]
+    public async Task Pairing_Returns404_ForAnUnknownSession()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(PairingUri("0123456789abcdef0123456789abcdef"), null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Pairing_Returns409_WhenTheSessionIsNotReady()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        var response = await client.PostAsync(PairingUri(session!.SessionId), null);
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Pairing_Returns202AndStartsTheWait()
+    {
+        await using var factory = new CredentialsWebFactory();
+        factory.Steps.PairingWaitsForGate = true;
+        var session = await ReadySessionAsync(factory);
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(PairingUri(session.SessionId), null);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        // Bounded: a regression that never reaches AwaitingPairing must fail as an assertion,
+        // not park a foreground thread and hang the test process.
+        using var reachTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (session.State != SessionState.AwaitingPairing)
+        {
+            Assert.False(reachTimeout.IsCancellationRequested, "The flow never reached AwaitingPairing.");
+            await Task.Delay(10);
+        }
+
+        factory.Steps.PairingGate.SetResult();
+        await session.BackgroundWork;
+        Assert.Equal(SessionState.Paired, session.State);
+    }
+
+    [Fact]
+    public async Task Pairing_Returns429_WhenThePairingCapIsFull()
+    {
+        await using var factory = new CredentialsWebFactory(
+            new Dictionary<string, string> { ["CredentialsWeb__MaxConcurrentPairings"] = "1" });
+        var session = await ReadySessionAsync(factory);
+        using var client = factory.CreateClient();
+
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryAcquirePairingSlot();
+
+        var response = await client.PostAsync(PairingUri(session.SessionId), null);
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+        Assert.Empty(factory.Steps.Calls);
+    }
+
+    [Fact]
+    public async Task Pairing_ReleasesTheSlotOnceTheWaitFinishes()
+    {
+        await using var factory = new CredentialsWebFactory();
+        var session = await ReadySessionAsync(factory);
+        using var client = factory.CreateClient();
+
+        await client.PostAsync(PairingUri(session.SessionId), null);
+        await session.BackgroundWork;
+
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        Assert.Equal(0, store.ActivePairings);
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/PairingEndpointTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/PairingEndpointTests.cs
@@ -15,7 +15,10 @@ public sealed class PairingEndpointTests
     private static async Task<Session> ReadySessionAsync(CredentialsWebFactory factory)
     {
         using var client = factory.CreateClient(
-            new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+            new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false
+            });
 
         var store = factory.Services.GetRequiredService<SessionStore>();
         store.TryCreate("203.0.113.7", out var session, out _);
@@ -83,7 +86,10 @@ public sealed class PairingEndpointTests
     public async Task Pairing_Returns429_WhenThePairingCapIsFull()
     {
         await using var factory = new CredentialsWebFactory(
-            new Dictionary<string, string> { ["CredentialsWeb__MaxConcurrentPairings"] = "1" });
+            new Dictionary<string, string>
+            {
+                ["CredentialsWeb__MaxConcurrentPairings"] = "1"
+            });
         var session = await ReadySessionAsync(factory);
         using var client = factory.CreateClient();
 

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/RustPlusApi.CredentialsWeb.UnitTests.csproj
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/RustPlusApi.CredentialsWeb.UnitTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <!-- net10.0 only: the app under test is net10.0 only, so there is no
+             netstandard2.0 build to validate for parity. -->
+        <TargetFramework>net10.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\apps\RustPlusApi.CredentialsWeb\RustPlusApi.CredentialsWeb.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SecretsAreNeverLoggedTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SecretsAreNeverLoggedTests.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.Fcm.Registration;
+using Xunit;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SecretsAreNeverLoggedTests
+{
+    private const string SteamTokenSentinel = "SENTINEL-STEAM-TOKEN-b3a1f0c2";
+    private const int PlayerTokenSentinel = 1928374650;
+
+    private static async Task<(CredentialsWebFactory Factory, Session Session)> RunFullFlowAsync()
+    {
+        var factory = new CredentialsWebFactory();
+        factory.Steps.PairingToReturn = new ServerPairing
+        {
+            Ip = "10.0.0.1",
+            Port = 28082,
+            PlayerId = 76561198249527954,
+            PlayerToken = PlayerTokenSentinel,
+            Name = "Test Server"
+        };
+
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        await client.GetAsync(new Uri(
+            $"/callback/{session!.ReturnToken}?steamId=76561198249527954&token={SteamTokenSentinel}",
+            UriKind.Relative));
+        await session.BackgroundWork;
+
+        await client.PostAsync(new Uri($"/api/sessions/{session.SessionId}/pairing", UriKind.Relative), null);
+        await session.BackgroundWork;
+
+        return (factory, session);
+    }
+
+    [Fact]
+    public async Task TheHarnessActuallyCapturesLogs()
+    {
+        // Guards against the whole suite passing vacuously because nothing was ever captured.
+        var (factory, _) = await RunFullFlowAsync();
+        await using var _f = factory;
+
+        Assert.NotEmpty(factory.Logs.Records);
+    }
+
+    [Fact]
+    public async Task TheSteamTokenNeverReachesALogRecord()
+    {
+        var (factory, _) = await RunFullFlowAsync();
+        await using var _f = factory;
+
+        Assert.DoesNotContain(
+            factory.Logs.Records,
+            record => record.Contains(SteamTokenSentinel, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TheCallbackQueryStringNeverReachesALogRecord()
+    {
+        var (factory, _) = await RunFullFlowAsync();
+        await using var _f = factory;
+
+        Assert.DoesNotContain(
+            factory.Logs.Records,
+            record => record.Contains("token=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ThePlayerTokenNeverReachesALogRecord()
+    {
+        var (factory, session) = await RunFullFlowAsync();
+        await using var _f = factory;
+
+        Assert.Equal(SessionState.Paired, session.State);
+        Assert.DoesNotContain(
+            factory.Logs.Records,
+            record => record.Contains(
+                PlayerTokenSentinel.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TheExpoPushTokenNeverReachesALogRecord()
+    {
+        var (factory, _) = await RunFullFlowAsync();
+        await using var _f = factory;
+
+        Assert.DoesNotContain(
+            factory.Logs.Records,
+            record => record.Contains("ExponentPushToken", StringComparison.Ordinal));
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEndpointTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEndpointTests.cs
@@ -99,6 +99,50 @@ public sealed class SessionEndpointTests
     }
 
     [Fact]
+    public async Task CreateSession_EvictsThisAddressesFailedSession()
+    {
+        // Nothing in a Failed session is resumable, so the app's own "Start over" flow — which
+        // leads straight back into POST /api/sessions — must not be refused because of it.
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var store = factory.Services.GetRequiredService<SessionStore>();
+
+        var first = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+        var firstBody = await first.Content.ReadFromJsonAsync<CreateSessionResponse>();
+        store.TryGet(firstBody!.SessionId, out var failedSession);
+        failedSession!.Advance(SessionState.Failed, factory.Time.GetUtcNow().AddMinutes(15));
+
+        var second = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+
+        second.EnsureSuccessStatusCode();
+        Assert.False(store.TryGet(firstBody.SessionId, out _));
+        Assert.Equal(1, store.Count);
+    }
+
+    [Fact]
+    public async Task CreateSession_Returns429WithADistinctMessage_WhenThisAddressHasAResumableSession()
+    {
+        // Distinct from the generic "at capacity" 429: a session past Created and not Failed
+        // carries real, resumable upstream work, and the false "at capacity" framing sent a visitor
+        // into a needless wait instead of pointing them back at the session they already have.
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var store = factory.Services.GetRequiredService<SessionStore>();
+
+        var first = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+        var firstBody = await first.Content.ReadFromJsonAsync<CreateSessionResponse>();
+        store.TryGet(firstBody!.SessionId, out var activeSession);
+        activeSession!.Advance(SessionState.Authenticated, factory.Time.GetUtcNow().AddMinutes(15));
+
+        var response = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("already have a session", body, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("docker run", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task Responses_CarryTheSecurityHeaders()
     {
         await using var factory = new CredentialsWebFactory();

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEndpointTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEndpointTests.cs
@@ -79,7 +79,10 @@ public sealed class SessionEndpointTests
     public async Task CreateSession_Returns429WithASelfHostPointer_WhenTheGlobalCapIsFull()
     {
         await using var factory = new CredentialsWebFactory(
-            new Dictionary<string, string> { ["CredentialsWeb__MaxConcurrentSessions"] = "1" });
+            new Dictionary<string, string>
+            {
+                ["CredentialsWeb__MaxConcurrentSessions"] = "1"
+            });
         using var client = factory.CreateClient();
 
         // Occupy the only slot from a different address, and move it out of Created so the
@@ -113,7 +116,10 @@ public sealed class SessionEndpointTests
         // it should apply no matter what status code the endpoint eventually returns — including
         // the 429 capacity response, where a missing Cache-Control: no-store would matter most.
         await using var factory = new CredentialsWebFactory(
-            new Dictionary<string, string> { ["CredentialsWeb__MaxConcurrentSessions"] = "1" });
+            new Dictionary<string, string>
+            {
+                ["CredentialsWeb__MaxConcurrentSessions"] = "1"
+            });
         using var client = factory.CreateClient();
         var store = factory.Services.GetRequiredService<SessionStore>();
         store.TryCreate("198.51.100.1", out var occupant, out _);
@@ -166,7 +172,10 @@ public sealed class SessionEndpointTests
         // claim a different address; correctly applied, they land in two separate buckets and
         // both sessions survive (Count == 2), the opposite of the no-proxy-configured case above.
         await using var factory = new CredentialsWebFactory(
-            new Dictionary<string, string> { ["CredentialsWeb__KnownProxies__0"] = "127.0.0.1" });
+            new Dictionary<string, string>
+            {
+                ["CredentialsWeb__KnownProxies__0"] = "127.0.0.1"
+            });
         using var client = factory.CreateClient();
         var store = factory.Services.GetRequiredService<SessionStore>();
 

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEndpointTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEndpointTests.cs
@@ -1,0 +1,134 @@
+using Microsoft.Extensions.DependencyInjection;
+using RustPlusApi.CredentialsWeb.Endpoints;
+using RustPlusApi.CredentialsWeb.Sessions;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SessionEndpointTests
+{
+    [Fact]
+    public async Task CreateSession_ReturnsSessionIdAndFacepunchLoginUrl()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadFromJsonAsync<CreateSessionResponse>();
+
+        Assert.NotNull(body);
+        Assert.Matches("^[0-9a-f]{32}$", body.SessionId);
+        Assert.StartsWith(
+            "https://companion-rust.facepunch.com/login?returnUrl=",
+            body.LoginUrl,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            Uri.EscapeDataString($"{CredentialsWebFactory.BaseUrl}/callback/"),
+            body.LoginUrl,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CreateSession_ReturnsADifferentReturnTokenEachTime()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+
+        var first = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+        var firstBody = await first.Content.ReadFromJsonAsync<CreateSessionResponse>();
+        var second = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+        var secondBody = await second.Content.ReadFromJsonAsync<CreateSessionResponse>();
+
+        Assert.NotEqual(firstBody!.LoginUrl, secondBody!.LoginUrl);
+    }
+
+    [Fact]
+    public async Task CreateSession_TheLoginUrlNeverCarriesTheSessionId()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+        var body = await response.Content.ReadFromJsonAsync<CreateSessionResponse>();
+
+        Assert.DoesNotContain(body!.SessionId, body.LoginUrl, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CreateSession_EvictsThisAddressesAbandonedCreatedSession()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var store = factory.Services.GetRequiredService<SessionStore>();
+
+        var first = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+        var firstBody = await first.Content.ReadFromJsonAsync<CreateSessionResponse>();
+
+        var second = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+        second.EnsureSuccessStatusCode();
+
+        Assert.False(store.TryGet(firstBody!.SessionId, out _));
+        Assert.Equal(1, store.Count);
+    }
+
+    [Fact]
+    public async Task CreateSession_Returns429WithASelfHostPointer_WhenTheGlobalCapIsFull()
+    {
+        await using var factory = new CredentialsWebFactory(
+            new Dictionary<string, string> { ["CredentialsWeb__MaxConcurrentSessions"] = "1" });
+        using var client = factory.CreateClient();
+
+        // Occupy the only slot from a different address, and move it out of Created so the
+        // eviction rule cannot reclaim it.
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryCreate("198.51.100.1", out var occupant, out _);
+        occupant!.Advance(SessionState.Authenticated, factory.Time.GetUtcNow().AddMinutes(15));
+
+        var response = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("docker run", body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Responses_CarryTheSecurityHeaders()
+    {
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+
+        Assert.Equal("no-referrer", response.Headers.GetValues("Referrer-Policy").Single());
+        Assert.Equal("nosniff", response.Headers.GetValues("X-Content-Type-Options").Single());
+        Assert.Contains("no-store", response.Headers.CacheControl!.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CreateSession_IgnoresForwardedFor_WhenNoProxyIsConfigured()
+    {
+        // With no CredentialsWeb__KnownProxies set, a caller must not be able to pick its own
+        // per-IP bucket by sending an arbitrary X-Forwarded-For. Both requests below claim a
+        // different address; if that were honored they would land in different buckets and both
+        // sessions would survive. Ignored (the safe default), both resolve to the same real
+        // connection address, so the second creation evicts the first's abandoned Created session.
+        await using var factory = new CredentialsWebFactory();
+        using var client = factory.CreateClient();
+        var store = factory.Services.GetRequiredService<SessionStore>();
+
+        using var first = new HttpRequestMessage(HttpMethod.Post, new Uri("/api/sessions", UriKind.Relative));
+        first.Headers.Add("X-Forwarded-For", "203.0.113.7");
+        (await client.SendAsync(first)).EnsureSuccessStatusCode();
+
+        using var second = new HttpRequestMessage(HttpMethod.Post, new Uri("/api/sessions", UriKind.Relative));
+        second.Headers.Add("X-Forwarded-For", "198.51.100.42");
+        var response = await client.SendAsync(second);
+
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(1, store.Count);
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEndpointTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEndpointTests.cs
@@ -103,6 +103,30 @@ public sealed class SessionEndpointTests
 
         var response = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
 
+        AssertSecurityHeaders(response);
+    }
+
+    [Fact]
+    public async Task ErrorResponses_CarryTheSecurityHeadersToo()
+    {
+        // The security-headers middleware sits ahead of the endpoint and writes via OnStarting, so
+        // it should apply no matter what status code the endpoint eventually returns — including
+        // the 429 capacity response, where a missing Cache-Control: no-store would matter most.
+        await using var factory = new CredentialsWebFactory(
+            new Dictionary<string, string> { ["CredentialsWeb__MaxConcurrentSessions"] = "1" });
+        using var client = factory.CreateClient();
+        var store = factory.Services.GetRequiredService<SessionStore>();
+        store.TryCreate("198.51.100.1", out var occupant, out _);
+        occupant!.Advance(SessionState.Authenticated, factory.Time.GetUtcNow().AddMinutes(15));
+
+        var response = await client.PostAsync(new Uri("/api/sessions", UriKind.Relative), null);
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+        AssertSecurityHeaders(response);
+    }
+
+    private static void AssertSecurityHeaders(HttpResponseMessage response)
+    {
         Assert.Equal("no-referrer", response.Headers.GetValues("Referrer-Policy").Single());
         Assert.Equal("nosniff", response.Headers.GetValues("X-Content-Type-Options").Single());
         Assert.Contains("no-store", response.Headers.CacheControl!.ToString(), StringComparison.Ordinal);
@@ -130,5 +154,31 @@ public sealed class SessionEndpointTests
 
         response.EnsureSuccessStatusCode();
         Assert.Equal(1, store.Count);
+    }
+
+    [Fact]
+    public async Task CreateSession_AppliesForwardedFor_WhenAProxyIsConfigured()
+    {
+        // The inverse of CreateSession_IgnoresForwardedFor_WhenNoProxyIsConfigured. Once the
+        // operator names their proxy, a forwarded address must actually be applied — otherwise
+        // every visitor behind that proxy would still collapse into the one shared per-IP bucket
+        // the setting exists to prevent, just silently instead of loudly. Both requests below
+        // claim a different address; correctly applied, they land in two separate buckets and
+        // both sessions survive (Count == 2), the opposite of the no-proxy-configured case above.
+        await using var factory = new CredentialsWebFactory(
+            new Dictionary<string, string> { ["CredentialsWeb__KnownProxies__0"] = "127.0.0.1" });
+        using var client = factory.CreateClient();
+        var store = factory.Services.GetRequiredService<SessionStore>();
+
+        using var first = new HttpRequestMessage(HttpMethod.Post, new Uri("/api/sessions", UriKind.Relative));
+        first.Headers.Add("X-Forwarded-For", "203.0.113.7");
+        (await client.SendAsync(first)).EnsureSuccessStatusCode();
+
+        using var second = new HttpRequestMessage(HttpMethod.Post, new Uri("/api/sessions", UriKind.Relative));
+        second.Headers.Add("X-Forwarded-For", "198.51.100.42");
+        var response = await client.SendAsync(second);
+
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(2, store.Count);
     }
 }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEventStreamTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEventStreamTests.cs
@@ -116,4 +116,38 @@ public sealed class SessionEventStreamTests
 
         Assert.Empty(received);
     }
+
+    [Fact]
+    public async Task SubscribeAsync_DeregistersSubscriberWhenEnumerationEnds()
+    {
+        var stream = new SessionEventStream();
+        stream.Publish(new SessionEvent("first", null));
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var enumerator = stream.SubscribeAsync(timeout.Token).GetAsyncEnumerator(timeout.Token);
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("first", enumerator.Current.Type);
+        Assert.Equal(1, stream.SubscriberCount);
+
+        // Cancel to end the enumeration
+        await timeout.CancelAsync();
+
+        try
+        {
+            await enumerator.MoveNextAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected
+        }
+
+        await enumerator.DisposeAsync();
+
+        // Subscriber should be deregistered after enumeration ends
+        Assert.Equal(0, stream.SubscriberCount);
+
+        // Publishing after deregistration should not affect the removed subscriber
+        stream.Publish(new SessionEvent("second", null));
+    }
 }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEventStreamTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEventStreamTests.cs
@@ -1,0 +1,119 @@
+using RustPlusApi.CredentialsWeb.Sessions;
+using Xunit;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SessionEventStreamTests
+{
+    private static async Task<List<SessionEvent>> DrainAsync(SessionEventStream stream, int expected)
+    {
+        var received = new List<SessionEvent>();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await foreach (var item in stream.SubscribeAsync(timeout.Token))
+        {
+            received.Add(item);
+            if (received.Count == expected)
+            {
+                break;
+            }
+        }
+
+        return received;
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_ReplaysEventsPublishedBeforeSubscription()
+    {
+        var stream = new SessionEventStream();
+        stream.Publish(new SessionEvent("step", new StepPayload("Registering")));
+        stream.Publish(new SessionEvent("step", new StepPayload("Ready")));
+
+        var received = await DrainAsync(stream, 2);
+
+        Assert.Equal(2, received.Count);
+        Assert.All(received, e => Assert.Equal("step", e.Type));
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_DeliversEventsPublishedAfterSubscription()
+    {
+        var stream = new SessionEventStream();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var enumerator = stream.SubscribeAsync(timeout.Token).GetAsyncEnumerator(timeout.Token);
+
+        stream.Publish(new SessionEvent("paired", null));
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("paired", enumerator.Current.Type);
+        await enumerator.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_ReplaysThenStreams_InOrder()
+    {
+        var stream = new SessionEventStream();
+        stream.Publish(new SessionEvent("first", null));
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var enumerator = stream.SubscribeAsync(timeout.Token).GetAsyncEnumerator(timeout.Token);
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("first", enumerator.Current.Type);
+
+        stream.Publish(new SessionEvent("second", null));
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("second", enumerator.Current.Type);
+        await enumerator.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_SupportsTwoConcurrentSubscribers()
+    {
+        var stream = new SessionEventStream();
+        var first = DrainAsync(stream, 1);
+        var second = DrainAsync(stream, 1);
+
+        // Give both subscribers a chance to register before publishing.
+        await Task.Delay(50);
+        stream.Publish(new SessionEvent("step", null));
+
+        Assert.Single(await first);
+        Assert.Single(await second);
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_CompletesWhenStreamCompleted()
+    {
+        var stream = new SessionEventStream();
+        stream.Publish(new SessionEvent("expired", null));
+        stream.Complete();
+
+        var received = new List<SessionEvent>();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await foreach (var item in stream.SubscribeAsync(timeout.Token))
+        {
+            received.Add(item);
+        }
+
+        Assert.Single(received);
+    }
+
+    [Fact]
+    public async Task Publish_AfterComplete_IsIgnored()
+    {
+        var stream = new SessionEventStream();
+        stream.Complete();
+        stream.Publish(new SessionEvent("step", null));
+
+        var received = new List<SessionEvent>();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await foreach (var item in stream.SubscribeAsync(timeout.Token))
+        {
+            received.Add(item);
+        }
+
+        Assert.Empty(received);
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs
@@ -112,7 +112,7 @@ public sealed class SessionStoreCapsTests
     }
 
     [Fact]
-    public void RecordCompletion_StillCounts_AfterItsAddressWasPrunedToEmptyAndUnlinked()
+    public void RecordCompletion_CountsAgain_AfterItsAddressWasPrunedAndUnlinked()
     {
         var (store, time) = NewStore(o => o.MaxCompletionsPerIpPerHour = 1);
         using var _s = store;
@@ -130,6 +130,132 @@ public sealed class SessionStoreCapsTests
 
         Assert.False(store.TryCreate("203.0.113.7", out _, out var failure));
         Assert.Equal(SessionCreateFailure.HourlyLimit, failure);
+    }
+
+    [Fact]
+    public void RecordCompletion_NeverLosesAWrite_UnderConcurrentPruning()
+    {
+        // No clock manipulation: the vulnerable window in the pre-fix code is the gap between
+        // RecordCompletion's GetOrAdd returning a reference to an address's (still-empty,
+        // not-yet-populated) completions list and that same RecordCompletion call taking the
+        // list's own lock to add to it. A concurrent CountCompletionsUnderGate call (driven here
+        // by TryCreate, its only caller) can observe the list as empty in that gap and unlink it
+        // from the map, so the pending write lands in an orphaned list nothing can reach again.
+        //
+        // The window is nanoseconds wide on any single attempt, so a single racer pair essentially
+        // never hits it (verified empirically). This instead runs many "storms": one burst of
+        // dedicated OS threads (not the thread pool, whose queuing lets the two sides drift out of
+        // phase) pulling work off shared counters, where several recorder threads and several
+        // pruner threads hammer the *same*, never-before-seen addresses at once, oversubscribing
+        // the machine's cores to maximize preemption inside the tiny window. Measured against a
+        // scratch revert of the fix (see the fix report), 70 storms at these sizes caught the loss
+        // in 9 of 10 runs in roughly a second — repeating drives the odds up further without an
+        // unbounded loop; it can never produce a false failure against the fixed code (verified
+        // over dozens of runs), so there is no flakiness downside to running it every time.
+        //
+        // With the per-address cap set to the exact number of recorders, a lost write is directly
+        // observable afterward: the count CountCompletionsUnderGate reads can never exceed the
+        // number of writes that actually landed, so the final TryCreate for an address hits
+        // HourlyLimit only if every one of its recorders' writes survived.
+        const int storms = 70;
+        const int addressCount = 2_000;
+        const int recordersPerAddress = 16;
+        const int recorderThreadCount = 100;
+        const int prunerThreadCount = 50;
+        const int recordTotal = addressCount * recordersPerAddress;
+
+        var lostWrites = new List<string>();
+
+        for (var storm = 0; storm < storms; storm++)
+        {
+            var (store, _) = NewStore(o => o.MaxCompletionsPerIpPerHour = recordersPerAddress);
+            using var _s = store;
+
+            var addresses = new string[addressCount];
+            for (var i = 0; i < addressCount; i++)
+            {
+                addresses[i] = $"stress-{storm}-{i}";
+            }
+
+            var nextRecordUnit = -1;
+            var nextPruneAddress = -1;
+
+            // Every worker blocks here until all of them exist and are waiting, then all are
+            // released together — otherwise starting recorder threads before pruner threads (or
+            // vice versa) hands one side a head start that skews away from the interleaving under
+            // test.
+            using var allReady = new CountdownEvent(recorderThreadCount + prunerThreadCount);
+            using var go = new ManualResetEventSlim(initialState: false);
+
+            void RecordWorker()
+            {
+                allReady.Signal();
+                go.Wait();
+
+                int unit;
+
+                // Grouped, not round-robin: consecutive units target the *same* address, so
+                // several recorder threads pile onto that one address's list lock at once instead
+                // of spreading across distinct addresses — the queued contention a pruner thread
+                // needs to cut in front of while the list is still empty.
+                while ((unit = Interlocked.Increment(ref nextRecordUnit)) < recordTotal)
+                {
+                    store.RecordCompletion(addresses[unit / recordersPerAddress]);
+                }
+            }
+
+            void PruneWorker()
+            {
+                allReady.Signal();
+                go.Wait();
+
+                int index;
+                while ((index = Interlocked.Increment(ref nextPruneAddress)) < addressCount)
+                {
+                    if (store.TryCreate(addresses[index], out var session, out _))
+                    {
+                        store.Remove(session!.SessionId);
+                    }
+                }
+            }
+
+            var threads = new List<Thread>(recorderThreadCount + prunerThreadCount);
+            for (var t = 0; t < recorderThreadCount; t++)
+            {
+                threads.Add(new Thread(RecordWorker));
+            }
+
+            for (var t = 0; t < prunerThreadCount; t++)
+            {
+                threads.Add(new Thread(PruneWorker));
+            }
+
+            foreach (var thread in threads)
+            {
+                thread.Start();
+            }
+
+            Assert.True(allReady.Wait(TimeSpan.FromSeconds(10)));
+            go.Set();
+
+            foreach (var thread in threads)
+            {
+                Assert.True(thread.Join(TimeSpan.FromSeconds(10)));
+            }
+
+            foreach (var address in addresses)
+            {
+                if (store.TryCreate(address, out _, out var failure))
+                {
+                    lostWrites.Add(address);
+                    continue;
+                }
+
+                Assert.Equal(SessionCreateFailure.HourlyLimit, failure);
+            }
+        }
+
+        Assert.Empty(lostWrites);
     }
 
     [Fact]

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs
@@ -112,6 +112,27 @@ public sealed class SessionStoreCapsTests
     }
 
     [Fact]
+    public void RecordCompletion_StillCounts_AfterItsAddressWasPrunedToEmptyAndUnlinked()
+    {
+        var (store, time) = NewStore(o => o.MaxCompletionsPerIpPerHour = 1);
+        using var _s = store;
+        store.RecordCompletion("203.0.113.7");
+
+        time.Advance(TimeSpan.FromMinutes(61));
+
+        // The stale entry is now more than an hour old. This TryCreate's hourly check prunes
+        // "203.0.113.7"'s completions list to empty and unlinks it from the per-IP map — the exact
+        // moment a same-address RecordCompletion must not lose its write.
+        Assert.True(store.TryCreate("203.0.113.7", out var session, out _));
+        store.Remove(session!.SessionId);
+
+        store.RecordCompletion("203.0.113.7");
+
+        Assert.False(store.TryCreate("203.0.113.7", out _, out var failure));
+        Assert.Equal(SessionCreateFailure.HourlyLimit, failure);
+    }
+
+    [Fact]
     public void TryAcquirePairingSlot_HonoursTheGlobalPairingCap()
     {
         var (store, _) = NewStore(o => o.MaxConcurrentPairings = 2);

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs
@@ -315,6 +315,104 @@ public sealed class SessionStoreCapsTests
     }
 
     [Fact]
+    public void TryCreate_NeverEvicts_ASessionThatConcurrentlyAdvancedPastCreated()
+    {
+        // The pre-fix code reads existing.State via a plain, unsynchronised property read while only
+        // holding _createGate — a different lock than the one Session.Advance writes State under. So
+        // TryCreate can decide "Created, evict" a moment before a concurrent Advance commits
+        // Authenticated, then go on to evict anyway: the session ends up both disposed (Lifetime
+        // cancelled) *and* showing State == Authenticated, destroying a session with real, resumable
+        // upstream work in flight (the exact scenario in CredentialFlow.CompleteRegistrationAsync,
+        // where the Facepunch callback calls SetSteamLogin then Advance(Authenticated) right after
+        // TryCreate might be evaluating the same address).
+        //
+        // The fixed code makes the check-and-evict decision atomic with Advance under the session's
+        // own lock (Session.TryClaimForEviction), so that combination can never be observed: either
+        // the eviction claim wins the lock first (Advance then no-ops instead of resurrecting state)
+        // or Advance wins it first (the claim then sees the new state and refuses instead of evicting).
+        //
+        // The window between TryCreate's read and its eventual Dispose() spans several dictionary
+        // operations under _createGate (much wider than the nanosecond-scale race in
+        // RecordCompletion_NeverLosesAWrite_UnderConcurrentPruning above), so a modest number of
+        // gated two-thread trials is enough to hit it reliably against the pre-fix code (verified
+        // empirically — see the fix report).
+        const int trials = 500;
+        const int gateTimeoutSeconds = 10;
+
+        var violations = 0;
+        var gateTimeouts = 0;
+
+        for (var trial = 0; trial < trials; trial++)
+        {
+            var (store, time) = NewStore();
+            using var _s = store;
+            store.TryCreate("203.0.113.7", out var session, out _);
+
+            using var allReady = new CountdownEvent(2);
+            using var go = new ManualResetEventSlim(initialState: false);
+            var evictorTimedOut = false;
+            var advancerTimedOut = false;
+
+            var evictor = new Thread(() =>
+            {
+                allReady.Signal();
+                if (!go.Wait(TimeSpan.FromSeconds(gateTimeoutSeconds)))
+                {
+                    evictorTimedOut = true;
+                    return;
+                }
+
+                store.TryCreate("203.0.113.7", out _, out _);
+            })
+            {
+                IsBackground = true
+            };
+
+            var advancer = new Thread(() =>
+            {
+                allReady.Signal();
+                if (!go.Wait(TimeSpan.FromSeconds(gateTimeoutSeconds)))
+                {
+                    advancerTimedOut = true;
+                    return;
+                }
+
+                session!.Advance(SessionState.Authenticated, time.GetUtcNow().AddMinutes(15));
+            })
+            {
+                IsBackground = true
+            };
+
+            evictor.Start();
+            advancer.Start();
+
+            Assert.True(allReady.Wait(TimeSpan.FromSeconds(10)));
+            go.Set();
+
+            Assert.True(evictor.Join(TimeSpan.FromSeconds(10)));
+            Assert.True(advancer.Join(TimeSpan.FromSeconds(10)));
+
+            if (evictorTimedOut || advancerTimedOut)
+            {
+                gateTimeouts++;
+                continue;
+            }
+
+            if (session!.Lifetime.IsCancellationRequested && session.State == SessionState.Authenticated)
+            {
+                violations++;
+            }
+        }
+
+        Assert.True(
+            gateTimeouts == 0,
+            $"{gateTimeouts} trial(s) timed out waiting for the release gate instead of running, so "
+            + "results below cannot be trusted as a race-detection signal — the test environment is "
+            + "too slow or throttled for this test's timing budget.");
+        Assert.Equal(0, violations);
+    }
+
+    [Fact]
     public void TryAcquirePairingSlot_HonoursTheGlobalPairingCap()
     {
         var (store, _) = NewStore(o => o.MaxConcurrentPairings = 2);

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs
@@ -64,6 +64,30 @@ public sealed class SessionStoreCapsTests
     }
 
     [Fact]
+    public void TryCreate_EvictsAFailedSession_FromTheSameIp()
+    {
+        // Nothing in a Failed session is resumable — it is terminal — so it must not block its own
+        // address the way a genuinely active session does. Before the fix, a Failed session carried
+        // the full 15-minute SessionTtl and TryCreate evicted only Created sessions, so the app's own
+        // "Start over" button led straight into a false "at capacity" 429 for up to 15 minutes.
+        var (store, time) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var failed, out _);
+        failed!.Advance(SessionState.Failed, time.GetUtcNow().AddMinutes(15));
+
+        Assert.True(store.TryCreate("203.0.113.7", out var replacement, out var failure));
+
+        Assert.Equal(SessionCreateFailure.None, failure);
+        Assert.NotSame(failed, replacement);
+        Assert.False(store.TryGet(failed.SessionId, out _));
+        Assert.True(store.TryGet(replacement!.SessionId, out _));
+        Assert.Equal(1, store.Count);
+        // The eviction actually disposed the old session (cancelling its Lifetime) rather than just
+        // dropping it from the maps — Dispose() is the only thing that ever cancels Lifetime.
+        Assert.True(failed.Lifetime.IsCancellationRequested);
+    }
+
+    [Fact]
     public void TryCreate_IsUnaffectedByOtherAddresses()
     {
         var (store, time) = NewStore();

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs
@@ -1,0 +1,149 @@
+using Microsoft.Extensions.Time.Testing;
+using RustPlusApi.CredentialsWeb;
+using RustPlusApi.CredentialsWeb.Sessions;
+using Xunit;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SessionStoreCapsTests
+{
+    private static readonly DateTimeOffset Origin = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    private static (SessionStore Store, FakeTimeProvider Time) NewStore(Action<AppOptions>? configure = null)
+    {
+        var time = new FakeTimeProvider(Origin);
+        var options = new AppOptions
+        {
+            PublicBaseUrl = "https://creds.example.org"
+        };
+        configure?.Invoke(options);
+        return (new SessionStore(options, time), time);
+    }
+
+    [Fact]
+    public void TryCreate_Refuses_WhenGlobalLimitReached()
+    {
+        var (store, _) = NewStore(o => o.MaxConcurrentSessions = 1);
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out _, out _);
+
+        Assert.False(store.TryCreate("203.0.113.8", out var session, out var failure));
+
+        Assert.Null(session);
+        Assert.Equal(SessionCreateFailure.GlobalLimit, failure);
+    }
+
+    [Fact]
+    public void TryCreate_EvictsAbandonedCreatedSession_FromTheSameIp()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var abandoned, out _);
+
+        Assert.True(store.TryCreate("203.0.113.7", out var replacement, out var failure));
+
+        Assert.Equal(SessionCreateFailure.None, failure);
+        Assert.NotSame(abandoned, replacement);
+        Assert.False(store.TryGet(abandoned!.SessionId, out _));
+        Assert.True(store.TryGet(replacement!.SessionId, out _));
+        Assert.Equal(1, store.Count);
+    }
+
+    [Fact]
+    public void TryCreate_Refuses_WhenTheSameIpHasAnAuthenticatedSession()
+    {
+        var (store, time) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var active, out _);
+        active!.Advance(SessionState.Authenticated, time.GetUtcNow().AddMinutes(15));
+
+        Assert.False(store.TryCreate("203.0.113.7", out var session, out var failure));
+
+        Assert.Null(session);
+        Assert.Equal(SessionCreateFailure.ActiveSessionForIp, failure);
+    }
+
+    [Fact]
+    public void TryCreate_IsUnaffectedByOtherAddresses()
+    {
+        var (store, time) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var other, out _);
+        other!.Advance(SessionState.Authenticated, time.GetUtcNow().AddMinutes(15));
+
+        Assert.True(store.TryCreate("203.0.113.8", out _, out var failure));
+        Assert.Equal(SessionCreateFailure.None, failure);
+    }
+
+    [Fact]
+    public void TryCreate_Refuses_AfterTooManyCompletionsInAnHour()
+    {
+        var (store, _) = NewStore(o => o.MaxCompletionsPerIpPerHour = 2);
+        using var _s = store;
+        store.RecordCompletion("203.0.113.7");
+        store.RecordCompletion("203.0.113.7");
+
+        Assert.False(store.TryCreate("203.0.113.7", out _, out var failure));
+        Assert.Equal(SessionCreateFailure.HourlyLimit, failure);
+    }
+
+    [Fact]
+    public void TryCreate_Recovers_AfterTheHourlyWindowSlidesPast()
+    {
+        var (store, time) = NewStore(o => o.MaxCompletionsPerIpPerHour = 1);
+        using var _s = store;
+        store.RecordCompletion("203.0.113.7");
+        Assert.False(store.TryCreate("203.0.113.7", out _, out _));
+
+        time.Advance(TimeSpan.FromMinutes(61));
+
+        Assert.True(store.TryCreate("203.0.113.7", out _, out var failure));
+        Assert.Equal(SessionCreateFailure.None, failure);
+    }
+
+    [Fact]
+    public void RecordCompletion_IsScopedToOneAddress()
+    {
+        var (store, _) = NewStore(o => o.MaxCompletionsPerIpPerHour = 1);
+        using var _s = store;
+        store.RecordCompletion("203.0.113.7");
+
+        Assert.True(store.TryCreate("203.0.113.8", out _, out _));
+    }
+
+    [Fact]
+    public void TryAcquirePairingSlot_HonoursTheGlobalPairingCap()
+    {
+        var (store, _) = NewStore(o => o.MaxConcurrentPairings = 2);
+        using var _s = store;
+
+        Assert.True(store.TryAcquirePairingSlot());
+        Assert.True(store.TryAcquirePairingSlot());
+        Assert.False(store.TryAcquirePairingSlot());
+        Assert.Equal(2, store.ActivePairings);
+    }
+
+    [Fact]
+    public void ReleasePairingSlot_FreesCapacity()
+    {
+        var (store, _) = NewStore(o => o.MaxConcurrentPairings = 1);
+        using var _s = store;
+        store.TryAcquirePairingSlot();
+
+        store.ReleasePairingSlot();
+
+        Assert.Equal(0, store.ActivePairings);
+        Assert.True(store.TryAcquirePairingSlot());
+    }
+
+    [Fact]
+    public void ReleasePairingSlot_NeverGoesNegative()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+
+        store.ReleasePairingSlot();
+
+        Assert.Equal(0, store.ActivePairings);
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreCapsTests.cs
@@ -164,7 +164,10 @@ public sealed class SessionStoreCapsTests
         const int prunerThreadCount = 50;
         const int recordTotal = addressCount * recordersPerAddress;
 
+        const int gateTimeoutSeconds = 10;
+
         var lostWrites = new List<string>();
+        var gateTimeouts = 0;
 
         for (var storm = 0; storm < storms; storm++)
         {
@@ -187,10 +190,20 @@ public sealed class SessionStoreCapsTests
             using var allReady = new CountdownEvent(recorderThreadCount + prunerThreadCount);
             using var go = new ManualResetEventSlim(initialState: false);
 
+            // go.Wait() is bounded and a timed-out worker simply returns having recorded nothing,
+            // rather than parking forever: if allReady.Wait below ever fails (a starved CI runner
+            // failing to spin up every thread in time), go.Set() is never reached, and an unbounded
+            // wait here would hang the process instead of surfacing a clean assertion failure.
+            // Workers are also background threads for the same reason, as defence in depth.
+
             void RecordWorker()
             {
                 allReady.Signal();
-                go.Wait();
+                if (!go.Wait(TimeSpan.FromSeconds(gateTimeoutSeconds)))
+                {
+                    Interlocked.Increment(ref gateTimeouts);
+                    return;
+                }
 
                 int unit;
 
@@ -207,7 +220,11 @@ public sealed class SessionStoreCapsTests
             void PruneWorker()
             {
                 allReady.Signal();
-                go.Wait();
+                if (!go.Wait(TimeSpan.FromSeconds(gateTimeoutSeconds)))
+                {
+                    Interlocked.Increment(ref gateTimeouts);
+                    return;
+                }
 
                 int index;
                 while ((index = Interlocked.Increment(ref nextPruneAddress)) < addressCount)
@@ -222,12 +239,18 @@ public sealed class SessionStoreCapsTests
             var threads = new List<Thread>(recorderThreadCount + prunerThreadCount);
             for (var t = 0; t < recorderThreadCount; t++)
             {
-                threads.Add(new Thread(RecordWorker));
+                threads.Add(new Thread(RecordWorker)
+                {
+                    IsBackground = true
+                });
             }
 
             for (var t = 0; t < prunerThreadCount; t++)
             {
-                threads.Add(new Thread(PruneWorker));
+                threads.Add(new Thread(PruneWorker)
+                {
+                    IsBackground = true
+                });
             }
 
             foreach (var thread in threads)
@@ -254,6 +277,15 @@ public sealed class SessionStoreCapsTests
                 Assert.Equal(SessionCreateFailure.HourlyLimit, failure);
             }
         }
+
+        // Checked separately from lostWrites and with its own message: a gate timeout means some
+        // workers never ran, which would otherwise masquerade as a lost write and misattribute an
+        // environment slowdown to the production race this test targets.
+        Assert.True(
+            gateTimeouts == 0,
+            $"{gateTimeouts} storm worker(s) timed out waiting for the release gate instead of "
+            + "running, so the counts below cannot be trusted as a race-detection signal — the "
+            + "test environment is too slow or throttled for this test's timing budget.");
 
         Assert.Empty(lostWrites);
     }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreTests.cs
@@ -12,7 +12,10 @@ public sealed class SessionStoreTests
     private static (SessionStore Store, FakeTimeProvider Time) NewStore()
     {
         var time = new FakeTimeProvider(Origin);
-        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        var options = new AppOptions
+        {
+            PublicBaseUrl = "https://creds.example.org"
+        };
         return (new SessionStore(options, time), time);
     }
 

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionStoreTests.cs
@@ -1,0 +1,180 @@
+using Microsoft.Extensions.Time.Testing;
+using RustPlusApi.CredentialsWeb;
+using RustPlusApi.CredentialsWeb.Sessions;
+using Xunit;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SessionStoreTests
+{
+    private static readonly DateTimeOffset Origin = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    private static (SessionStore Store, FakeTimeProvider Time) NewStore()
+    {
+        var time = new FakeTimeProvider(Origin);
+        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        return (new SessionStore(options, time), time);
+    }
+
+    [Fact]
+    public void TryCreate_ReturnsCreatedSessionWithDistinctIds()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+
+        Assert.True(store.TryCreate("203.0.113.7", out var session, out var failure));
+
+        Assert.Equal(SessionCreateFailure.None, failure);
+        Assert.Equal(SessionState.Created, session.State);
+        Assert.Equal("203.0.113.7", session.ClientIp);
+        Assert.NotEqual(session.SessionId, session.ReturnToken);
+        Assert.Equal(Origin.AddMinutes(5), session.ExpiresAt);
+        Assert.Equal(1, store.Count);
+    }
+
+    [Fact]
+    public void TryGet_FindsSessionBySessionId()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var created, out _);
+
+        Assert.True(store.TryGet(created!.SessionId, out var found));
+        Assert.Same(created, found);
+    }
+
+    [Fact]
+    public void TryGet_ReturnsFalse_ForUnknownId()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+
+        Assert.False(store.TryGet("nope", out var found));
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public void TryGet_DoesNotAcceptTheReturnToken()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var created, out _);
+
+        Assert.False(store.TryGet(created!.ReturnToken, out _));
+    }
+
+    [Fact]
+    public void TryConsumeReturnToken_ReturnsSessionOnce()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var created, out _);
+
+        Assert.True(store.TryConsumeReturnToken(created!.ReturnToken, out var first));
+        Assert.Same(created, first);
+
+        Assert.False(store.TryConsumeReturnToken(created.ReturnToken, out var second));
+        Assert.Null(second);
+    }
+
+    [Fact]
+    public void TryConsumeReturnToken_ReturnsFalse_ForUnknownToken()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+
+        Assert.False(store.TryConsumeReturnToken("unknown", out _));
+    }
+
+    [Fact]
+    public void TryConsumeReturnToken_LeavesSessionRetrievable()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var created, out _);
+
+        store.TryConsumeReturnToken(created!.ReturnToken, out _);
+
+        Assert.True(store.TryGet(created.SessionId, out _));
+    }
+
+    [Fact]
+    public void Remove_DisposesAndForgetsTheSession()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var created, out _);
+
+        store.Remove(created!.SessionId);
+
+        Assert.False(store.TryGet(created.SessionId, out _));
+        Assert.True(created.Lifetime.IsCancellationRequested);
+        Assert.Equal(0, store.Count);
+    }
+
+    [Fact]
+    public void Remove_IsSafeForUnknownId()
+    {
+        var (store, _) = NewStore();
+        using var _s = store;
+
+        store.Remove("unknown");
+
+        Assert.Equal(0, store.Count);
+    }
+
+    [Fact]
+    public void SweepExpired_RemovesOnlyExpiredSessions()
+    {
+        var (store, time) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var stale, out _);
+        time.Advance(TimeSpan.FromMinutes(6));
+        store.TryCreate("203.0.113.8", out var fresh, out _);
+
+        var swept = store.SweepExpired();
+
+        Assert.Equal(1, swept);
+        Assert.False(store.TryGet(stale!.SessionId, out _));
+        Assert.True(store.TryGet(fresh!.SessionId, out _));
+    }
+
+    [Fact]
+    public void SweepExpired_AlsoInvalidatesTheReturnToken()
+    {
+        var (store, time) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var session, out _);
+        time.Advance(TimeSpan.FromMinutes(6));
+
+        store.SweepExpired();
+
+        Assert.False(store.TryConsumeReturnToken(session!.ReturnToken, out _));
+    }
+
+    [Fact]
+    public void SweepExpired_UsesTheStateSpecificTtl()
+    {
+        var (store, time) = NewStore();
+        using var _s = store;
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        // Authenticated sessions get SessionTtl (15 min), not CreatedTtl (5 min).
+        session!.Advance(SessionState.Authenticated, time.GetUtcNow().Add(TimeSpan.FromMinutes(15)));
+        time.Advance(TimeSpan.FromMinutes(6));
+
+        Assert.Equal(0, store.SweepExpired());
+    }
+
+    [Fact]
+    public void Dispose_DisposesEverySession()
+    {
+        var (store, _) = NewStore();
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        store.Dispose();
+
+        Assert.True(session!.Lifetime.IsCancellationRequested);
+        Assert.Equal(0, store.Count);
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
@@ -18,13 +18,14 @@ public sealed class SessionSweeperTests
         using var sweeper = new SessionSweeper(store, time);
         await sweeper.StartAsync(CancellationToken.None);
 
-        time.Advance(TimeSpan.FromMinutes(6));
-
+        // Advance past TTL. Tolerate the startup race: the sweeper may not have created its timer yet,
+        // so repeated advances ensure it fires after being created.
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         while (store.TryGet(session!.SessionId, out _))
         {
             timeout.Token.ThrowIfCancellationRequested();
-            await Task.Delay(20, timeout.Token);
+            time.Advance(TimeSpan.FromSeconds(31)); // Advance past sweep interval to ensure timer fires
+            await Task.Delay(10, timeout.Token);
         }
 
         await sweeper.StopAsync(CancellationToken.None);
@@ -42,7 +43,8 @@ public sealed class SessionSweeperTests
         using var sweeper = new SessionSweeper(store, time);
         await sweeper.StartAsync(CancellationToken.None);
 
-        time.Advance(TimeSpan.FromMinutes(1));
+        // Advance past one sweep interval to ensure the sweeper demonstrably ran, but not past TTL
+        time.Advance(TimeSpan.FromSeconds(31));
         await Task.Delay(100);
 
         await sweeper.StopAsync(CancellationToken.None);

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Time.Testing;
+using RustPlusApi.CredentialsWeb;
+using RustPlusApi.CredentialsWeb.Sessions;
+using Xunit;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SessionSweeperTests
+{
+    [Fact]
+    public async Task ExecuteAsync_RemovesExpiredSessionsOnTick()
+    {
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero));
+        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        using var store = new SessionStore(options, time);
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        using var sweeper = new SessionSweeper(store, time);
+        await sweeper.StartAsync(CancellationToken.None);
+
+        time.Advance(TimeSpan.FromMinutes(6));
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (store.TryGet(session!.SessionId, out _))
+        {
+            timeout.Token.ThrowIfCancellationRequested();
+            await Task.Delay(20, timeout.Token);
+        }
+
+        await sweeper.StopAsync(CancellationToken.None);
+        Assert.Equal(0, store.Count);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_LeavesLiveSessionsAlone()
+    {
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero));
+        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        using var store = new SessionStore(options, time);
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        using var sweeper = new SessionSweeper(store, time);
+        await sweeper.StartAsync(CancellationToken.None);
+
+        time.Advance(TimeSpan.FromMinutes(1));
+        await Task.Delay(100);
+
+        await sweeper.StopAsync(CancellationToken.None);
+        Assert.True(store.TryGet(session!.SessionId, out _));
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
@@ -76,8 +76,12 @@ public sealed class SessionSweeperTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ContinuesAfterSweepThrows()
+    public async Task ExecuteAsync_RemovesSessionWithThrowingCallback_AndKeepsSweepingOthers()
     {
+        // A session whose cancellation callback throws (Cancel() rethrows callback exceptions) must
+        // no longer disrupt sweeping at all: Session.Dispose() now swallows that exception and still
+        // completes its own cleanup, and the sweeper must still go on to reap sessions on other IPs.
+        // This models the real scenario where pairing tasks register callbacks that may throw.
         var time = new FakeTimeProvider(new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero));
         var options = new AppOptions
         {
@@ -85,8 +89,6 @@ public sealed class SessionSweeperTests
         };
         using var store = new SessionStore(options, time);
 
-        // Create a session that will throw when disposed (via Lifetime.Token callback).
-        // This models the real scenario where pairing tasks register callbacks that may throw.
         // Expires at 5 minutes.
         store.TryCreate("203.0.113.7", out var throwingSession, out _);
         throwingSession!.Lifetime.Token.Register(() =>
@@ -102,9 +104,8 @@ public sealed class SessionSweeperTests
         using var sweeper = new SessionSweeper(store, time, NullLogger);
         await sweeper.StartAsync(CancellationToken.None);
 
-        // Advance past the canary's TTL. The tick that removes the throwing session will fail with exception,
-        // but the service should log and continue. A later tick must remove the canary.
-        // If the service had died on the first exception, the canary would never be removed.
+        // Advance past the canary's TTL. If the sweeper had died (or SweepExpired had aborted the
+        // rest of its own loop) on the throwing session, the canary would never be removed.
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         while (store.TryGet(canary!.SessionId, out _))
         {
@@ -115,9 +116,18 @@ public sealed class SessionSweeperTests
 
         await sweeper.StopAsync(CancellationToken.None);
 
-        // Canary removal proves the service survived the throwing session's removal.
-        Assert.False(store.TryGet(canary.SessionId, out _),
-            "Canary should be removed (proves sweeper survived exception)");
+        Assert.False(store.TryGet(throwingSession.SessionId, out _),
+            "Session with a throwing cancellation callback should still be removed");
         Assert.Equal(0, store.Count);
+
+        // The stronger property Copilot's finding calls for: this wasn't a removal that aborted
+        // partway through Dispose() because Cancel() threw. A disposed CancellationTokenSource
+        // throws ObjectDisposedException on Token access, which only holds if Session.Dispose()
+        // still reached Lifetime.Dispose() despite Cancel() throwing above it. Before the fix, the
+        // exception from Cancel() escaped Dispose() before Events.Complete()/Lifetime.Dispose() ran,
+        // so this assertion fails against the unfixed code even though the two removal assertions
+        // above already pass there (the sweeper's own outer try/catch was already enough to recover
+        // on the next tick).
+        Assert.Throws<ObjectDisposedException>(() => _ = throwingSession.Lifetime.Token);
     }
 }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
@@ -78,17 +78,23 @@ public sealed class SessionSweeperTests
 
         // Create a session that will throw when disposed (via Lifetime.Token callback).
         // This models the real scenario where pairing tasks register callbacks that may throw.
+        // Expires at 5 minutes.
         store.TryCreate("203.0.113.7", out var throwingSession, out _);
         throwingSession!.Lifetime.Token.Register(() => throw new InvalidOperationException("Simulated callback failure"));
 
-        // Create a canary session from a different IP that will also expire
+        // Advance time by 1 minute so the canary's expiry is staggered.
+        time.Advance(TimeSpan.FromMinutes(1));
+
+        // Create a canary session from a different IP. Expires at 1+5=6 minutes.
+        // Staggering ensures the canary can only be removed on a tick *after* the throwing session.
         store.TryCreate("203.0.113.8", out var canary, out _);
 
         using var sweeper = new SessionSweeper(store, time, NullLogger);
         await sweeper.StartAsync(CancellationToken.None);
 
-        // Advance past both sessions' TTL. The first sweep will hit the throwing session and fail,
-        // but the service should continue. The second sweep should succeed and remove the canary.
+        // Advance past the canary's TTL. The tick that removes the throwing session will fail with exception,
+        // but the service should log and continue. A later tick must remove the canary.
+        // If the service had died on the first exception, the canary would never be removed.
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         while (store.TryGet(canary!.SessionId, out _))
         {
@@ -99,11 +105,8 @@ public sealed class SessionSweeperTests
 
         await sweeper.StopAsync(CancellationToken.None);
 
-        // Both sessions should be gone: throwing session on first sweep (despite exception),
-        // canary on a later tick. If the service had died on the exception, the canary would still be there.
-        Assert.False(store.TryGet(throwingSession.SessionId, out _), "Throwing session should be removed despite exception");
-        Assert.False(store.TryGet(canary.SessionId, out _), "Canary session should be removed on later sweep");
+        // Canary removal proves the service survived the throwing session's removal.
+        Assert.False(store.TryGet(canary.SessionId, out _), "Canary should be removed (proves sweeper survived exception)");
         Assert.Equal(0, store.Count);
     }
-
 }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
@@ -69,4 +69,41 @@ public sealed class SessionSweeperTests
         Assert.True(store.TryGet(liveSession!.SessionId, out _), "Live session should survive sweep");
     }
 
+    [Fact]
+    public async Task ExecuteAsync_ContinuesAfterSweepThrows()
+    {
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero));
+        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        using var store = new SessionStore(options, time);
+
+        // Create a session that will throw when disposed (via Lifetime.Token callback).
+        // This models the real scenario where pairing tasks register callbacks that may throw.
+        store.TryCreate("203.0.113.7", out var throwingSession, out _);
+        throwingSession!.Lifetime.Token.Register(() => throw new InvalidOperationException("Simulated callback failure"));
+
+        // Create a canary session from a different IP that will also expire
+        store.TryCreate("203.0.113.8", out var canary, out _);
+
+        using var sweeper = new SessionSweeper(store, time, NullLogger);
+        await sweeper.StartAsync(CancellationToken.None);
+
+        // Advance past both sessions' TTL. The first sweep will hit the throwing session and fail,
+        // but the service should continue. The second sweep should succeed and remove the canary.
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (store.TryGet(canary!.SessionId, out _))
+        {
+            timeout.Token.ThrowIfCancellationRequested();
+            time.Advance(TimeSpan.FromSeconds(31)); // Advance past sweep interval to ensure timer fires
+            await Task.Delay(10, timeout.Token);
+        }
+
+        await sweeper.StopAsync(CancellationToken.None);
+
+        // Both sessions should be gone: throwing session on first sweep (despite exception),
+        // canary on a later tick. If the service had died on the exception, the canary would still be there.
+        Assert.False(store.TryGet(throwingSession.SessionId, out _), "Throwing session should be removed despite exception");
+        Assert.False(store.TryGet(canary.SessionId, out _), "Canary session should be removed on later sweep");
+        Assert.Equal(0, store.Count);
+    }
+
 }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using RustPlusApi.CredentialsWeb;
 using RustPlusApi.CredentialsWeb.Sessions;
@@ -7,6 +9,8 @@ namespace RustPlusApi.CredentialsWeb.UnitTests;
 
 public sealed class SessionSweeperTests
 {
+    private static ILogger<SessionSweeper> NullLogger => NullLoggerFactory.Instance.CreateLogger<SessionSweeper>();
+
     [Fact]
     public async Task ExecuteAsync_RemovesExpiredSessionsOnTick()
     {
@@ -15,7 +19,7 @@ public sealed class SessionSweeperTests
         using var store = new SessionStore(options, time);
         store.TryCreate("203.0.113.7", out var session, out _);
 
-        using var sweeper = new SessionSweeper(store, time);
+        using var sweeper = new SessionSweeper(store, time, NullLogger);
         await sweeper.StartAsync(CancellationToken.None);
 
         // Advance past TTL. Tolerate the startup race: the sweeper may not have created its timer yet,
@@ -38,16 +42,31 @@ public sealed class SessionSweeperTests
         var time = new FakeTimeProvider(new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero));
         var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
         using var store = new SessionStore(options, time);
-        store.TryCreate("203.0.113.7", out var session, out _);
 
-        using var sweeper = new SessionSweeper(store, time);
+        // Create a canary session from one IP at time 0, expires at 5 minutes
+        store.TryCreate("203.0.113.7", out var canary, out _);
+
+        // Advance time by 1 minute
+        time.Advance(TimeSpan.FromMinutes(1));
+
+        // Create a live session from a different IP, expires at 1+5=6 minutes
+        store.TryCreate("203.0.113.8", out var liveSession, out _);
+
+        using var sweeper = new SessionSweeper(store, time, NullLogger);
         await sweeper.StartAsync(CancellationToken.None);
 
-        // Advance past one sweep interval to ensure the sweeper demonstrably ran, but not past TTL
-        time.Advance(TimeSpan.FromSeconds(31));
-        await Task.Delay(100);
+        // Advance past canary's TTL (5 minutes) repeatedly until it is removed,
+        // proving the sweeper actually ran. The live session (expires at 6 minutes) should still be present.
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (store.TryGet(canary!.SessionId, out _))
+        {
+            timeout.Token.ThrowIfCancellationRequested();
+            time.Advance(TimeSpan.FromSeconds(31)); // Advance past sweep interval to ensure timer fires
+            await Task.Delay(10, timeout.Token);
+        }
 
         await sweeper.StopAsync(CancellationToken.None);
-        Assert.True(store.TryGet(session!.SessionId, out _));
+        Assert.True(store.TryGet(liveSession!.SessionId, out _), "Live session should survive sweep");
     }
+
 }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
@@ -15,7 +15,10 @@ public sealed class SessionSweeperTests
     public async Task ExecuteAsync_RemovesExpiredSessionsOnTick()
     {
         var time = new FakeTimeProvider(new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero));
-        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        var options = new AppOptions
+        {
+            PublicBaseUrl = "https://creds.example.org"
+        };
         using var store = new SessionStore(options, time);
         store.TryCreate("203.0.113.7", out var session, out _);
 
@@ -40,7 +43,10 @@ public sealed class SessionSweeperTests
     public async Task ExecuteAsync_LeavesLiveSessionsAlone()
     {
         var time = new FakeTimeProvider(new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero));
-        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        var options = new AppOptions
+        {
+            PublicBaseUrl = "https://creds.example.org"
+        };
         using var store = new SessionStore(options, time);
 
         // Create a canary session from one IP at time 0, expires at 5 minutes
@@ -73,14 +79,18 @@ public sealed class SessionSweeperTests
     public async Task ExecuteAsync_ContinuesAfterSweepThrows()
     {
         var time = new FakeTimeProvider(new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero));
-        var options = new AppOptions { PublicBaseUrl = "https://creds.example.org" };
+        var options = new AppOptions
+        {
+            PublicBaseUrl = "https://creds.example.org"
+        };
         using var store = new SessionStore(options, time);
 
         // Create a session that will throw when disposed (via Lifetime.Token callback).
         // This models the real scenario where pairing tasks register callbacks that may throw.
         // Expires at 5 minutes.
         store.TryCreate("203.0.113.7", out var throwingSession, out _);
-        throwingSession!.Lifetime.Token.Register(() => throw new InvalidOperationException("Simulated callback failure"));
+        throwingSession!.Lifetime.Token.Register(() =>
+            throw new InvalidOperationException("Simulated callback failure"));
 
         // Advance time by 1 minute so the canary's expiry is staggered.
         time.Advance(TimeSpan.FromMinutes(1));
@@ -106,7 +116,8 @@ public sealed class SessionSweeperTests
         await sweeper.StopAsync(CancellationToken.None);
 
         // Canary removal proves the service survived the throwing session's removal.
-        Assert.False(store.TryGet(canary.SessionId, out _), "Canary should be removed (proves sweeper survived exception)");
+        Assert.False(store.TryGet(canary.SessionId, out _),
+            "Canary should be removed (proves sweeper survived exception)");
         Assert.Equal(0, store.Count);
     }
 }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionTests.cs
@@ -1,0 +1,157 @@
+using RustPlusApi.CredentialsWeb.Sessions;
+using RustPlusApi.Fcm.Data;
+using RustPlusApi.Fcm.Registration;
+using Xunit;
+
+namespace RustPlusApi.CredentialsWeb.UnitTests;
+
+public sealed class SessionTests
+{
+    private static readonly DateTimeOffset Origin = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    private static Session NewSession() =>
+        new("session-id", "return-token", "203.0.113.7", Origin.AddMinutes(5));
+
+    private static async Task<List<SessionEvent>> ReadAsync(Session session, int expected)
+    {
+        var received = new List<SessionEvent>();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await foreach (var item in session.Events.SubscribeAsync(timeout.Token))
+        {
+            received.Add(item);
+            if (received.Count == expected)
+            {
+                break;
+            }
+        }
+
+        return received;
+    }
+
+    [Fact]
+    public void New_StartsInCreatedState()
+    {
+        using var session = NewSession();
+
+        Assert.Equal(SessionState.Created, session.State);
+        Assert.Equal(Origin.AddMinutes(5), session.ExpiresAt);
+        Assert.Equal("203.0.113.7", session.ClientIp);
+    }
+
+    [Fact]
+    public async Task Advance_UpdatesStateAndExpiry_AndPublishesStepEvent()
+    {
+        using var session = NewSession();
+
+        session.Advance(SessionState.Registering, Origin.AddMinutes(15));
+
+        Assert.Equal(SessionState.Registering, session.State);
+        Assert.Equal(Origin.AddMinutes(15), session.ExpiresAt);
+
+        var events = await ReadAsync(session, 1);
+        Assert.Equal("step", events[0].Type);
+    }
+
+    [Fact]
+    public void SetSteamLogin_StoresIdAndToken()
+    {
+        using var session = NewSession();
+
+        session.SetSteamLogin(new SteamLoginResult(76561198249527954, "steam-token"));
+
+        Assert.Equal(76561198249527954UL, session.SteamId);
+        Assert.Equal("steam-token", session.SteamToken);
+    }
+
+    [Fact]
+    public void ClearSteamToken_DropsTokenButKeepsSteamId()
+    {
+        using var session = NewSession();
+        session.SetSteamLogin(new SteamLoginResult(76561198249527954, "steam-token"));
+
+        session.ClearSteamToken();
+
+        Assert.Null(session.SteamToken);
+        Assert.Equal(76561198249527954UL, session.SteamId);
+    }
+
+    [Fact]
+    public void SetCredentialsAndPairing_AreExposed()
+    {
+        using var session = NewSession();
+        var credentials = new Credentials { ExpoPushToken = "expo-token" };
+        var pairing = new ServerPairing { Ip = "10.0.0.1", Port = 28082, PlayerId = 1, PlayerToken = 2 };
+
+        session.SetCredentials(credentials);
+        session.SetPairing(pairing);
+
+        Assert.Same(credentials, session.Credentials);
+        Assert.Same(pairing, session.Pairing);
+    }
+
+    [Theory]
+    [InlineData(4, false)]
+    [InlineData(5, true)]
+    [InlineData(6, true)]
+    public void IsExpired_ComparesAgainstExpiry(int minutes, bool expected)
+    {
+        using var session = NewSession();
+
+        Assert.Equal(expected, session.IsExpired(Origin.AddMinutes(minutes)));
+    }
+
+    [Fact]
+    public void Dispose_ClearsSecretsAndCancelsLifetime()
+    {
+        var session = NewSession();
+        session.SetSteamLogin(new SteamLoginResult(1, "steam-token"));
+        session.SetCredentials(new Credentials { ExpoPushToken = "expo-token" });
+        session.SetPairing(new ServerPairing { Ip = "10.0.0.1", Port = 1, PlayerId = 1, PlayerToken = 2 });
+
+        session.Dispose();
+
+        Assert.Null(session.SteamToken);
+        Assert.Null(session.Credentials);
+        Assert.Null(session.Pairing);
+        Assert.True(session.Lifetime.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task Dispose_CompletesTheEventStream()
+    {
+        var session = NewSession();
+        session.Dispose();
+
+        var received = new List<SessionEvent>();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await foreach (var item in session.Events.SubscribeAsync(timeout.Token))
+        {
+            received.Add(item);
+        }
+
+        Assert.Empty(received);
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var session = NewSession();
+
+        session.Dispose();
+        session.Dispose();
+
+        Assert.True(session.Lifetime.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void SessionIds_AreThirtyTwoLowercaseHexCharsAndUnique()
+    {
+        var first = SessionIds.New();
+        var second = SessionIds.New();
+
+        Assert.Equal(32, first.Length);
+        Assert.Matches("^[0-9a-f]{32}$", first);
+        Assert.NotEqual(first, second);
+    }
+}

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionTests.cs
@@ -80,8 +80,14 @@ public sealed class SessionTests
     public void SetCredentialsAndPairing_AreExposed()
     {
         using var session = NewSession();
-        var credentials = new Credentials { ExpoPushToken = "expo-token" };
-        var pairing = new ServerPairing { Ip = "10.0.0.1", Port = 28082, PlayerId = 1, PlayerToken = 2 };
+        var credentials = new Credentials
+        {
+            ExpoPushToken = "expo-token"
+        };
+        var pairing = new ServerPairing
+        {
+            Ip = "10.0.0.1", Port = 28082, PlayerId = 1, PlayerToken = 2
+        };
 
         session.SetCredentials(credentials);
         session.SetPairing(pairing);
@@ -106,8 +112,14 @@ public sealed class SessionTests
     {
         var session = NewSession();
         session.SetSteamLogin(new SteamLoginResult(1, "steam-token"));
-        session.SetCredentials(new Credentials { ExpoPushToken = "expo-token" });
-        session.SetPairing(new ServerPairing { Ip = "10.0.0.1", Port = 1, PlayerId = 1, PlayerToken = 2 });
+        session.SetCredentials(new Credentials
+        {
+            ExpoPushToken = "expo-token"
+        });
+        session.SetPairing(new ServerPairing
+        {
+            Ip = "10.0.0.1", Port = 1, PlayerId = 1, PlayerToken = 2
+        });
 
         session.Dispose();
 
@@ -161,7 +173,10 @@ public sealed class SessionTests
         var session = NewSession();
         session.Dispose();
 
-        session.SetCredentials(new Credentials { ExpoPushToken = "expo-token" });
+        session.SetCredentials(new Credentials
+        {
+            ExpoPushToken = "expo-token"
+        });
 
         Assert.Null(session.Credentials);
     }
@@ -172,7 +187,10 @@ public sealed class SessionTests
         var session = NewSession();
         session.Dispose();
 
-        session.SetPairing(new ServerPairing { Ip = "10.0.0.1", Port = 1, PlayerId = 1, PlayerToken = 2 });
+        session.SetPairing(new ServerPairing
+        {
+            Ip = "10.0.0.1", Port = 1, PlayerId = 1, PlayerToken = 2
+        });
 
         Assert.Null(session.Pairing);
     }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionTests.cs
@@ -145,6 +145,50 @@ public sealed class SessionTests
     }
 
     [Fact]
+    public void SetSteamLogin_AfterDispose_DoesNotResurrectToken()
+    {
+        var session = NewSession();
+        session.Dispose();
+
+        session.SetSteamLogin(new SteamLoginResult(76561198249527954, "steam-token"));
+
+        Assert.Null(session.SteamToken);
+    }
+
+    [Fact]
+    public void SetCredentials_AfterDispose_DoesNotResurrectCredentials()
+    {
+        var session = NewSession();
+        session.Dispose();
+
+        session.SetCredentials(new Credentials { ExpoPushToken = "expo-token" });
+
+        Assert.Null(session.Credentials);
+    }
+
+    [Fact]
+    public void SetPairing_AfterDispose_DoesNotResurrectPairing()
+    {
+        var session = NewSession();
+        session.Dispose();
+
+        session.SetPairing(new ServerPairing { Ip = "10.0.0.1", Port = 1, PlayerId = 1, PlayerToken = 2 });
+
+        Assert.Null(session.Pairing);
+    }
+
+    [Fact]
+    public void Advance_AfterDispose_DoesNotChangeState()
+    {
+        var session = NewSession();
+        session.Dispose();
+
+        session.Advance(SessionState.Registering, Origin.AddMinutes(15));
+
+        Assert.Equal(SessionState.Created, session.State);
+    }
+
+    [Fact]
     public void SessionIds_AreThirtyTwoLowercaseHexCharsAndUnique()
     {
         var first = SessionIds.New();

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionTests.cs
@@ -157,6 +157,40 @@ public sealed class SessionTests
     }
 
     [Fact]
+    public void Dispose_DoesNotThrow_WhenACancellationCallbackThrows()
+    {
+        var session = NewSession();
+        session.Lifetime.Token.Register(() => throw new InvalidOperationException("Simulated callback failure"));
+
+        var exception = Record.Exception(session.Dispose);
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task Dispose_StillCompletesEventsAndDisposesLifetime_WhenACancellationCallbackThrows()
+    {
+        var session = NewSession();
+        session.Lifetime.Token.Register(() => throw new InvalidOperationException("Simulated callback failure"));
+
+        session.Dispose();
+
+        // Events.Complete() ran despite Cancel() throwing: the stream is closed rather than left
+        // open for a subscriber that would otherwise never see it end.
+        var received = new List<SessionEvent>();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await foreach (var item in session.Events.SubscribeAsync(timeout.Token))
+        {
+            received.Add(item);
+        }
+
+        Assert.Empty(received);
+
+        // Lifetime.Dispose() ran too: a disposed CancellationTokenSource throws on Token access.
+        Assert.Throws<ObjectDisposedException>(() => _ = session.Lifetime.Token);
+    }
+
+    [Fact]
     public void SetSteamLogin_AfterDispose_DoesNotResurrectToken()
     {
         var session = NewSession();

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionTests.cs
@@ -241,6 +241,71 @@ public sealed class SessionTests
     }
 
     [Fact]
+    public void TryClaimForEviction_SucceedsForCreatedState()
+    {
+        using var session = NewSession();
+
+        Assert.True(session.TryClaimForEviction());
+    }
+
+    [Fact]
+    public void TryClaimForEviction_SucceedsForFailedState()
+    {
+        using var session = NewSession();
+        session.Advance(SessionState.Failed, Origin.AddMinutes(5));
+
+        Assert.True(session.TryClaimForEviction());
+    }
+
+    [Fact]
+    public void TryClaimForEviction_RefusesForAnyOtherState()
+    {
+        // Theory + InlineData(SessionState.X) is unavailable here: SessionState is internal and an
+        // InlineData-decorated test method must be public, which the runtime rejects (CS0051) for a
+        // parameter less accessible than the method. Looping internally instead.
+        SessionState[] resumableStates =
+        [
+            SessionState.Authenticated, SessionState.Registering, SessionState.Ready,
+            SessionState.AwaitingPairing, SessionState.Paired
+        ];
+
+        foreach (var state in resumableStates)
+        {
+            using var session = NewSession();
+            session.Advance(state, Origin.AddMinutes(5));
+
+            Assert.False(session.TryClaimForEviction());
+        }
+    }
+
+    [Fact]
+    public void TryClaimForEviction_SucceedsForAnAlreadyDisposedSession()
+    {
+        // Something else (the sweeper, a concurrent eviction) already disposed it; there is nothing
+        // left to protect, so this must not block a new session over one that is already gone.
+        var session = NewSession();
+        session.Dispose();
+
+        Assert.True(session.TryClaimForEviction());
+    }
+
+    [Fact]
+    public void TryClaimForEviction_MakesASubsequentAdvanceANoOp()
+    {
+        // This is the race SessionStore.TryCreate closes: once claimed, a concurrent Advance call
+        // that lands afterwards (the visitor's Facepunch callback landing just after eviction won
+        // the race) must not resurrect state on a session that is about to be disposed.
+        using var session = NewSession();
+
+        Assert.True(session.TryClaimForEviction());
+
+        session.Advance(SessionState.Authenticated, Origin.AddMinutes(15));
+
+        Assert.Equal(SessionState.Created, session.State);
+        Assert.Equal(Origin.AddMinutes(5), session.ExpiresAt);
+    }
+
+    [Fact]
     public void SessionIds_AreThirtyTwoLowercaseHexCharsAndUnique()
     {
         var first = SessionIds.New();

--- a/tools/coverage/check_threshold.py
+++ b/tools/coverage/check_threshold.py
@@ -1,22 +1,21 @@
 #!/usr/bin/env python3
 """Fail (exit 1) if merged coverage is below the given line/branch thresholds.
 
-Usage: check_threshold.py <line_min> <branch_min>
-Reads the single merged Cobertura report produced by ReportGenerator at
-TestResults/merged/Cobertura.xml (a union across every test project and TFM,
-de-duplicated by ReportGenerator) and checks its overall line-rate and
-branch-rate against the floors.
+Usage: check_threshold.py <line_min> <branch_min> [report_path]
+Reads a merged Cobertura report produced by ReportGenerator (by default
+TestResults/merged/Cobertura.xml, the union across every library test project
+and TFM) and checks its overall line-rate and branch-rate against the floors.
 """
 import sys
 import os
 import xml.etree.ElementTree as ET
 
-if len(sys.argv) != 3:
-    print("Usage: check_threshold.py <line_min> <branch_min>")
+if len(sys.argv) not in (3, 4):
+    print("Usage: check_threshold.py <line_min> <branch_min> [report_path]")
     sys.exit(2)
 
 line_min, branch_min = float(sys.argv[1]), float(sys.argv[2])
-report = 'TestResults/merged/Cobertura.xml'
+report = sys.argv[3] if len(sys.argv) == 4 else 'TestResults/merged/Cobertura.xml'
 if not os.path.exists(report):
     print(f"Merged coverage report not found at {report}")
     sys.exit(1)

--- a/tools/coverage/report.sh
+++ b/tools/coverage/report.sh
@@ -8,20 +8,36 @@ dotnet test RustPlusApi.sln \
   --settings tests/RustPlusApi.UnitTests/coverlet.runsettings \
   --results-directory ./TestResults
 dotnet tool restore
+
+# Two reports, two gates. The library gate must stay exactly what it was before the web app
+# existed: merging a net10.0-only ASP.NET app into it would lower the bar the libraries clear.
 dotnet tool run reportgenerator -- \
   "-reports:TestResults/**/coverage.opencover.xml" \
   "-targetdir:TestResults/merged" \
+  "-assemblyfilters:-RustPlusApi.CredentialsWeb" \
   "-reporttypes:Cobertura"
+
+dotnet tool run reportgenerator -- \
+  "-reports:TestResults/**/coverage.opencover.xml" \
+  "-targetdir:TestResults/merged-web" \
+  "-assemblyfilters:+RustPlusApi.CredentialsWeb" \
+  "-reporttypes:Cobertura"
+
 python3 - <<'PY'
 import xml.etree.ElementTree as ET
-root = ET.parse('TestResults/merged/Cobertura.xml').getroot()
-line = float(root.attrib['line-rate']) * 100
-branch = float(root.attrib['branch-rate']) * 100
-print(f"merged -> line={line:.2f}% branch={branch:.2f}%")
-for cls in root.iter('class'):
-    name = cls.attrib.get('name', '?')
-    lr = float(cls.attrib.get('line-rate', '1')) * 100
-    br = float(cls.attrib.get('branch-rate', '1')) * 100
-    if lr < 100 or br < 100:
-        print(f"  line={lr:6.2f}% branch={br:6.2f}%  {name}")
+for label, path in (('libraries', 'TestResults/merged/Cobertura.xml'),
+                    ('web app  ', 'TestResults/merged-web/Cobertura.xml')):
+    root = ET.parse(path).getroot()
+    line = float(root.attrib['line-rate']) * 100
+    branch = float(root.attrib['branch-rate']) * 100
+    print(f"{label} -> line={line:.2f}% branch={branch:.2f}%")
+    for cls in root.iter('class'):
+        name = cls.attrib.get('name', '?')
+        lr = float(cls.attrib.get('line-rate', '1')) * 100
+        br = float(cls.attrib.get('branch-rate', '1')) * 100
+        if lr < 100 or br < 100:
+            print(f"  line={lr:6.2f}% branch={br:6.2f}%  {name}")
 PY
+
+python3 tools/coverage/check_threshold.py 95 90
+python3 tools/coverage/check_threshold.py 95 90 TestResults/merged-web/Cobertura.xml


### PR DESCRIPTION
Adds `apps/RustPlusApi.CredentialsWeb` — a single-page site that takes a visitor from nothing to working Rust+ credentials in a browser. It replaces "clone the repo, install the .NET SDK, run a console app" for the common case, and doubles as a live exercise of `RustPlusApi.Fcm.Registration`.

Deployable as a self-host starter (`docker run`) or as a public instance.

**No library changes.** `src/**` is untouched — the app consumes only the existing public API exposed by #118.

## The finding this rests on

PR #118 established that Facepunch's login honours an arbitrary `returnUrl`. This branch confirmed the rest, live on 2026-09-03:

- An `https` return URL on a **non-3000 port** with a **path nonce** completes the round trip — verified with a real Steam login.
- Neither `GET /login` nor `POST /login` applies an allowlist to an external host: the value is reflected verbatim and rides inside the encrypted OpenID `state` blob.

## Design

The flow runs **`4 → 1,2,3 → 5`**, not the console app's `1,2,3 → 4 → 5`. Putting the Steam login first makes a real Steam account the entry gate, so an unauthenticated visitor costs one dictionary entry with a 5-minute TTL — not a Google device registration. Step 6 (the pairing wait, the only step holding a socket) is an opt-in continuation.

Trust properties, each verified rather than asserted:

- **No credential reaches a log record.** `SecretsAreNeverLoggedTests` boots the real app at `LogLevel.Trace`, drives a full callback *and* a pairing, and asserts four sentinels are absent — including the raw substring `token=`, which catches query-string leakage generically.
- **The Steam token is dropped** the moment the device is registered — on the success, failure and cancellation paths.
- **The callback responds 302, not 200**, so the token-bearing URL never becomes a browser history entry; the session handle rides in a URL fragment.
- **The return token is single-use**, and a replayed callback is indistinguishable from an unknown one by construction — same branch, same empty body.
- **Nothing is persisted.** In-memory only, enforced at runtime by a read-only container root filesystem.

Abuse is bounded by global, per-IP and pairing-slot caps with a rolling hourly limit.

## Coverage

The gate is split so the app cannot dilute the libraries' bar. Both clear line 95 / branch 90:

| Report | Line | Branch |
|---|---|---|
| Libraries | 96.18% | 92.19% |
| Web app | 98.75% | 94.64% |

The library figure is unchanged from `develop` — the app is filtered out, not netted against it.

## Worth a reviewer's attention

1. **`Flow/CredentialFlow.cs` next to `Sessions/SessionStore.cs`** — read them together and ask what cancels `session.Lifetime.Token`. An earlier revision made the pairing TTL the *session's* expiry, so the sweeper disposed the session and the promised retry-after-timeout could never happen. Two tests passed anyway, because they drove a token production never constructs.
2. **`Sessions/SessionStore.cs` eviction next to `wwwroot/app.js`'s "Start over"** — a `Failed` session used to block its own IP for 15 minutes while the UI's own recovery button led straight into it.
3. **`Program.cs`** — the hosting-diagnostics log filter, the conditional `UseForwardedHeaders`, and the 302-plus-fragment callback. An empty `KnownProxies`/`KnownNetworks` in ASP.NET Core means *trust everything*, not trust nothing; the app therefore does not register the middleware at all unless a proxy is configured.

## Before announcing a public instance

- **The external-hostname round trip has not been run end to end.** Every gate that could reject one is proven open, but a live staging deployment should confirm it.
- **`KnownProxies` address matching is untested by construction** — `TestServer` leaves the remote address null, so ASP.NET Core's own check never runs. It fails safe, and the README says so.
- Pre-existing formatter drift in `samples/RustPlus.Camera.ConsoleApp` was deliberately left out of this branch; it wants its own `style:` PR.

Design and plan: `docs/superpowers/specs/2026-09-03-credential-acquisition-website-design.md`, `docs/superpowers/plans/2026-09-03-credential-acquisition-website.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)