### PR TITLE
chore: clear SonarQube violations and close coverage gaps

### DIFF
--- a/.github/workflows/Sonar.yml
+++ b/.github/workflows/Sonar.yml
@@ -59,10 +59,18 @@ jobs:
           dotnet tool update dotnet-sonarscanner --tool-path ./.sonar/scanner
 
       - name: Build and analyze
+        # Coverage is handed to SonarQube as ONE pre-merged report rather than the raw per-project,
+        # per-TFM opencover files. Passing the raw set understates coverage: the libraries are
+        # multi-targeted, so a file with a `#if NET10_0_OR_GREATER` fork is fully covered only across
+        # both reports, and SonarQube does not union them — it settles on one, and every line the
+        # other TFM covered reads as uncovered. ReportGenerator merges them properly first (the same
+        # merge tools/coverage/report.sh gates on), then emits SonarQube's generic coverage format.
         run: |
-          ./.sonar/scanner/dotnet-sonarscanner begin /k:"${{ secrets.SONAR_PROJECT_KEY }}" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="${{ secrets.SONAR_HOST_URL }}" /d:sonar.exclusions="**/samples/**" /d:sonar.coverage.exclusions="**/samples/**,**/tests/**,**/tools/**" /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"${{ secrets.SONAR_PROJECT_KEY }}" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="${{ secrets.SONAR_HOST_URL }}" /d:sonar.exclusions="**/samples/**" /d:sonar.coverage.exclusions="**/samples/**,**/tests/**,**/tools/**" /d:sonar.coverageReportPaths="TestResults/sonarqube/SonarQube.xml"
           dotnet build
-          dotnet test --no-build --collect:"XPlat Code Coverage;Format=opencover" --blame-hang-timeout 60s
+          dotnet test --no-build --settings tools/coverage/sonar.runsettings --results-directory ./TestResults --blame-hang-timeout 60s
+          dotnet tool restore
+          dotnet tool run reportgenerator -- "-reports:TestResults/**/coverage.opencover.xml" "-targetdir:TestResults/sonarqube" "-reporttypes:SonarQube"
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 
       - name: Upload coverage reports to Codecov

--- a/apps/RustPlusApi.CredentialsWeb/Program.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Program.cs
@@ -78,12 +78,12 @@ app.MapEventEndpoints();
 await app.RunAsync().ConfigureAwait(false);
 return 0;
 
-/// <summary>Entry point marker so <c>WebApplicationFactory&lt;Program&gt;</c> can boot the app in tests.</summary>
+/// <summary>Entry point marker so <c>WebApplicationFactory&lt;Program&gt;</c> can boot the app in tests.
+/// No accessibility modifier: since .NET 10 the compiler already emits the top-level-statement
+/// <c>Program</c> class as public, so restating it here is what ASP0027 flags. This part only
+/// carries the attributes below.</summary>
 [ExcludeFromCodeCoverage(Justification = "Host wiring: composition only, exercised end to end by the endpoint tests.")]
-[SuppressMessage("Design", "CA1515:Consider making public types internal",
-    Justification =
-        "Must stay public: WebApplicationFactory<Program> in the test assembly needs a public type parameter.")]
 [SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors",
     Justification =
         "Not a utility class — an empty marker type WebApplicationFactory<Program> uses to locate the app's assembly.")]
-public partial class Program;
+partial class Program;

--- a/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Sessions/Session.cs
@@ -17,7 +17,9 @@ internal sealed class Session(string sessionId, string returnToken, string clien
     private bool _claimedForEviction;
     private bool _disposed;
 
+#pragma warning disable IDE0032 // Explicit backing field; see the remarks on ExpiresAt below.
     private DateTimeOffset _expiresAt = expiresAt;
+#pragma warning restore IDE0032
 
     /// <summary>Background work started for this session, kept so it is observed rather than fire-and-forget.</summary>
     internal Task BackgroundWork { get; set; } = Task.CompletedTask;
@@ -34,6 +36,10 @@ internal sealed class Session(string sessionId, string returnToken, string clien
     /// <summary>When this session becomes sweepable. The getter takes <see cref="_gate"/>: the
     /// sweeper reads this concurrently with <see cref="Advance"/>'s writes on the flow's own thread,
     /// and <see cref="DateTimeOffset"/> is not guaranteed to read or write atomically.</summary>
+    /// <remarks>Not an auto property, and IDE0032 is suppressed on the backing field accordingly:
+    /// the getter has to take <see cref="_gate"/>, which an auto property cannot do, and
+    /// <see cref="Advance"/>/<see cref="TryClaimForPairing"/> assign the field from outside the
+    /// accessor, which rules out the <c>field</c> keyword as well.</remarks>
     internal DateTimeOffset ExpiresAt
     {
         get

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -101,7 +101,7 @@ ReportGenerator into `TestResults/merged/Cobertura.xml`, prints per-class gaps, 
 **ReportGenerator-merged Cobertura line-rate/branch-rate** (not per-TFM opencover numbers). CI
 (`.github/workflows/CI.yml`) runs it at **line 95 / branch 90**.
 
-Achieved at the time of writing: **≈ 96.7% line / 91.4% branch** (merged Cobertura aggregate
+Achieved at the time of writing: **≈ 97.0% line / 93.6% branch** (merged Cobertura aggregate
 across all test projects and both TFMs).
 The gap to a literal 100% is irreducible and lives mostly in:
 
@@ -116,6 +116,32 @@ The gap to a literal 100% is irreducible and lives mostly in:
 These are not dead code (so they were not removed) and not cleanly excludable per-branch, so the
 gate floor sits below the achieved figures rather than at 100%, with headroom so routine changes
 don't trip the gate.
+
+---
+
+## SonarQube coverage
+
+`.github/workflows/Sonar.yml` reports coverage to SonarQube as a **single pre-merged report**, not
+as the raw per-project/per-TFM opencover files.
+
+This matters because of the parity mechanism above. `dotnet test` writes one opencover report per
+test project *per TFM*, and a file with a `#if NET10_0_OR_GREATER` fork is only fully covered when
+those reports are unioned — the `net10.0` report covers the `#if` lines, the `net8.0` one covers the
+`#else` lines. SonarQube does not union them: handed the raw set it settles on one report per file,
+so every line the other TFM covered is reported as uncovered. `HtmlColorParser` is the clearest
+casualty — genuinely 100/100 across the matrix, but previously shown at 56.5% line coverage.
+
+So the workflow runs ReportGenerator first (the same merge `tools/coverage/report.sh` gates on),
+emits `-reporttypes:SonarQube` to `TestResults/sonarqube/SonarQube.xml`, and passes it via
+`sonar.coverageReportPaths` (the generic coverage format) instead of
+`sonar.cs.opencover.reportsPaths`.
+
+The analysis run uses **`tools/coverage/sonar.runsettings`** rather than the per-test-project
+`coverlet.runsettings`. The two are identical apart from `UseSourceLink`, which is deliberately
+omitted for Sonar: with it on, coverlet writes `raw.githubusercontent.com` URLs in place of file
+paths and SonarQube cannot match them against the files it indexed. Keeping the exclusions in sync
+is what makes SonarQube measure the same thing the local gate does — if you change one file's
+`Exclude`/`ExcludeByFile`/`ExcludeByAttribute` rules, change both.
 
 ---
 
@@ -267,7 +293,7 @@ callback parsing (`ParseCallback`/`ParseQuery`), nonce generation, and the loopb
 success/unknown-path/bad-callback branches and port-bind failure — is exercised by
 `SteamLoginServiceTests` via the `openBrowser: false` seam, which drives the accept loop with a real
 loopback `HttpListener` and `HttpClient` without opening a browser. As of this writing
-`tools/coverage/report.sh` reports 90.62% line / 83.33% branch for this class — the gaps above
+`tools/coverage/report.sh` reports 90.45% line / 83.33% branch for this class — the gaps above
 account for the shortfall.
 
 ### `FcmRegistration.RegisterWithRustPlusAsync`
@@ -297,6 +323,20 @@ and handshake sequence itself requires the live Google endpoint.
 **Justification:** Calls `_fcm.ConnectAsync()` internally, which requires a live FCM connection (see
 above). The pairing-notification mapping helper (`ToServerPairing`) is `internal static` and is fully
 unit-tested in `RegistrationTests` independently of the live flow.
+
+### `System.Index` / `System.Range` netstandard2.0 polyfill
+
+**File:** `src/RustPlusApi.Fcm.Registration/Polyfills/IndexRange.cs`
+
+**Justification:** Pure compiler scaffolding. `netstandard2.0` has no `System.Index`/`System.Range`,
+and the C# compiler refuses `..`/`^` syntax unless those types exist somewhere — so the polyfill has
+to be compiled into the `netstandard2.0` asset even though nothing calls it. Roslyn lowers every
+current use site (`SteamLoginService.ParseQuery`'s `pair[..separator]` / `pair[(separator + 1)..]`)
+straight to `string.Substring`, so not a single member of either struct is reachable at runtime and
+no test can make one execute. Excluding it keeps 20 permanently-unreachable lines and 12 branches
+out of the library gate's denominator. If a future use site takes an actual `Index`/`Range` value
+(e.g. a from-end `^n`), the calls become reachable and this exclusion should be dropped in favour of
+real tests.
 
 ### Generated protobuf contract files (via `ExcludeByFile`)
 

--- a/src/RustPlusApi.Fcm.Registration/Polyfills/IndexRange.cs
+++ b/src/RustPlusApi.Fcm.Registration/Polyfills/IndexRange.cs
@@ -2,12 +2,19 @@
 // Enables the index (`^`) and range (`..`) operators when targeting netstandard2.0,
 // where these compiler-required types are not part of the BCL. Only the members the C#
 // compiler binds against are implemented; see the reference impl in dotnet/runtime.
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace System;
 
 /// <summary>Indexes a collection from the start (<c>i</c>) or the end (<c>^i</c>).</summary>
+/// <remarks>Excluded from coverage: compiler scaffolding, never executed. The type only has to
+/// exist for the C# compiler to accept <c>..</c>/<c>^</c> syntax on netstandard2.0; Roslyn lowers
+/// every current use site to a direct <c>Substring</c> call, so no member here is reachable at
+/// runtime. (<c>Justification</c> is unavailable on netstandard2.0 — see
+/// <c>docs/development/testing.md</c>.)</remarks>
+[ExcludeFromCodeCoverage]
 internal readonly struct Index
 {
     private readonly int _value;
@@ -34,6 +41,9 @@ internal readonly struct Index
 /// <summary>Represents the range used to slice a collection with the <c>..</c> operator.</summary>
 /// <param name="start">The inclusive start index of the range.</param>
 /// <param name="end">The exclusive end index of the range.</param>
+/// <remarks>Excluded from coverage: compiler scaffolding, never executed — see
+/// <see cref="Index"/> above.</remarks>
+[ExcludeFromCodeCoverage]
 internal readonly struct Range(Index start, Index end)
 {
     public Index Start { get; } = start;

--- a/src/RustPlusApi.Fcm.Registration/SteamLoginResult.cs
+++ b/src/RustPlusApi.Fcm.Registration/SteamLoginResult.cs
@@ -10,11 +10,16 @@ namespace RustPlusApi.Fcm.Registration;
 /// null, empty, or whitespace-only — enforced on construction and on <c>with</c>.</param>
 public sealed record SteamLoginResult(ulong SteamId, string Token)
 {
+#pragma warning disable IDE0032 // Explicit backing field; see the remarks on Token below.
     private readonly string _token = ValidateToken(Token);
+#pragma warning restore IDE0032
 
     /// <summary>The Rust+ auth token handed back by the Facepunch login.</summary>
     /// <exception cref="ArgumentException">Thrown when assigned a null, empty, or
     /// whitespace-only value.</exception>
+    /// <remarks>Not an auto property, and IDE0032 is suppressed on the backing field accordingly:
+    /// the <c>init</c> accessor validates, so an auto property would let
+    /// <c>with { Token = "" }</c> past the check the constructor enforces.</remarks>
     public string Token
     {
         get => _token;

--- a/src/RustPlusApi.Fcm.Registration/Steps/SteamLoginService.cs
+++ b/src/RustPlusApi.Fcm.Registration/Steps/SteamLoginService.cs
@@ -360,8 +360,8 @@ public sealed class SteamLoginService(int port = 3000)
                 continue;
             }
 
-            var key = WebUtility.UrlDecode(pair.Substring(0, separator));
-            result[key] = WebUtility.UrlDecode(pair.Substring(separator + 1));
+            var key = WebUtility.UrlDecode(pair[..separator]);
+            result[key] = WebUtility.UrlDecode(pair[(separator + 1)..]);
         }
 
         return result;

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/CapturingLoggerProvider.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/CapturingLoggerProvider.cs
@@ -15,7 +15,7 @@ internal sealed class CapturingLoggerProvider : ILoggerProvider
         {
             lock (_records)
             {
-                return _records.ToArray();
+                return [.. _records];
             }
         }
     }

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/CredentialFlowTests.cs
@@ -178,6 +178,23 @@ public sealed class CredentialFlowTests
     }
 
     [Fact]
+    public async Task CompleteRegistrationAsync_FailsWhenTheSteamTokenIsGoneByCompanionRegistration()
+    {
+        // The token is dropped as soon as it has no further use, and disposal drops it too, so
+        // between device registration and the companion call it can legitimately be null. That
+        // must land the session in Failed rather than dereference null.
+        var h = NewHarness();
+        using var _s = h.Store;
+        h.Store.TryCreate("203.0.113.7", out var session, out _);
+        h.Steps.OnAcquire = session!.ClearSteamToken;
+
+        await h.Flow.CompleteRegistrationAsync(session, Login(), CancellationToken.None);
+
+        Assert.Equal(SessionState.Failed, session.State);
+        Assert.DoesNotContain(nameof(FakeRegistrationSteps.RegisterWithCompanionAsync), h.Steps.Calls);
+    }
+
+    [Fact]
     public async Task CompleteRegistrationAsync_StaysQuietWhenCancelled()
     {
         var h = NewHarness();

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/EventEndpointTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/EventEndpointTests.cs
@@ -191,15 +191,14 @@ public sealed class EventEndpointTests
         // terminates the second — a dropped separator would merge the two frames into one that
         // EventSource cannot parse, which none of the count-based replay tests above would notice.
         Assert.Equal(
-            new List<string?>
-            {
+            [
                 "event: step",
                 """data: {"state":"Authenticated"}""",
                 string.Empty,
                 "event: step",
                 """data: {"state":"Registering"}""",
                 string.Empty
-            },
+            ],
             lines);
     }
 

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/FakeRegistrationSteps.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/FakeRegistrationSteps.cs
@@ -42,11 +42,16 @@ internal sealed class FakeRegistrationSteps : IRegistrationSteps
 
     internal bool PairingWaitsForGate { get; set; }
 
+    /// <summary>Runs at the top of <see cref="AcquireDeviceCredentialsAsync"/>, so a test can change
+    /// the session's state while the flow is between steps.</summary>
+    internal Action? OnAcquire { get; set; }
+
     internal string? SteamTokenSeen { get; private set; }
 
     public Task<Credentials> AcquireDeviceCredentialsAsync(CancellationToken cancellationToken)
     {
         Calls.Add(nameof(AcquireDeviceCredentialsAsync));
+        OnAcquire?.Invoke();
         return AcquireFailure is not null
             ? Task.FromException<Credentials>(AcquireFailure)
             : Task.FromResult(CredentialsToReturn);

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEventStreamTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionEventStreamTests.cs
@@ -101,6 +101,53 @@ public sealed class SessionEventStreamTests
     }
 
     [Fact]
+    public async Task SubscribeAsync_EndsNaturallyWhenTheStreamIsCompletedMidEnumeration()
+    {
+        // The other completion test completes the stream *before* subscribing, which takes the
+        // "no channel, replay only" shortcut. This one pins the live-subscriber path: Complete()
+        // must close an in-flight enumeration without anyone cancelling it.
+        var stream = new SessionEventStream();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var received = new List<SessionEvent>();
+        var drain = Task.Run(
+            async () =>
+            {
+                await foreach (var item in stream.SubscribeAsync(timeout.Token))
+                {
+                    received.Add(item);
+                }
+            },
+            timeout.Token);
+
+        while (stream.SubscriberCount == 0)
+        {
+            timeout.Token.ThrowIfCancellationRequested();
+            await Task.Delay(10, timeout.Token);
+        }
+
+        stream.Publish(new SessionEvent("step", null));
+        stream.Complete();
+
+        await drain.WaitAsync(timeout.Token);
+
+        Assert.Single(received);
+        Assert.Equal(0, stream.SubscriberCount);
+    }
+
+    [Fact]
+    public void Complete_IsIdempotent()
+    {
+        var stream = new SessionEventStream();
+        stream.Publish(new SessionEvent("step", null));
+
+        stream.Complete();
+        var second = Record.Exception(stream.Complete);
+
+        Assert.Null(second);
+    }
+
+    [Fact]
     public async Task Publish_AfterComplete_IsIgnored()
     {
         var stream = new SessionEventStream();

--- a/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
+++ b/tests/RustPlusApi.CredentialsWeb.UnitTests/SessionSweeperTests.cs
@@ -130,4 +130,67 @@ public sealed class SessionSweeperTests
         // on the next tick).
         Assert.Throws<ObjectDisposedException>(() => _ = throwingSession.Lifetime.Token);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_LogsAndKeepsTickingWhenASweepThrows()
+    {
+        // The per-tick try/catch is the only thing standing between one bad sweep and a sweeper that
+        // never runs again — and a dead sweeper is silent, so nothing else in the app would notice
+        // that sessions had stopped expiring. Fail one sweep outright, then let the next succeed.
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero));
+        var options = new AppOptions
+        {
+            PublicBaseUrl = "https://creds.example.org"
+        };
+
+        // Only the store's clock is made to fail: the sweeper keeps a working one so its timer
+        // still ticks while SweepExpired throws.
+        var storeClock = new FailableTimeProvider(time);
+        using var store = new SessionStore(options, storeClock);
+        store.TryCreate("203.0.113.7", out var session, out _);
+
+        var records = new CapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder => builder
+            .SetMinimumLevel(LogLevel.Trace)
+            .AddProvider(records));
+
+        using var sweeper = new SessionSweeper(store, time, loggerFactory.CreateLogger<SessionSweeper>());
+        await sweeper.StartAsync(CancellationToken.None);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        storeClock.Failing = true;
+        while (!records.Records.Any(r => r.Contains("Sweep failed", StringComparison.Ordinal)))
+        {
+            timeout.Token.ThrowIfCancellationRequested();
+            time.Advance(TimeSpan.FromSeconds(31));
+            await Task.Delay(10, timeout.Token);
+        }
+
+        // Recovery: with the clock working again the sweeper must still be running its loop.
+        storeClock.Failing = false;
+        time.Advance(TimeSpan.FromMinutes(10));
+        while (store.TryGet(session!.SessionId, out _))
+        {
+            timeout.Token.ThrowIfCancellationRequested();
+            time.Advance(TimeSpan.FromSeconds(31));
+            await Task.Delay(10, timeout.Token);
+        }
+
+        await sweeper.StopAsync(CancellationToken.None);
+        Assert.Equal(0, store.Count);
+    }
+
+    /// <summary>A clock that can be made to throw on demand, so <c>SweepExpired</c> fails without
+    /// the test needing a seam inside the store.</summary>
+    /// <param name="inner">The clock to delegate to while healthy.</param>
+    private sealed class FailableTimeProvider(TimeProvider inner) : TimeProvider
+    {
+        internal bool Failing { get; set; }
+
+        public override DateTimeOffset GetUtcNow() =>
+            Failing
+                ? throw new InvalidOperationException("Simulated clock failure")
+                : inner.GetUtcNow();
+    }
 }

--- a/tests/RustPlusApi.Fcm.Registration.UnitTests/SteamLoginServiceTests.cs
+++ b/tests/RustPlusApi.Fcm.Registration.UnitTests/SteamLoginServiceTests.cs
@@ -75,6 +75,38 @@ public class SteamLoginServiceTests
         Assert.Throws<ArgumentException>(() => new SteamLoginResult(7, token!));
 
     [Fact]
+    public void SteamLoginResult_WithNonBlankToken_ReplacesTheToken()
+    {
+        var original = new SteamLoginResult(7, "first");
+
+        var copy = original with
+        {
+            Token = "second"
+        };
+
+        Assert.Equal("second", copy.Token);
+        Assert.Equal(7UL, copy.SteamId);
+        Assert.Equal("first", original.Token);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SteamLoginResult_WithBlankToken_Throws(string? token)
+    {
+        // The `with` path runs the init accessor rather than the field initializer the constructor
+        // uses, so it needs pinning separately: without it a copy could carry a blank token past
+        // validation the constructor already rejects.
+        var original = new SteamLoginResult(7, "first");
+
+        Assert.Throws<ArgumentException>(() => original with
+        {
+            Token = token!
+        });
+    }
+
+    [Fact]
     public void ParseCallback_DuplicateParameter_LastValueWins()
     {
         var uri = new Uri("http://localhost:3000/callback?steamId=100&token=first&token=second&steamId=200");

--- a/tests/RustPlusApi.IntegrationTests/ClanNexusClientTests.cs
+++ b/tests/RustPlusApi.IntegrationTests/ClanNexusClientTests.cs
@@ -100,7 +100,11 @@ public class ClanNexusClientTests
             TaskCreationOptions.RunContinuationsAsynchronously);
         var (server, client) = await ConnectAsync(request =>
         {
-            if (request.KickFromTeam is not null) kick.TrySetResult(request.KickFromTeam);
+            if (request.KickFromTeam is not null)
+            {
+                kick.TrySetResult(request.KickFromTeam);
+            }
+
             return MockResponses.Default(request);
         });
         await using var _ = server;

--- a/tools/coverage/sonar.runsettings
+++ b/tools/coverage/sonar.runsettings
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Coverage settings for the SonarQube analysis run only (.github/workflows/Sonar.yml).
+
+     Identical to the per-test-project coverlet.runsettings that drives the local/CI coverage gate,
+     except that UseSourceLink is off: with it on, coverlet writes raw.githubusercontent.com URLs in
+     place of file paths, and SonarQube cannot match those against the files it indexed. Keeping the
+     exclusions in sync is what makes SonarQube measure the same thing tools/coverage/report.sh
+     gates on — see docs/development/testing.md. -->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>opencover</Format>
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+          <Exclude>[RustPlusApi.MockServer]*,[ProtoGen]*</Exclude>
+          <ExcludeByFile>**/obj/**,**/ProtoBuf/Mcs.cs,**/Protobuf/CheckinContracts.cs</ExcludeByFile>
+          <SkipAutoProps>true</SkipAutoProps>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/tools/update-proto/ProtoGen/ServerParser.cs
+++ b/tools/update-proto/ProtoGen/ServerParser.cs
@@ -77,7 +77,7 @@ internal sealed class ServerParser
     /// <param name="roots">Qualified root message names, e.g. AppRequest.</param>
     /// <returns>The roots absent from the parsed model, in the order given.</returns>
     public IReadOnlyList<string> MissingRoots(IEnumerable<string> roots) =>
-        roots.Where(r => !_messages.ContainsKey(r)).ToList();
+        [.. roots.Where(r => !_messages.ContainsKey(r))];
 
     /// <summary>First pass: register every message/enum and the parent/child structure.</summary>
     /// <param name="member">The syntax node to register.</param>


### PR DESCRIPTION
## Why

The SonarQube quality gate on `develop` is **ERROR** — `new_violations = 9` against a threshold of 0. All nine are INFO-severity Roslyn IDE rules. This clears them, closes the coverage gaps that were reachable, and fixes a workflow bug that was understating coverage to SonarQube by ~3.5 points.

## Violations

| Rule | Where | Fix |
|---|---|---|
| `ASP0027` | `Program.cs` | Dropped the redundant `public` — .NET 10 already emits the top-level `Program` as public. Also dropped the now-dead `CA1515` suppression. |
| `IDE0011` | `ClanNexusClientTests.cs` | Added braces |
| `IDE0305` ×2 | `CapturingLoggerProvider.cs`, `ProtoGen/ServerParser.cs` | `.ToArray()`/`.ToList()` → collection expressions |
| `IDE0028` | `EventEndpointTests.cs` | `new List<string?> {…}` → collection expression |
| `IDE0057` ×2 | `SteamLoginService.cs` | `Substring` → range operator |
| `IDE0032` ×2 | `Session.cs`, `SteamLoginResult.cs` | `#pragma` suppression + `<remarks>` — see below |

The two `IDE0032`s are false positives, and applying them would be a real regression:

- `Session._expiresAt` is written from `Advance`/`TryClaimForPairing` and read through a getter that takes `_gate`. An auto property drops the lock and exposes torn `DateTimeOffset` reads. The `field` keyword is not an option either — the assignments are outside the accessor.
- `SteamLoginResult._token` has a validating `init`. An auto property lets `with { Token = "" }` past the check the constructor enforces.

Neither reproduces on SDK 10.0.400 even with `IDE0032` escalated to `warning`, so they are suppressed in code with the reasoning recorded on the property.

**Verification:** escalating all six rules to `warning` on a `--no-incremental` solution build now yields nothing outside `samples/`, which `sonar.exclusions` already drops.

## Coverage

| Gate | Before | After |
|---|---|---|
| libraries | 96.20 / 92.21 | **96.87 / 93.55** |
| web app | 98.15 / 95.24 | **99.49 / 97.62** |

New tests, each aimed at a specific uncovered line:

- **`SteamLoginResult`** — the `init` accessor was never executed. Pinned via `with`, valid and blank.
- **`SessionEventStream`** — `Complete()` idempotency, and completion ending a *live* enumeration. The existing test completes the stream before subscribing, which takes the replay-only shortcut and never reaches the channel loop.
- **`CredentialFlow`** — Steam token gone by companion registration, via a new `OnAcquire` hook on `FakeRegistrationSteps`.
- **`SessionSweeper`** — a throwing sweep is logged and the loop keeps ticking, via a `FailableTimeProvider` on the store's clock only (the sweeper keeps a working one so its timer still fires).

Plus `[ExcludeFromCodeCoverage]` on the `System.Index`/`System.Range` netstandard2.0 polyfill. It exists only so the compiler accepts `..`/`^` syntax; Roslyn lowers every use site to `string.Substring`, so no member is reachable at runtime and no test can make one execute. Justified in `docs/development/testing.md` per the repo rule.

## SonarQube coverage reporting

SonarQube showed 93.4% against the repo's real 96.99%.

`dotnet test` emits one opencover report per project **per TFM**. A file with a `#if NET10_0_OR_GREATER` fork is only fully covered across both, and SonarQube does not union them — it settles on one report per file, so every line the other TFM covered reads as uncovered. Confirmed by matching SonarQube's uncovered-line list for `HtmlColorParser.cs` byte-for-byte against one specific report, on a file that is genuinely 100/100.

`Sonar.yml` now merges via ReportGenerator (`-reporttypes:SonarQube`) and passes `sonar.coverageReportPaths`. The analysis run uses the new `tools/coverage/sonar.runsettings` — the same exclusions as the local gate, minus `UseSourceLink`, which writes `raw.githubusercontent.com` URLs in place of paths that SonarQube cannot match against its indexed files.

Verified locally end to end: paths resolve, `HtmlColorParser` reports 19/19, total **97.36%**.

## Testing

- `dtk dotnet build RustPlusApi.sln` — clean, `TreatWarningsAsErrors` on
- `dtk dotnet test RustPlusApi.sln` — 1139 passed, both TFM hosts
- `tools/coverage/report.sh` — both gates pass
- `dotnet jb cleanupcode` — clean

⚠️ The `Sonar.yml` change can only be proven by a merge to `develop`, since the workflow runs on push.

⚠️ Unrelated flake spotted: `RustPlusClientTests.GetInfoAsync_ReturnsMappedServerInfo` failed once in four runs with `HttpListenerException: ... conflicts with an existing registration` — a random-port collision, pre-existing and not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)