### PR TITLE
feat(team): add KickFromTeamAsync + surface AppInfo.cameras_enabled

### DIFF
--- a/docs/articles/rustplus-client.md
+++ b/docs/articles/rustplus-client.md
@@ -106,6 +106,7 @@ and the mapper's message.
 | `GetTeamChatAsync()` | `Response<TeamChatInfo?>` | Recent team chat history. |
 | `SendTeamMessageAsync(message)` | `Response<TeamMessage?>` | Sends text; reply is the echo broadcast for your own message. |
 | `PromoteToLeaderAsync(steamId)` | `Response` | Promotes the specified team member to leader. |
+| `KickFromTeamAsync(steamId)` | `Response` | Kicks the specified member out of the team. Leader only. |
 
 ### Clan
 

--- a/samples/RustPlus.ConsoleApp/Features/KickFromTeam.cs
+++ b/samples/RustPlus.ConsoleApp/Features/KickFromTeam.cs
@@ -1,0 +1,13 @@
+using RustPlus.ConsoleApp.Utils;
+using RustPlusApi.Interfaces;
+
+namespace RustPlus.ConsoleApp.Features;
+
+internal sealed class KickFromTeam(IRustPlus rustPlus)
+{
+    public async Task KickFromTeamAsync(ulong steamId)
+    {
+        var response = await rustPlus.KickFromTeamAsync(steamId);
+        DisplayUtilities.DisplayJson("KickFromTeam", response);
+    }
+}

--- a/samples/RustPlus.ConsoleApp/Program.cs
+++ b/samples/RustPlus.ConsoleApp/Program.cs
@@ -65,6 +65,8 @@ await Menu.RunAsync("Main menu",
         new MenuItem("Get Team Chat", () => new GetTeamChat(rustPlus).GetTeamChatAsync()),
         new MenuItem("Promote to Leader", () =>
             new PromoteToLeader(rustPlus).PromoteToLeaderAsync(ids.GetUlong("steamId"))),
+        new MenuItem("Kick from Team", () =>
+            new KickFromTeam(rustPlus).KickFromTeamAsync(ids.GetUlong("steamId"))),
         new MenuItem("Send Team Message", () =>
         {
             Console.Write("\nType your message to send to the team: ");

--- a/src/RustPlusApi/Data/ServerInfo.cs
+++ b/src/RustPlusApi/Data/ServerInfo.cs
@@ -47,4 +47,10 @@ public sealed record ServerInfo
 
     /// <summary>Zone identifier within the Nexus cluster.</summary>
     public string? NexusZone { get; init; }
+
+    /// <summary>
+    /// Whether the server allows CCTV camera access through the companion app, or
+    /// <see langword="null"/> if the server is too old to report it.
+    /// </summary>
+    public bool? CamerasEnabled { get; init; }
 }

--- a/src/RustPlusApi/Extensions/AppInfoToModel.cs
+++ b/src/RustPlusApi/Extensions/AppInfoToModel.cs
@@ -26,7 +26,8 @@ public static class AppInfoToModel
             LogoImage = appInfo.LogoImage,
             Nexus = appInfo.Nexus,
             NexusId = appInfo.ShouldSerializeNexusId() ? appInfo.NexusId : null,
-            NexusZone = appInfo.NexusZone
+            NexusZone = appInfo.NexusZone,
+            CamerasEnabled = appInfo.ShouldSerializeCamerasEnabled() ? appInfo.CamerasEnabled : null
         };
     }
 }

--- a/src/RustPlusApi/Interfaces/IRustPlus.cs
+++ b/src/RustPlusApi/Interfaces/IRustPlus.cs
@@ -151,6 +151,11 @@ public interface IRustPlus : IRustPlusSocket
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
     Task<Response<TimeInfo?>> GetTimeAsync(CancellationToken cancellationToken = default);
 
+    /// <summary>Kicks a member out of the team.</summary>
+    /// <param name="steamId">Steam64 ID of the member to kick.</param>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    Task<Response> KickFromTeamAsync(ulong steamId, CancellationToken cancellationToken = default);
+
     /// <summary>Promotes a team member to team leader.</summary>
     /// <param name="steamId">Steam64 ID of the member to promote.</param>
     /// <param name="cancellationToken">A token to observe for cancellation requests.</param>

--- a/src/RustPlusApi/Protobuf/RustPlusContracts.proto
+++ b/src/RustPlusApi/Protobuf/RustPlusContracts.proto
@@ -146,6 +146,7 @@ message AppRequest {
 	optional AppCameraSubscribe camera_subscribe = 30;
 	optional AppEmpty camera_unsubscribe = 31;
 	optional AppCameraInput camera_input = 32;
+	optional AppTeamKick kick_from_team = 33;
 }
 
 message AppMessage {
@@ -226,6 +227,7 @@ message AppInfo {
 	optional string nexus = 13;
 	optional int32 nexus_id = 14;
 	optional string nexus_zone = 15;
+	optional bool cameras_enabled = 16;
 }
 
 message AppTime {
@@ -440,4 +442,8 @@ message AppCameraRays {
 		required Vector3 size = 5;
 		optional string name = 6;
 	}
+}
+
+message AppTeamKick {
+	optional uint64 steam_id = 1;
 }

--- a/src/RustPlusApi/RustPlus.cs
+++ b/src/RustPlusApi/RustPlus.cs
@@ -412,6 +412,24 @@ public class RustPlus(
     }
 
     /// <summary>
+    /// Kicks a player out of the team asynchronously.
+    /// </summary>
+    /// <param name="steamId">The Steam ID of the player to kick.</param>
+    /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous operation. The task result contains a payload-free <see cref="Response"/> indicating the success of the operation.</returns>
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    public async Task<Response> KickFromTeamAsync(ulong steamId, CancellationToken cancellationToken = default)
+    {
+        var request = new AppRequest
+        {
+            KickFromTeam = new AppTeamKick
+            {
+                SteamId = steamId
+            }
+        };
+        return await ProcessAckRequestAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Promotes a player to leader asynchronously.
     /// </summary>
     /// <param name="steamId">The Steam ID of the player to promote.</param>

--- a/tests/RustPlusApi.IntegrationTests/ClanNexusClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/ClanNexusClientTests.cs
@@ -94,6 +94,27 @@ public class ClanNexusClientTests
     }
 
     [Fact]
+    public async Task KickFromTeamAsync_SendsSteamIdAndReportsSuccess()
+    {
+        var kick = new TaskCompletionSource<RustPlusContracts.AppTeamKick>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var (server, client) = await ConnectAsync(request =>
+        {
+            if (request.KickFromTeam is not null) kick.TrySetResult(request.KickFromTeam);
+            return MockResponses.Default(request);
+        });
+        await using var _ = server;
+        await using var __ = client;
+
+        var response = await client.KickFromTeamAsync(PlayerId).WaitAsync(Timeout);
+
+        Assert.True(response.IsSuccess);
+        Assert.Null(response.Error);
+        // The bare ack would pass even for an empty request, so pin the payload the server receives.
+        Assert.Equal(PlayerId, (await kick.Task.WaitAsync(Timeout)).SteamId);
+    }
+
+    [Fact]
     public async Task ClanMessageBroadcast_RaisesOnClanChatReceived()
     {
         var (server, client) = await ConnectAsync();

--- a/tests/RustPlusApi.IntegrationTests/RustPlusClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/RustPlusClientTests.cs
@@ -33,6 +33,7 @@ public class RustPlusClientTests
         Assert.Equal("Mock Rust Server", response.Data!.Name);
         Assert.Equal(4000u, response.Data.MapSize);
         Assert.Equal(42u, response.Data.PlayerCount);
+        Assert.True(response.Data.CamerasEnabled);
     }
 
     [Fact]

--- a/tests/RustPlusApi.MockServer/MockResponses.cs
+++ b/tests/RustPlusApi.MockServer/MockResponses.cs
@@ -232,7 +232,8 @@ public static class MockResponses
         LogoImage = ExampleBaseUrl + "/logo.png",
         Nexus = "",
         NexusId = 123,
-        NexusZone = ""
+        NexusZone = "",
+        CamerasEnabled = true
     };
 
     public static AppTime SampleTime() => new()

--- a/tests/RustPlusApi.UnitTests/RemainingMapperTests.cs
+++ b/tests/RustPlusApi.UnitTests/RemainingMapperTests.cs
@@ -231,4 +231,25 @@ public class RemainingMapperTests
         Assert.False(info.ShouldSerializeNexusId());
         Assert.Null(info.ToServerInfo().NexusId);
     }
+
+    [Fact]
+    public void ToServerInfo_MapsCamerasEnabled()
+    {
+        var info = MockResponses.SampleInfo();
+        Assert.True(info.ShouldSerializeCamerasEnabled());
+        Assert.Equal(info.CamerasEnabled, info.ToServerInfo().CamerasEnabled);
+    }
+
+    [Fact]
+    public void ToServerInfo_AbsentCamerasEnabled_IsNull()
+    {
+        // cameras_enabled arrived in server build 25083359; an older server omits it, and that
+        // must map to null rather than a fabricated false.
+        var info = new AppInfo
+        {
+            Name = "n", HeaderImage = "h", Url = "u", Map = "m"
+        };
+        Assert.False(info.ShouldSerializeCamerasEnabled());
+        Assert.Null(info.ToServerInfo().CamerasEnabled);
+    }
 }


### PR DESCRIPTION
Closes #123.

Applies the three genuine wire changes reported for server build `25083359`, plus the client surface for the new request.

## Changes

**Proto** — `AppRequest.kick_from_team = 33`, `AppInfo.cameras_enabled = 16`, and the new `AppTeamKick { steam_id = 1 }`, verbatim from the drift report. Contracts regenerate at compile time via `protobuf-net.BuildTools`.

**Client** — `KickFromTeamAsync(ulong steamId, CancellationToken = default)` → `Task<Response>` on `IRustPlus`/`RustPlus`, over `ProcessAckRequestAsync` and shaped like `PromoteToLeaderAsync`. Named after the proto request field, per the existing convention.

No new event: the server answers with a bare `seq` ack, and any resulting roster change already reaches consumers through the existing `team_changed` broadcast → `OnTeamChanged`.

**Model** — `ServerInfo.CamerasEnabled` as `bool?`, mapped through `ShouldSerializeCamerasEnabled()` rather than read directly. A server older than this build omits the field, and `false` would be a fabricated answer to "does this server allow camera access" instead of "it did not say" — same treatment `NexusId` already gets.

**Docs & sample** — a Team-table row in `docs/articles/rustplus-client.md`, plus `Features/KickFromTeam.cs` and a "Kick from Team" menu entry beside "Promote to Leader".

## Tests

- `KickFromTeamAsync_SendsSteamIdAndReportsSuccess` pins the `steam_id` the server actually receives, not just the ack. `MockResponses.Default` replies with a bare `AppSuccess` to any unmatched request, so an ack-only assertion would pass against an empty `AppTeamKick`.
- Two mapper unit tests for present/absent `cameras_enabled`, mirroring the existing `NexusId` pair.
- `SampleInfo()` and the `GetInfoAsync` assertion extended, so `cameras_enabled` is pinned across the real serialize/deserialize path rather than only on a constructed object.

## Verification

- `dotnet build RustPlusApi.sln` — clean.
- `dotnet test RustPlusApi.sln` — 996 passed, both TFM hosts.
- `tools/coverage/report.sh` — merged line 96.32% / branch 92.43% against the 95/90 gate; neither `RustPlus` nor `AppInfoToModel` appears in the per-class gap list.
- `jb cleanupcode --profile=ReformatAndReorder` — idempotent; the pre-push hook passed.

One caveat on the local run: this machine has no .NET 8 runtime, so the `net8.0` host was executed with `DOTNET_ROLL_FORWARD=LatestMajor`. It still resolves the `netstandard2.0` library assets — which is what the parity suite validates — but runs them on the .NET 10 runtime. CI exercises the real .NET 8 host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)