### PR TITLE
chore(web): clear the SonarQube code smells on develop

### DIFF
--- a/apps/RustPlusApi.CredentialsWeb/Endpoints/CallbackParsing.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Endpoints/CallbackParsing.cs
@@ -55,7 +55,7 @@ internal static class CallbackParsing
 
         try
         {
-            login = SteamLoginService.ParseCallback(uri!);
+            login = SteamLoginService.ParseCallback(uri);
         }
         catch (InvalidOperationException)
         {

--- a/apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs
+++ b/apps/RustPlusApi.CredentialsWeb/Endpoints/SessionEndpoints.cs
@@ -44,81 +44,95 @@ internal static class SessionEndpoints
     /// <param name="app">The route builder.</param>
     internal static void MapSessionEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapPost("/api/sessions", (HttpContext context, SessionStore store, AppOptions options) =>
+        app.MapPost("/api/sessions", CreateSession);
+        app.MapPost("/api/sessions/{sessionId}/pairing", StartPairing);
+    }
+
+    /// <summary>Handles <c>POST /api/sessions</c>: opens a session and hands back the Facepunch login
+    /// URL to send the visitor to.</summary>
+    /// <param name="context">The request, which decides local versus remote and supplies the origin.</param>
+    /// <param name="store">The session store.</param>
+    /// <param name="options">The instance's settings.</param>
+    private static IResult CreateSession(HttpContext context, SessionStore store, AppOptions options)
+    {
+        var isLocal = RequestMode.IsLocal(context);
+
+        if (!store.TryCreate(ClientAddress.Of(context), isLocal, out var session, out var failure))
         {
-            var isLocal = RequestMode.IsLocal(context);
+            // ActiveSessionForIp means a resumable session already exists for this address —
+            // "at capacity" would be false and would send the visitor into a five-minute wait
+            // for no reason. GlobalLimit and HourlyLimit are genuine capacity/rate limits, so
+            // they keep the existing message.
+            var message = failure == SessionCreateFailure.ActiveSessionForIp
+                ? ActiveSessionMessage
+                : OverCapacityMessage;
+            return Results.Json(new ErrorPayload(message), statusCode: 429);
+        }
 
-            if (!store.TryCreate(ClientAddress.Of(context), isLocal, out var session, out var failure))
-            {
-                // ActiveSessionForIp means a resumable session already exists for this address —
-                // "at capacity" would be false and would send the visitor into a five-minute wait
-                // for no reason. GlobalLimit and HourlyLimit are genuine capacity/rate limits, so
-                // they keep the existing message.
-                var message = failure == SessionCreateFailure.ActiveSessionForIp
-                    ? ActiveSessionMessage
-                    : OverCapacityMessage;
-                return Results.Json(new ErrorPayload(message), statusCode: 429);
-            }
+        // Local: the redirect can land here, so the return URL is this very request's origin.
+        // Nothing is configured, so nothing can be configured wrong.
+        //
+        // Remote: Facepunch only honours a loopback returnUrl, and decides that from the URL's
+        // shape rather than its reachability — their servers cannot reach a visitor's localhost
+        // either. So it gets a loopback address nothing is listening on. The visitor's browser
+        // fails to connect and shows the address, which they paste back at POST /api/callback.
+        // The port comes from the dynamic range, so it is very unlikely to belong to something
+        // the visitor actually runs; if it somehow does, the single-use return token means the
+        // paste fails closed rather than the flow completing somewhere else.
+        var returnUrl = isLocal
+            ? $"{context.Request.Scheme}://{context.Request.Host}/callback/{session.ReturnToken}"
+            : $"http://localhost:{RandomNumberGenerator.GetInt32(49152, 65536)}/callback/{session.ReturnToken}";
 
-            // Local: the redirect can land here, so the return URL is this very request's origin.
-            // Nothing is configured, so nothing can be configured wrong.
-            //
-            // Remote: Facepunch only honours a loopback returnUrl, and decides that from the URL's
-            // shape rather than its reachability — their servers cannot reach a visitor's localhost
-            // either. So it gets a loopback address nothing is listening on. The visitor's browser
-            // fails to connect and shows the address, which they paste back at POST /api/callback.
-            // The port comes from the dynamic range, so it is very unlikely to belong to something
-            // the visitor actually runs; if it somehow does, the single-use return token means the
-            // paste fails closed rather than the flow completing somewhere else.
-            var returnUrl = isLocal
-                ? $"{context.Request.Scheme}://{context.Request.Host}/callback/{session.ReturnToken}"
-                : $"http://localhost:{RandomNumberGenerator.GetInt32(49152, 65536)}/callback/{session.ReturnToken}";
+        return Results.Ok(new CreateSessionResponse(
+            session.SessionId,
+            SteamLoginService.BuildLoginUrl(returnUrl),
+            isLocal ? "redirect" : "paste",
+            isLocal || options.AllowRemotePairing));
+    }
 
-            return Results.Ok(new CreateSessionResponse(
-                session.SessionId,
-                SteamLoginService.BuildLoginUrl(returnUrl),
-                isLocal ? "redirect" : "paste",
-                isLocal || options.AllowRemotePairing));
-        });
-
-        app.MapPost("/api/sessions/{sessionId}/pairing", (
-            string sessionId,
-            SessionStore store,
-            CredentialFlow flow,
-            AppOptions options) =>
+    /// <summary>Handles <c>POST /api/sessions/{sessionId}/pairing</c>: starts the background wait for
+    /// an in-game pairing.</summary>
+    /// <param name="sessionId">The session handle from the route.</param>
+    /// <param name="store">The session store.</param>
+    /// <param name="flow">The registration flow that owns the wait.</param>
+    /// <param name="options">The instance's settings.</param>
+    private static IResult StartPairing(
+        string sessionId,
+        SessionStore store,
+        CredentialFlow flow,
+        AppOptions options)
+    {
+        if (!store.TryGet(sessionId, out var session))
         {
-            if (!store.TryGet(sessionId, out var session))
-            {
-                return Results.NotFound();
-            }
+            return Results.NotFound();
+        }
 
-            // The pairing wait is the one step that holds a long-lived socket per visitor. A public
-            // instance has no reason to hold one for a stranger, so it is local-only unless the
-            // operator opts in — which someone self-hosting on a LAN address will want to.
-            if (!session.IsLocal && !options.AllowRemotePairing)
-            {
-                return Results.Json(new ErrorPayload(RemotePairingMessage), statusCode: 403);
-            }
+        // The pairing wait is the one step that holds a long-lived socket per visitor. A public
+        // instance has no reason to hold one for a stranger, so it is local-only unless the
+        // operator opts in — which someone self-hosting on a LAN address will want to.
+        if (!session.IsLocal && !options.AllowRemotePairing)
+        {
+            return Results.Json(new ErrorPayload(RemotePairingMessage), statusCode: 403);
+        }
 
-            // Advisory: it settles the ordinary 409 without starting anything, but it is a read of
-            // a state a concurrent request can change a moment later. What actually holds a session
-            // to one pairing wait is Session.TryClaimForPairing, which
-            // CredentialFlow.WaitForPairingAsync takes before it touches the network.
-            if (session.State != SessionState.Ready)
-            {
-                return Results.Conflict(new ErrorPayload(
-                    "This session is not ready to wait for a pairing."));
-            }
+        // Advisory: it settles the ordinary 409 without starting anything, but it is a read of
+        // a state a concurrent request can change a moment later. What actually holds a session
+        // to one pairing wait is Session.TryClaimForPairing, which
+        // CredentialFlow.WaitForPairingAsync takes before it touches the network.
+        if (session.State != SessionState.Ready)
+        {
+            return Results.Conflict(new ErrorPayload(
+                "This session is not ready to wait for a pairing."));
+        }
 
-            // The slot is taken here rather than inside the flow so that a refusal is a plain 429
-            // with nothing started; CredentialFlow.WaitForPairingAsync always releases it.
-            if (!store.TryAcquirePairingSlot())
-            {
-                return Results.Json(new ErrorPayload(PairingBusyMessage), statusCode: 429);
-            }
+        // The slot is taken here rather than inside the flow so that a refusal is a plain 429
+        // with nothing started; CredentialFlow.WaitForPairingAsync always releases it.
+        if (!store.TryAcquirePairingSlot())
+        {
+            return Results.Json(new ErrorPayload(PairingBusyMessage), statusCode: 429);
+        }
 
-            session.BackgroundWork = flow.WaitForPairingAsync(session, session.Lifetime.Token);
-            return Results.Accepted();
-        });
+        session.BackgroundWork = flow.WaitForPairingAsync(session, session.Lifetime.Token);
+        return Results.Accepted();
     }
 }

--- a/apps/RustPlusApi.CredentialsWeb/wwwroot/app.css
+++ b/apps/RustPlusApi.CredentialsWeb/wwwroot/app.css
@@ -115,4 +115,4 @@ button.copy {
     border: 1px solid var(--line);
 }
 
-.status { color: var(--muted); min-height: 1.5rem; margin: 0.5rem 0 0; }
+.status { display: block; color: var(--muted); min-height: 1.5rem; margin: 0.5rem 0 0; }

--- a/apps/RustPlusApi.CredentialsWeb/wwwroot/index.html
+++ b/apps/RustPlusApi.CredentialsWeb/wwwroot/index.html
@@ -88,7 +88,7 @@
             <button id="download" type="button">Download rustplus.config.json</button>
         </div>
         <pre id="config-json" hidden></pre>
-        <p class="status" role="status" aria-live="polite"></p>
+        <output class="status"></output>
         <div id="pair-offer">
             <h3>Optional: get your pairing values</h3>
             <p>
@@ -130,7 +130,7 @@
             <button id="copy-snippet" type="button" class="secondary">Copy the snippet</button>
             <button id="download-paired" type="button">Download rustplus.config.json</button>
         </div>
-        <p class="status" role="status" aria-live="polite"></p>
+        <output class="status"></output>
     </section>
 
     <section id="failed" hidden>


### PR DESCRIPTION
Clears the four open SonarQube issues on `develop`, all raised by the out-of-band callback work in #128. No behaviour change.

## The issues

| Rule | File | Fix |
|---|---|---|
| `csharpsquid:S3776` (Critical) | `Endpoints/SessionEndpoints.cs` | Cognitive complexity 19 → both handlers extracted |
| `csharpsquid:S8969` (Minor) | `Endpoints/CallbackParsing.cs` | Redundant `!` removed |
| `Web:S6819` (Major) ×2 | `wwwroot/index.html` | `<p role="status">` → `<output>` |

### S3776 — `MapSessionEndpoints`

Both route handlers lived as inline lambdas, so their branches stacked into one method with a cognitive complexity of 19. The bodies move out to `CreateSession` and `StartPairing`, and the routes bind by method group — the same shape `CallbackEndpoints` already uses for `TryParseSteamLogin`.

Minimal APIs resolve a method group's parameters exactly as they did the lambdas', and every service involved (`SessionStore`, `CredentialFlow`, `AppOptions`) is a registered singleton, so the binding is unchanged. `SessionEndpointTests` and `PairingEndpointTests` drive both routes over HTTP through `WebApplicationFactory<Program>` and still pass.

### S8969 — `ParseCallback(uri!)`

The null-forgiving operator suppressed nothing: `TryAsWebUri` is annotated `[NotNullWhen(true)]`, so past the guard the compiler already knows `uri` is not null.

### Web:S6819 — the live status lines

The two per-section status lines were `<p class="status" role="status" aria-live="polite">`. `<output>` carries `role="status"` implicitly, and that role implies `aria-live="polite"`, so both attributes come off with the element swap.

`<output>` is inline by default, so `.status` now asks for `display: block` to keep the `min-height` and `margin` the line relies on. The class name is unchanged, so `app.js` still reaches them via `button.closest("section")?.querySelector(".status")`.

## Verification

- `dotnet build` — clean (`TreatWarningsAsErrors`, 39 projects)
- `dotnet test RustPlusApi.sln` — 1210 passed across both TFM hosts
- `tools/coverage/report.sh` — both gates green: libraries `line=96.91% branch=93.44%`, web app `line=99.26% branch=97.09%`
- `jb cleanupcode` (pre-push hook) — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)